### PR TITLE
add error to handler checkPreconditions function

### DIFF
--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -140,10 +140,10 @@ func (h DatabaseHandler) get(i client.Object) (client.Object, *corev1.Secret, er
 	return db, nil, nil
 }
 
-func (h DatabaseHandler) checkPreconditions(i client.Object) bool {
+func (h DatabaseHandler) checkPreconditions(i client.Object) (bool, error) {
 	db, err := h.convert(i)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	return checkServiceIsRunning(h.client, db.Spec.Project, db.Spec.ServiceName)

--- a/controllers/kafka_controller.go
+++ b/controllers/kafka_controller.go
@@ -200,8 +200,8 @@ func (h KafkaHandler) get(i client.Object) (client.Object, *corev1.Secret, error
 	}, nil
 }
 
-func (h KafkaHandler) checkPreconditions(_ client.Object) bool {
-	return true
+func (h KafkaHandler) checkPreconditions(_ client.Object) (bool, error) {
+	return true, nil
 }
 
 func (h KafkaHandler) convert(i client.Object) (*k8soperatorv1alpha1.Kafka, error) {

--- a/controllers/kafkaacl_controller.go
+++ b/controllers/kafkaacl_controller.go
@@ -149,10 +149,10 @@ func (h KafkaACLHandler) get(i client.Object) (client.Object, *corev1.Secret, er
 	return acl, nil, nil
 }
 
-func (h KafkaACLHandler) checkPreconditions(i client.Object) bool {
+func (h KafkaACLHandler) checkPreconditions(i client.Object) (bool, error) {
 	acl, err := h.convert(i)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	return checkServiceIsRunning(h.client, acl.Spec.Project, acl.Spec.ServiceName)

--- a/controllers/kafkaconnect_controller.go
+++ b/controllers/kafkaconnect_controller.go
@@ -184,6 +184,6 @@ func (h KafkaConnectHandler) convert(i client.Object) (*k8soperatorv1alpha1.Kafk
 	return kc, nil
 }
 
-func (h KafkaConnectHandler) checkPreconditions(client.Object) bool {
-	return true
+func (h KafkaConnectHandler) checkPreconditions(client.Object) (bool, error) {
+	return true, nil
 }

--- a/controllers/kafkaschema_controller.go
+++ b/controllers/kafkaschema_controller.go
@@ -139,10 +139,10 @@ func (h KafkaSchemaHandler) get(i client.Object) (client.Object, *corev1.Secret,
 	return schema, nil, nil
 }
 
-func (h KafkaSchemaHandler) checkPreconditions(i client.Object) bool {
+func (h KafkaSchemaHandler) checkPreconditions(i client.Object) (bool, error) {
 	schema, err := h.convert(i)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	return checkServiceIsRunning(h.client, schema.Spec.Project, schema.Spec.ServiceName)

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -174,10 +174,10 @@ func (h KafkaTopicHandler) get(i client.Object) (client.Object, *corev1.Secret, 
 	return topic, nil, err
 }
 
-func (h KafkaTopicHandler) checkPreconditions(i client.Object) bool {
+func (h KafkaTopicHandler) checkPreconditions(i client.Object) (bool, error) {
 	topic, err := h.convert(i)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	return checkServiceIsRunning(h.client, topic.Spec.Project, topic.Spec.ServiceName)

--- a/controllers/pg_controller.go
+++ b/controllers/pg_controller.go
@@ -204,6 +204,6 @@ func (h PGHandler) convert(i client.Object) (*k8soperatorv1alpha1.PG, error) {
 	return pg, nil
 }
 
-func (h PGHandler) checkPreconditions(client.Object) bool {
-	return true
+func (h PGHandler) checkPreconditions(client.Object) (bool, error) {
+	return true, nil
 }

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -227,6 +227,6 @@ func (h ProjectHandler) convert(i client.Object) (*k8soperatorv1alpha1.Project, 
 	return p, nil
 }
 
-func (h ProjectHandler) checkPreconditions(client.Object) bool {
-	return true
+func (h ProjectHandler) checkPreconditions(client.Object) (bool, error) {
+	return true, nil
 }

--- a/controllers/projectvpc_controller.go
+++ b/controllers/projectvpc_controller.go
@@ -152,8 +152,8 @@ func (h ProjectVPCHandler) get(i client.Object) (client.Object, *corev1.Secret, 
 	return projectVPC, nil, nil
 }
 
-func (h ProjectVPCHandler) checkPreconditions(client.Object) bool {
-	return true
+func (h ProjectVPCHandler) checkPreconditions(client.Object) (bool, error) {
+	return true, nil
 }
 
 func (h *ProjectVPCHandler) convert(i client.Object) (*k8soperatorv1alpha1.ProjectVPC, error) {

--- a/controllers/serviceintegration_controller.go
+++ b/controllers/serviceintegration_controller.go
@@ -146,14 +146,23 @@ func (h ServiceIntegrationHandler) get(i client.Object) (client.Object, *corev1.
 	return si, nil, nil
 }
 
-func (h ServiceIntegrationHandler) checkPreconditions(i client.Object) bool {
+func (h ServiceIntegrationHandler) checkPreconditions(i client.Object) (bool, error) {
 	si, err := h.convert(i)
 	if err != nil {
-		return false
+		return false, err
 	}
 
-	return checkServiceIsRunning(h.client, si.Spec.Project, si.Spec.SourceServiceName) &&
-		checkServiceIsRunning(h.client, si.Spec.Project, si.Spec.DestinationServiceName)
+	sourceCheck, err := checkServiceIsRunning(h.client, si.Spec.Project, si.Spec.SourceServiceName)
+	if err != nil {
+		return false, err
+	}
+
+	destinationCheck, err := checkServiceIsRunning(h.client, si.Spec.Project, si.Spec.DestinationServiceName)
+	if err != nil {
+		return false, err
+	}
+
+	return sourceCheck && destinationCheck, nil
 }
 
 func (h ServiceIntegrationHandler) convert(i client.Object) (*k8soperatorv1alpha1.ServiceIntegration, error) {

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -158,10 +158,10 @@ func (h ServiceUserHandler) getSecretName(user *k8soperatorv1alpha1.ServiceUser)
 	return user.Name
 }
 
-func (h ServiceUserHandler) checkPreconditions(i client.Object) bool {
+func (h ServiceUserHandler) checkPreconditions(i client.Object) (bool, error) {
 	user, err := h.convert(i)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	return checkServiceIsRunning(h.client, user.Spec.Project, user.Spec.ServiceName)


### PR DESCRIPTION
It is important to communicate with a K8s user regarding any errors that may appear in the reconciliation loop, including precondition checks.