### PR TITLE
config: commit autogenerated changes that were missing

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -109,26 +109,6 @@ rules:
 - apiGroups:
   - k8s-operator.aiven.io
   resources:
-  - kafkaschemas
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - k8s-operator.aiven.io
-  resources:
-  - kafkaschemas/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - k8s-operator.aiven.io
-  resources:
   - kafkatopics
   verbs:
   - create


### PR DESCRIPTION
Didn't notice these were missing before merging.  Those lines were duplicates, don't know what caused them (but it's something that @ivan-savciuc committed to ivans-kafka-schema originally).