### PR TITLE
kafkaconnect, fix: rename misnamed field in KafkaConnect CRD's user config

### DIFF
--- a/api/v1alpha1/kafkaconnect_types.go
+++ b/api/v1alpha1/kafkaconnect_types.go
@@ -101,7 +101,7 @@ type KafkaConnectStatus struct {
 
 type KafkaConnectUserConfig struct {
 	// Defines what client configurations can be overridden by the connector. Default is None
-	ConnectorClientConfigOverridePolicy string `json:"additionalProperties,omitempty"`
+	ConnectorClientConfigOverridePolicy string `json:"connector_client_config_override_policy,omitempty"`
 
 	// What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server. Default is earliest
 	ConsumerAutoOffsetReset string `json:"consumer_auto_offset_reset,omitempty"`

--- a/config/crd/bases/k8s-operator.aiven.io_kafkaconnects.yaml
+++ b/config/crd/bases/k8s-operator.aiven.io_kafkaconnects.yaml
@@ -43,7 +43,7 @@ spec:
             kafka_connect_user_config:
               description: PostgreSQL specific user configuration options
               properties:
-                additionalProperties:
+                connector_client_config_override_policy:
                   description: Defines what client configurations can be overridden
                     by the connector. Default is None
                   type: string
@@ -178,7 +178,7 @@ spec:
             kafka_connect_user_config:
               description: PostgreSQL specific user configuration options
               properties:
-                additionalProperties:
+                connector_client_config_override_policy:
                   description: Defines what client configurations can be overridden
                     by the connector. Default is None
                   type: string


### PR DESCRIPTION
connector_client_config_override_policy was called additionalProperties for unknown reasons.