### PR TITLE
WIP: fix secret deletion racecondition

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -4,8 +4,10 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // AuthSecretReference references a Secret containing an Aiven authentication token
 type AuthSecretReference struct {
+	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
-	Key  string `json:"key"`
+	// +kubebuilder:validation:MinLength=1
+	Key string `json:"key"`
 }
 
 // ConnInfoSecretTarget contains information secret name

--- a/api/v1alpha1/connectionpool_types.go
+++ b/api/v1alpha1/connectionpool_types.go
@@ -65,6 +65,10 @@ type ConnectionPool struct {
 	Status ConnectionPoolStatus `json:"status,omitempty"`
 }
 
+func (cp ConnectionPool) AuthSecretRef() AuthSecretReference {
+	return cp.Spec.AuthSecretRef
+}
+
 // +kubebuilder:object:root=true
 
 // ConnectionPoolList contains a list of ConnectionPool

--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -54,6 +54,10 @@ type Database struct {
 	Status DatabaseStatus `json:"status,omitempty"`
 }
 
+func (db Database) AuthSecretRef() AuthSecretReference {
+	return db.Spec.AuthSecretRef
+}
+
 // +kubebuilder:object:root=true
 
 // DatabaseList contains a list of Database

--- a/api/v1alpha1/kafka_types.go
+++ b/api/v1alpha1/kafka_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 
 package v1alpha1
 
@@ -359,6 +359,10 @@ type Kafka struct {
 
 	Spec   KafkaSpec     `json:"spec,omitempty"`
 	Status ServiceStatus `json:"status,omitempty"`
+}
+
+func (kfk Kafka) AuthSecretRef() AuthSecretReference {
+	return kfk.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/kafkaacl_types.go
+++ b/api/v1alpha1/kafkaacl_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 
 package v1alpha1
 
@@ -55,6 +55,10 @@ type KafkaACL struct {
 
 	Spec   KafkaACLSpec   `json:"spec,omitempty"`
 	Status KafkaACLStatus `json:"status,omitempty"`
+}
+
+func (acl KafkaACL) AuthSecretRef() AuthSecretReference {
+	return acl.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/kafkaconnect_types.go
+++ b/api/v1alpha1/kafkaconnect_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 
 package v1alpha1
 
@@ -82,6 +82,10 @@ type KafkaConnect struct {
 
 	Spec   KafkaConnectSpec `json:"spec,omitempty"`
 	Status ServiceStatus    `json:"status,omitempty"`
+}
+
+func (kfkc KafkaConnect) AuthSecretRef() AuthSecretReference {
+	return kfkc.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/kafkaschema_types.go
+++ b/api/v1alpha1/kafkaschema_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 
 package v1alpha1
 
@@ -56,6 +56,10 @@ type KafkaSchema struct {
 
 	Spec   KafkaSchemaSpec   `json:"spec,omitempty"`
 	Status KafkaSchemaStatus `json:"status,omitempty"`
+}
+
+func (kfks KafkaSchema) AuthSecretRef() AuthSecretReference {
+	return kfks.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/kafkatopic_types.go
+++ b/api/v1alpha1/kafkatopic_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 
 package v1alpha1
 
@@ -150,6 +150,10 @@ type KafkaTopic struct {
 
 	Spec   KafkaTopicSpec   `json:"spec,omitempty"`
 	Status KafkaTopicStatus `json:"status,omitempty"`
+}
+
+func (kfkt KafkaTopic) AuthSecretRef() AuthSecretReference {
+	return kfkt.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/pg_types.go
+++ b/api/v1alpha1/pg_types.go
@@ -396,6 +396,10 @@ type PG struct {
 	Status ServiceStatus `json:"status,omitempty"`
 }
 
+func (pg PG) AuthSecretRef() AuthSecretReference {
+	return pg.Spec.AuthSecretRef
+}
+
 // +kubebuilder:object:root=true
 
 // PGList contains a list of PG

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -90,6 +90,10 @@ type Project struct {
 	Status ProjectStatus `json:"status,omitempty"`
 }
 
+func (proj Project) AuthSecretRef() AuthSecretReference {
+	return proj.Spec.AuthSecretRef
+}
+
 // +kubebuilder:object:root=true
 
 // ProjectList contains a list of Project

--- a/api/v1alpha1/projectvpc_types.go
+++ b/api/v1alpha1/projectvpc_types.go
@@ -49,6 +49,10 @@ type ProjectVPC struct {
 	Status ProjectVPCStatus `json:"status,omitempty"`
 }
 
+func (pvpc ProjectVPC) AuthSecretRef() AuthSecretReference {
+	return pvpc.Spec.AuthSecretRef
+}
+
 // +kubebuilder:object:root=true
 
 // ProjectVPCList contains a list of ProjectVPC

--- a/api/v1alpha1/serviceintegration_types.go
+++ b/api/v1alpha1/serviceintegration_types.go
@@ -133,6 +133,10 @@ type ServiceIntegration struct {
 	Status ServiceIntegrationStatus `json:"status,omitempty"`
 }
 
+func (svcint ServiceIntegration) AuthSecretRef() AuthSecretReference {
+	return svcint.Spec.AuthSecretRef
+}
+
 // +kubebuilder:object:root=true
 
 // ServiceIntegrationList contains a list of ServiceIntegration

--- a/api/v1alpha1/serviceuser_types.go
+++ b/api/v1alpha1/serviceuser_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
+// Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 
 package v1alpha1
 
@@ -50,6 +50,10 @@ type ServiceUser struct {
 
 	Spec   ServiceUserSpec   `json:"spec,omitempty"`
 	Status ServiceUserStatus `json:"status,omitempty"`
+}
+
+func (svcusr ServiceUser) AuthSecretRef() AuthSecretReference {
+	return svcusr.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/aiven.io_connectionpools.yaml
+++ b/config/crd/bases/aiven.io_connectionpools.yaml
@@ -59,8 +59,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_databases.yaml
+++ b/config/crd/bases/aiven.io_databases.yaml
@@ -47,8 +47,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_kafkaacls.yaml
+++ b/config/crd/bases/aiven.io_kafkaacls.yaml
@@ -56,8 +56,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_kafkaconnects.yaml
+++ b/config/crd/bases/aiven.io_kafkaconnects.yaml
@@ -44,8 +44,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -53,8 +53,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_kafkaschemas.yaml
+++ b/config/crd/bases/aiven.io_kafkaschemas.yaml
@@ -56,8 +56,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_kafkatopics.yaml
+++ b/config/crd/bases/aiven.io_kafkatopics.yaml
@@ -53,8 +53,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_pgs.yaml
+++ b/config/crd/bases/aiven.io_pgs.yaml
@@ -53,8 +53,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_projects.yaml
+++ b/config/crd/bases/aiven.io_projects.yaml
@@ -44,8 +44,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_projectvpcs.yaml
+++ b/config/crd/bases/aiven.io_projectvpcs.yaml
@@ -50,8 +50,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_serviceintegrations.yaml
+++ b/config/crd/bases/aiven.io_serviceintegrations.yaml
@@ -41,8 +41,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/crd/bases/aiven.io_serviceusers.yaml
+++ b/config/crd/bases/aiven.io_serviceusers.yaml
@@ -50,8 +50,10 @@ spec:
                 description: Authentication reference to Aiven token in a secret
                 properties:
                   key:
+                    minLength: 1
                     type: string
                   name:
+                    minLength: 1
                     type: string
                 required:
                 - key

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,7 @@ spec:
         args:
         - --enable-leader-election
         image: controller:latest
+        imagePullPolicy: IfNotPresent
         name: manager
         resources:
           limits:

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -1,9 +1,36 @@
 package controllers
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"context"
+	"strconv"
+	"time"
 
-const conditionTypeRunning = "Running"
-const conditionTypeInitialized = "Initialized"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	conditionTypeRunning     = "Running"
+	conditionTypeInitialized = "Initialized"
+
+	secretProtectionFinalizer = "finalizers.aiven.io/needed-to-delete-services"
+	instanceDeletionFinalizer = "finalizers.aiven.io/delete-remote-resource"
+
+	processedGenerationAnnotation = "controllers.aiven.io/generation-was-processed"
+	instanceIsRunningAnnotation   = "controllers.aiven.io/instance-is-running"
+)
+
+func requeueCtrlResult() ctrl.Result {
+	// nolint: gomnd
+	requeueTimeout := 10 * time.Second
+
+	return ctrl.Result{
+		Requeue:      true,
+		RequeueAfter: requeueTimeout,
+	}
+}
 
 func getInitializedCondition(reason, message string) metav1.Condition {
 	return metav1.Condition{
@@ -21,4 +48,27 @@ func getRunningCondition(status metav1.ConditionStatus, reason, message string) 
 		Reason:  reason,
 		Message: message,
 	}
+}
+
+func markedForDeletion(o client.Object) bool {
+	return !o.GetDeletionTimestamp().IsZero()
+}
+
+func addFinalizer(ctx context.Context, client client.Client, o client.Object, f string) error {
+	controllerutil.AddFinalizer(o, f)
+	return client.Update(ctx, o)
+}
+
+func removeFinalizer(ctx context.Context, client client.Client, o client.Object, f string) error {
+	controllerutil.RemoveFinalizer(o, f)
+	return client.Update(ctx, o)
+}
+
+func isAlreadyProcessed(o client.Object) bool {
+	return o.GetAnnotations()[processedGenerationAnnotation] == strconv.FormatInt(o.GetGeneration(), formatIntBaseDecimal)
+}
+
+func isAlreadyRunning(o client.Object) bool {
+	_, found := o.GetAnnotations()[instanceIsRunningAnnotation]
+	return found
 }

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -4,34 +4,20 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
-	"time"
 
-	"github.com/aiven/aiven-go-client"
-	"github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
 )
-
-// requeueTimeout sets timeout to requeue controller
-const requeueTimeout = 10 * time.Second
-
-// processedGeneration annotations key that holds value of processed generation
-const processedGeneration = "processed"
-
-// isRunning annotations key which is set when resource is running on Aiven side
-const isRunning = "running"
-
-// requeueAfterTimeout set the timeout for reconciler when to requeue
-const requeueAfterTimeout = 10 * time.Second
 
 // formatIntBaseDecimal it is a base to format int64 to string
 const formatIntBaseDecimal = 10
@@ -49,271 +35,155 @@ type (
 	// of the Aiven services lifecycle.
 	Handlers interface {
 		// create or updates an instance on the Aiven side.
-		createOrUpdate(client.Object) error
+		createOrUpdate(*aiven.Client, client.Object) error
 
 		// delete removes an instance on Aiven side.
 		// If an object is already deleted and cannot be found, it should not be an error. For other deletion
 		// errors, return an error.
-		delete(client.Object) (bool, error)
+		delete(*aiven.Client, client.Object) (bool, error)
 
 		// get retrieve an object and a secret (for example, connection credentials) that is generated on the
 		// fly based on data from Aiven API.  When not applicable to service, it should return nil.
-		get(client.Object) (*corev1.Secret, error)
+		get(*aiven.Client, client.Object) (*corev1.Secret, error)
 
 		// checkPreconditions check whether all preconditions for creating (or updating) the resource are in place.
 		// For example, it is applicable when a service needs to be running before this resource can be created.
-		checkPreconditions(client.Object) (bool, error)
+		checkPreconditions(*aiven.Client, client.Object) (bool, error)
+	}
+
+	aivenManagedObject interface {
+		client.Object
+
+		AuthSecretRef() v1alpha1.AuthSecretReference
 	}
 )
 
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
-func (c *Controller) reconcileInstance(ctx context.Context, h Handlers, o client.Object) (_ ctrl.Result, rErr error) {
-	log := c.initLog(o)
-
+func (c *Controller) reconcileInstance(ctx context.Context, req ctrl.Request, h Handlers, o aivenManagedObject) (_ ctrl.Result, rErr error) {
+	if err := c.Get(ctx, req.NamespacedName, o); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	log := c.loggerForInstance(o)
 	log.Info("reconciling instance")
-	// Check if the instance is marked to be deleted, which is
-	// indicated by the deletion timestamp being set.
-	isInstanceMarkedToBeDeleted := o.GetDeletionTimestamp() != nil
-	if isInstanceMarkedToBeDeleted {
-		if contains(o.GetFinalizers(), c.getFinalizerName(o)) {
-			// Run finalization logic for finalizer. If the
-			// finalization logic fails, don't remove the finalize so
-			// that we can retry during the next reconciliation.
-			// When applicable, it retrieves an associated object that
-			// has to be deleted from Kubernetes, and it could be a
-			// secret associated with an instance.
-			finalised, err := h.delete(o)
-			if err != nil {
+
+	clientAuthSecret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Name: o.AuthSecretRef().Name, Namespace: req.Namespace}, clientAuthSecret); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot get secret %q: %w", o.AuthSecretRef().Name, err)
+	}
+	avn, err := aiven.NewTokenClient(string(clientAuthSecret.Data[o.AuthSecretRef().Key]), "k8s-operator/")
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot get initialize aiven client: %w", err)
+	}
+
+	log.Info("handling finalizers")
+	if markedForDeletion(o) {
+		if controllerutil.ContainsFinalizer(o, instanceDeletionFinalizer) {
+			log.Info("deleting instance at aiven")
+
+			if deleted, err := h.delete(avn, o); err != nil {
 				return ctrl.Result{}, err
+			} else if !deleted {
+				log.Info("instance was not deleted, requeue")
+				return requeueCtrlResult(), nil
 			}
-
-			log.Info("instance was successfully finalized")
-
-			// Checking if instance was finalized, if not triggering a requeue
-			if !finalised {
-				return ctrl.Result{
-					Requeue:      true,
-					RequeueAfter: requeueTimeout,
-				}, nil
-			}
-
-			// Remove finalizer. Once all finalizers have been
-			// removed, the object will be deleted.
-			log.Info("removing finalizer from instance")
-			controllerutil.RemoveFinalizer(o, c.getFinalizerName(o))
-			err = c.Update(ctx, o)
-			if err != nil {
-				return ctrl.Result{}, err
+			log.Info("instance was successfully deleted at aiven, removing finalizer")
+			if err = removeFinalizer(ctx, c.Client, o, instanceDeletionFinalizer); err != nil {
+				return ctrl.Result{}, fmt.Errorf("unable to remove finalizer: %w", err)
 			}
 		}
 		return ctrl.Result{}, nil
-	}
-
-	// Add finalizer for this CR
-	if !contains(o.GetFinalizers(), c.getFinalizerName(o)) {
-		log.Info("add finalizer")
-		if err := c.addFinalizer(o, c.getFinalizerName(o)); err != nil {
-			return ctrl.Result{}, err
+	} else {
+		if !controllerutil.ContainsFinalizer(clientAuthSecret, secretProtectionFinalizer) {
+			log.Info("adding finalizer to secret")
+			if err := addFinalizer(ctx, c.Client, clientAuthSecret, secretProtectionFinalizer); err != nil {
+				return ctrl.Result{}, fmt.Errorf("unable to add finalizer to secret: %w", err)
+			}
+		}
+		if !controllerutil.ContainsFinalizer(o, instanceDeletionFinalizer) {
+			log.Info("adding finalizer to instance")
+			if err := addFinalizer(ctx, c.Client, o, instanceDeletionFinalizer); err != nil {
+				return ctrl.Result{}, fmt.Errorf("unable to add finalizer to instance: %w", err)
+			}
 		}
 	}
 
-	// Check preconditions
+	log.Info("handling service update/creation")
 	log.Info("checking preconditions")
-	check, err := h.checkPreconditions(o)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if !check {
+	if check, err := h.checkPreconditions(avn, o); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to check preconditions")
+	} else if !check {
 		log.Info("preconditions are not met, requeue")
-		return ctrl.Result{Requeue: true, RequeueAfter: requeueTimeout}, nil
+		return requeueCtrlResult(), nil
 	}
 
 	defer func() {
-		var result error
-
-		err := c.Status().Update(ctx, o)
-		if err != nil {
-			log.Error(err, "cannot update CR status")
-			result = multierror.Append(result, err)
-		}
-
-		err = c.Update(ctx, o)
-		if err != nil {
-			log.Error(err, "cannot update CR")
-			result = multierror.Append(result, err)
-		}
-
-		rErr = multierror.Append(rErr, result)
+		rErr = multierror.Append(rErr, c.Status().Update(ctx, o))
+		rErr = multierror.Append(rErr, c.Update(ctx, o))
+		rErr = rErr.(*multierror.Error).ErrorOrNil()
 	}()
 
 	log.Info("checking if generation was processed")
-	if !c.processed(o) {
+	if !isAlreadyProcessed(o) {
 		log.Info("generation wasn't processed, creation or updating instance on aiven side")
 		c.resetAnnotations(o)
-		err := h.createOrUpdate(o)
-		if err != nil {
-			return ctrl.Result{}, err
+		if err := h.createOrUpdate(avn, o); err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to create or update aiven instance: %w", err)
 		}
-
-		log.Info(fmt.Sprintf("generation %q was processed, setting annotations: %+v",
-			o.GetGeneration(), o.GetAnnotations()))
-		return ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: requeueAfterTimeout,
-		}, nil
+		log.Info("processed instance, updating annotations", "generation", o.GetGeneration(), "annotations", o.GetAnnotations())
+		return requeueCtrlResult(), nil
 	}
 
-	log.Info("getting an instance")
-	s, err := h.get(o)
-	if err != nil {
+	log.Info("managing instance secret")
+	if serviceSecret, err := h.get(avn, o); err != nil {
 		if aiven.IsNotFound(err) {
-			return ctrl.Result{
-				Requeue:      true,
-				RequeueAfter: requeueAfterTimeout,
-			}, nil
+			log.Info("instance not found, requeue")
+			return requeueCtrlResult(), nil
 		}
-		return ctrl.Result{}, err
-	}
-
-	if s != nil {
-		err = c.manageSecret(ctx, o, s)
-		if err != nil {
-			return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("unable to get aiven instance: %w", err)
+	} else if serviceSecret != nil {
+		if err = c.createOrUpdateSecret(ctx, o, serviceSecret); err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to manage aiven secret: %w", err)
 		}
 	}
 
 	log.Info("checking if instance is running")
-	if !c.isRunning(o) {
-		log.Info("instance is not yet running, triggering requeue")
-		return ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: requeueAfterTimeout,
-		}, nil
+	if !isAlreadyRunning(o) {
+		log.Info("instance is not yet running, requeue")
+		return requeueCtrlResult(), nil
 	}
 
-	log.Info("instance is successfully reconciled")
+	log.Info("instance was successfully reconciled")
 	return ctrl.Result{}, nil
 }
 
 func (c *Controller) resetAnnotations(o client.Object) {
 	a := o.GetAnnotations()
-	delete(a, processedGeneration)
-	delete(a, isRunning)
+	delete(a, processedGenerationAnnotation)
+	delete(a, instanceIsRunningAnnotation)
 }
 
-func (c *Controller) initLog(o client.Object) logr.Logger {
+func (c *Controller) loggerForInstance(o client.Object) logr.Logger {
 	a := make(map[string]string)
-	if r, ok := o.GetAnnotations()[isRunning]; ok {
-		a[isRunning] = r
+	if r, ok := o.GetAnnotations()[instanceIsRunningAnnotation]; ok {
+		a[instanceIsRunningAnnotation] = r
 	}
 
-	if g, ok := o.GetAnnotations()[processedGeneration]; ok {
-		a[processedGeneration] = g
+	if g, ok := o.GetAnnotations()[processedGenerationAnnotation]; ok {
+		a[processedGenerationAnnotation] = g
 	}
+	kind := strings.ToLower(o.GetObjectKind().GroupVersionKind().Kind)
+	name := types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}
 
-	return c.Log.WithValues(strings.ToLower(o.GetObjectKind().GroupVersionKind().Kind),
-		types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()},
-		"annotations", a)
+	return c.Log.WithValues("kind", kind, "name", name, "annotations", a)
 }
 
-func (c *Controller) getFinalizerName(o client.Object) string {
-	return fmt.Sprintf("%s-finalizer.aiven.io", o.GetObjectKind().GroupVersionKind().Kind)
-}
-
-func (c *Controller) processed(o client.Object) bool {
-	for k, v := range o.GetAnnotations() {
-		if processedGeneration == k && v == strconv.FormatInt(o.GetGeneration(), formatIntBaseDecimal) {
-			return true
-		}
-	}
-	return false
-}
-
-func (c *Controller) isRunning(o client.Object) bool {
-	_, found := o.GetAnnotations()[isRunning]
-	return found
-}
-
-func (c *Controller) manageSecret(ctx context.Context, o client.Object, s *corev1.Secret) error {
-	createdSecret := &corev1.Secret{}
-	err := c.Get(ctx, types.NamespacedName{Name: s.Name, Namespace: s.Namespace}, createdSecret)
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-	err = ctrl.SetControllerReference(o, s, c.Scheme)
-	if err != nil {
-		return err
-	}
-
-	if len(createdSecret.Data) != 0 {
-		if err := c.Update(ctx, s); err != nil {
-			return err
-		}
-	} else {
-		if err := c.Create(ctx, s); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// InitAivenClient retrieves an Aiven client
-func (c *Controller) InitAivenClient(ctx context.Context, req ctrl.Request, secretRef v1alpha1.AuthSecretReference) (*aiven.Client, error) {
-	// Check if aiven-token secret exists
-	var token string
-	secret := &corev1.Secret{}
-	if secretRef.Name == "" || secretRef.Key == "" {
-		return nil, fmt.Errorf("secret ref  key or secret is empty, cannot createOrUpdate an aiven client")
-	}
-
-	err := c.Get(ctx, types.NamespacedName{Name: secretRef.Name, Namespace: req.Namespace}, secret)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get %q secret: %w", secretRef.Name, err)
-	}
-
-	if v, ok := secret.Data[secretRef.Key]; ok {
-		token = string(v)
-	} else {
-		return nil, fmt.Errorf("cannot initialize aiven client, kubernetes secret has no %q key", secretRef.Key)
-	}
-
-	if len(token) == 0 {
-		return nil, fmt.Errorf("cannot initialize aiven client, %q key in a secret is empty", secretRef.Key)
-	}
-
-	con, err := aiven.NewTokenClient(token, "k8s-operator/")
-	if err != nil {
-		return nil, fmt.Errorf("cannot createOrUpdate an aiven client: %w", err)
-	}
-
-	return con, nil
-}
-
-func (c *Controller) addFinalizer(o client.Object, f string) error {
-	controllerutil.AddFinalizer(o, f)
-
-	// Update CR
-	err := c.Client.Update(context.Background(), o)
-	if err != nil {
-		c.Log.Error(err, "failed to update instance with finalize")
-		return err
-	}
-
-	return nil
-}
-
-// contains checks if string slice contains an element
-func contains(list []string, s string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-	return false
+func (c *Controller) createOrUpdateSecret(ctx context.Context, owner client.Object, want *corev1.Secret) error {
+	_, err := controllerutil.CreateOrUpdate(ctx, c.Client, want, func() error {
+		return ctrl.SetControllerReference(owner, want, c.Scheme)
+	})
+	return err
 }
 
 // UserConfigurationToAPI converts UserConfiguration options structure

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	k8soperatorv1alpha1 "github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
+	"github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -29,13 +29,13 @@ func TestUserConfigurationToAPI(t *testing.T) {
 		{
 			name: "basic",
 			args: args{
-				c: k8soperatorv1alpha1.PGUserConfig{
+				c: v1alpha1.PGUserConfig{
 					PgVersion: "12",
-					Pg: k8soperatorv1alpha1.PGSubPGUserConfig{
+					Pg: v1alpha1.PGSubPGUserConfig{
 						Timezone:      "CEST",
 						TempFileLimit: &tempFileLimit,
 					},
-					PublicAccess: k8soperatorv1alpha1.PublicAccessUserConfig{
+					PublicAccess: v1alpha1.PublicAccessUserConfig{
 						Pg: &publicAccessPg,
 					},
 				},

--- a/controllers/kafkaacl_controller.go
+++ b/controllers/kafkaacl_controller.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/aiven/aiven-go-client"
-	k8soperatorv1alpha1 "github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
 )
 
 // KafkaACLReconciler reconciles a KafkaACL object
@@ -22,53 +22,34 @@ type KafkaACLReconciler struct {
 	Controller
 }
 
-type KafkaACLHandler struct {
-	Handlers
-	client *aiven.Client
-}
+type KafkaACLHandler struct{}
 
 // +kubebuilder:rbac:groups=aiven.io,resources=kafkaacls,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=aiven.io,resources=kafkaacls/status,verbs=get
 
 func (r *KafkaACLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	acl := &k8soperatorv1alpha1.KafkaACL{}
-	err := r.Get(ctx, req.NamespacedName, acl)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
-	}
-
-	c, err := r.InitAivenClient(ctx, req, acl.Spec.AuthSecretRef)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return r.reconcileInstance(ctx, KafkaACLHandler{
-		client: c,
-	}, acl)
+	return r.reconcileInstance(ctx, req, KafkaACLHandler{}, &v1alpha1.KafkaACL{})
 }
 
 func (r *KafkaACLReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&k8soperatorv1alpha1.KafkaACL{}).
+		For(&v1alpha1.KafkaACL{}).
 		Complete(r)
 }
 
-func (h KafkaACLHandler) createOrUpdate(i client.Object) error {
+func (h KafkaACLHandler) createOrUpdate(avn *aiven.Client, i client.Object) error {
 	acl, err := h.convert(i)
 	if err != nil {
 		return err
 	}
 
-	exists, err := h.exists(acl)
+	exists, err := h.exists(avn, acl)
 	if err != nil {
 		return err
 	}
 
 	if !exists {
-		_, err = h.client.KafkaACLs.Create(
+		_, err = avn.KafkaACLs.Create(
 			acl.Spec.Project,
 			acl.Spec.ServiceName,
 			aiven.CreateKafkaACLRequest{
@@ -91,18 +72,18 @@ func (h KafkaACLHandler) createOrUpdate(i client.Object) error {
 			"Instance was created or update on Aiven side, status remains unknown"))
 
 	metav1.SetMetaDataAnnotation(&acl.ObjectMeta,
-		processedGeneration, strconv.FormatInt(acl.GetGeneration(), formatIntBaseDecimal))
+		processedGenerationAnnotation, strconv.FormatInt(acl.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }
 
-func (h KafkaACLHandler) delete(i client.Object) (bool, error) {
+func (h KafkaACLHandler) delete(avn *aiven.Client, i client.Object) (bool, error) {
 	acl, err := h.convert(i)
 	if err != nil {
 		return false, err
 	}
 
-	err = h.client.KafkaACLs.Delete(acl.Spec.Project, acl.Spec.ServiceName, acl.Status.ID)
+	err = avn.KafkaACLs.Delete(acl.Spec.Project, acl.Spec.ServiceName, acl.Status.ID)
 	if err != nil && !aiven.IsNotFound(err) {
 		return false, fmt.Errorf("aiven client delete Kafka ACL error: %w", err)
 	}
@@ -110,16 +91,16 @@ func (h KafkaACLHandler) delete(i client.Object) (bool, error) {
 	return true, nil
 }
 
-func (h KafkaACLHandler) exists(acl *k8soperatorv1alpha1.KafkaACL) (bool, error) {
+func (h KafkaACLHandler) exists(avn *aiven.Client, acl *v1alpha1.KafkaACL) (bool, error) {
 	var aivenACL *aiven.KafkaACL
 	var err error
 	if acl.Status.ID != "" {
-		aivenACL, err = h.client.KafkaACLs.Get(acl.Spec.Project, acl.Spec.ServiceName, acl.Status.ID)
+		aivenACL, err = avn.KafkaACLs.Get(acl.Spec.Project, acl.Spec.ServiceName, acl.Status.ID)
 		if err != nil {
 			return false, err
 		}
 	} else {
-		list, err := h.client.KafkaACLs.List(acl.Spec.Project, acl.Spec.ServiceName)
+		list, err := avn.KafkaACLs.List(acl.Spec.Project, acl.Spec.ServiceName)
 		if err != nil {
 			return false, err
 		}
@@ -134,7 +115,7 @@ func (h KafkaACLHandler) exists(acl *k8soperatorv1alpha1.KafkaACL) (bool, error)
 	return aivenACL != nil, nil
 }
 
-func (h KafkaACLHandler) get(i client.Object) (*corev1.Secret, error) {
+func (h KafkaACLHandler) get(_ *aiven.Client, i client.Object) (*corev1.Secret, error) {
 	acl, err := h.convert(i)
 	if err != nil {
 		return nil, err
@@ -144,12 +125,12 @@ func (h KafkaACLHandler) get(i client.Object) (*corev1.Secret, error) {
 		getRunningCondition(metav1.ConditionTrue, "CheckRunning",
 			"Instance is running on Aiven side"))
 
-	metav1.SetMetaDataAnnotation(&acl.ObjectMeta, isRunning, "true")
+	metav1.SetMetaDataAnnotation(&acl.ObjectMeta, instanceIsRunningAnnotation, "true")
 
 	return nil, nil
 }
 
-func (h KafkaACLHandler) checkPreconditions(i client.Object) (bool, error) {
+func (h KafkaACLHandler) checkPreconditions(avn *aiven.Client, i client.Object) (bool, error) {
 	acl, err := h.convert(i)
 	if err != nil {
 		return false, err
@@ -158,11 +139,11 @@ func (h KafkaACLHandler) checkPreconditions(i client.Object) (bool, error) {
 	meta.SetStatusCondition(&acl.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsRunning(h.client, acl.Spec.Project, acl.Spec.ServiceName)
+	return checkServiceIsRunning(avn, acl.Spec.Project, acl.Spec.ServiceName)
 }
 
-func (h KafkaACLHandler) convert(i client.Object) (*k8soperatorv1alpha1.KafkaACL, error) {
-	acl, ok := i.(*k8soperatorv1alpha1.KafkaACL)
+func (h KafkaACLHandler) convert(i client.Object) (*v1alpha1.KafkaACL, error) {
+	acl, ok := i.(*v1alpha1.KafkaACL)
 	if !ok {
 		return nil, fmt.Errorf("cannot convert object to KafkaACL")
 	}

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -8,14 +8,14 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/aiven/aiven-go-client"
-	k8soperatorv1alpha1 "github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aiven/aiven-go-client"
+	"github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
 )
 
 // ProjectReconciler reconciles a Project object
@@ -24,43 +24,24 @@ type ProjectReconciler struct {
 }
 
 // ProjectHandler handles an Aiven project
-type ProjectHandler struct {
-	Handlers
-	client *aiven.Client
-}
+type ProjectHandler struct{}
 
 // +kubebuilder:rbac:groups=aiven.io,resources=projects,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=aiven.io,resources=projects/status,verbs=get;update;patch
 
 func (r *ProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	project := &k8soperatorv1alpha1.Project{}
-	err := r.Get(ctx, req.NamespacedName, project)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
-	}
-
-	c, err := r.InitAivenClient(ctx, req, project.Spec.AuthSecretRef)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return r.reconcileInstance(ctx, ProjectHandler{
-		client: c,
-	}, project)
+	return r.reconcileInstance(ctx, req, ProjectHandler{}, &v1alpha1.Project{})
 }
 
 func (r *ProjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&k8soperatorv1alpha1.Project{}).
+		For(&v1alpha1.Project{}).
 		Owns(&corev1.Secret{}).
 		Complete(r)
 }
 
 // create creates a project on Aiven side
-func (h ProjectHandler) createOrUpdate(i client.Object) error {
+func (h ProjectHandler) createOrUpdate(avn *aiven.Client, i client.Object) error {
 	project, err := h.convert(i)
 	if err != nil {
 		return err
@@ -76,7 +57,7 @@ func (h ProjectHandler) createOrUpdate(i client.Object) error {
 		technicalEmails = aiven.ContactEmailFromStringSlice(project.Spec.TechnicalEmails)
 	}
 
-	exists, err := h.exists(project)
+	exists, err := h.exists(avn, project)
 	if err != nil {
 		return err
 	}
@@ -84,7 +65,7 @@ func (h ProjectHandler) createOrUpdate(i client.Object) error {
 	var reason string
 	var p *aiven.Project
 	if !exists {
-		p, err = h.client.Projects.Create(aiven.CreateProjectRequest{
+		p, err = avn.Projects.Create(aiven.CreateProjectRequest{
 			BillingAddress:   toOptionalStringPointer(project.Spec.BillingAddress),
 			BillingEmails:    billingEmails,
 			BillingExtraText: toOptionalStringPointer(project.Spec.BillingExtraText),
@@ -103,7 +84,7 @@ func (h ProjectHandler) createOrUpdate(i client.Object) error {
 
 		reason = "Created"
 	} else {
-		p, err = h.client.Projects.Update(project.Name, aiven.UpdateProjectRequest{
+		p, err = avn.Projects.Update(project.Name, aiven.UpdateProjectRequest{
 			BillingAddress:   toOptionalStringPointer(project.Spec.BillingAddress),
 			BillingEmails:    billingEmails,
 			BillingExtraText: toOptionalStringPointer(project.Spec.BillingExtraText),
@@ -136,18 +117,18 @@ func (h ProjectHandler) createOrUpdate(i client.Object) error {
 			"Instance was created or update on Aiven side, status remains unknown"))
 
 	metav1.SetMetaDataAnnotation(&project.ObjectMeta,
-		processedGeneration, strconv.FormatInt(project.GetGeneration(), formatIntBaseDecimal))
+		processedGenerationAnnotation, strconv.FormatInt(project.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }
 
-func (h ProjectHandler) get(i client.Object) (*corev1.Secret, error) {
+func (h ProjectHandler) get(avn *aiven.Client, i client.Object) (*corev1.Secret, error) {
 	project, err := h.convert(i)
 	if err != nil {
 		return nil, err
 	}
 
-	cert, err := h.client.CA.Get(project.Name)
+	cert, err := avn.CA.Get(project.Name)
 	if err != nil {
 		return nil, fmt.Errorf("aiven client error %w", err)
 	}
@@ -156,7 +137,7 @@ func (h ProjectHandler) get(i client.Object) (*corev1.Secret, error) {
 		getRunningCondition(metav1.ConditionTrue, "CheckRunning",
 			"Instance is running on Aiven side"))
 
-	metav1.SetMetaDataAnnotation(&project.ObjectMeta, isRunning, "true")
+	metav1.SetMetaDataAnnotation(&project.ObjectMeta, instanceIsRunningAnnotation, "true")
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -170,8 +151,8 @@ func (h ProjectHandler) get(i client.Object) (*corev1.Secret, error) {
 }
 
 // exists checks if project already exists on Aiven side
-func (h ProjectHandler) exists(project *k8soperatorv1alpha1.Project) (bool, error) {
-	pr, err := h.client.Projects.Get(project.Name)
+func (h ProjectHandler) exists(avn *aiven.Client, project *v1alpha1.Project) (bool, error) {
+	pr, err := avn.Projects.Get(project.Name)
 	if aiven.IsNotFound(err) {
 		return false, nil
 	}
@@ -180,14 +161,14 @@ func (h ProjectHandler) exists(project *k8soperatorv1alpha1.Project) (bool, erro
 }
 
 // delete deletes Aiven project
-func (h ProjectHandler) delete(i client.Object) (bool, error) {
+func (h ProjectHandler) delete(avn *aiven.Client, i client.Object) (bool, error) {
 	project, err := h.convert(i)
 	if err != nil {
 		return false, err
 	}
 
 	// Delete project on Aiven side
-	if err := h.client.Projects.Delete(project.Name); err != nil {
+	if err := avn.Projects.Delete(project.Name); err != nil {
 		var skip bool
 
 		// If project not found then there is nothing to delete
@@ -211,15 +192,15 @@ func (h ProjectHandler) delete(i client.Object) (bool, error) {
 	return true, nil
 }
 
-func (h ProjectHandler) getSecretName(project *k8soperatorv1alpha1.Project) string {
+func (h ProjectHandler) getSecretName(project *v1alpha1.Project) string {
 	if project.Spec.ConnInfoSecretTarget.Name != "" {
 		return project.Spec.ConnInfoSecretTarget.Name
 	}
 	return project.Name
 }
 
-func (h ProjectHandler) convert(i client.Object) (*k8soperatorv1alpha1.Project, error) {
-	p, ok := i.(*k8soperatorv1alpha1.Project)
+func (h ProjectHandler) convert(i client.Object) (*v1alpha1.Project, error) {
+	p, ok := i.(*v1alpha1.Project)
 	if !ok {
 		return nil, fmt.Errorf("cannot convert object to project")
 	}
@@ -227,6 +208,6 @@ func (h ProjectHandler) convert(i client.Object) (*k8soperatorv1alpha1.Project, 
 	return p, nil
 }
 
-func (h ProjectHandler) checkPreconditions(client.Object) (bool, error) {
+func (h ProjectHandler) checkPreconditions(_ *aiven.Client, _ client.Object) (bool, error) {
 	return true, nil
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,7 +29,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	k8soperatorv1alpha1 "github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
+	"github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -73,7 +73,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = k8soperatorv1alpha1.AddToScheme(scheme.Scheme)
+	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/main.go
+++ b/main.go
@@ -13,8 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	k8soperatoraiveniov1alpha1 "github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
-	k8soperatorv1alpha1 "github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
+	v1alpha1 "github.com/aiven/aiven-kubernetes-operator/api/v1alpha1"
 	"github.com/aiven/aiven-kubernetes-operator/controllers"
 	// +kubebuilder:scaffold:imports
 )
@@ -27,8 +26,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(k8soperatorv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(k8soperatoraiveniov1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -54,6 +52,14 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err = (&controllers.SecretFinalizerGCController{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("SecretFinalizerGCController"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SecretFinalizerGCController")
 		os.Exit(1)
 	}
 
@@ -190,60 +196,60 @@ func main() {
 	}
 
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err = (&k8soperatorv1alpha1.Project{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.Project{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Project")
 			os.Exit(1)
 		}
-		if err = (&k8soperatorv1alpha1.PG{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.PG{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "PG")
 			os.Exit(1)
 		}
-		if err = (&k8soperatorv1alpha1.Database{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.Database{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Database")
 			os.Exit(1)
 		}
 
-		if err = (&k8soperatorv1alpha1.ConnectionPool{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.ConnectionPool{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ConnectionPool")
 			os.Exit(1)
 		}
 
-		if err = (&k8soperatorv1alpha1.ServiceUser{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.ServiceUser{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ServiceUser")
 			os.Exit(1)
 		}
 
-		if err = (&k8soperatorv1alpha1.ProjectVPC{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.ProjectVPC{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ProjectVPC")
 			os.Exit(1)
 		}
 
-		if err = (&k8soperatorv1alpha1.Kafka{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.Kafka{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Kafka")
 			os.Exit(1)
 		}
 
-		if err = (&k8soperatorv1alpha1.KafkaConnect{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.KafkaConnect{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "KafkaConnect")
 			os.Exit(1)
 		}
 
-		if err = (&k8soperatorv1alpha1.KafkaTopic{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.KafkaTopic{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "KafkaTopic")
 			os.Exit(1)
 		}
 
-		if err = (&k8soperatorv1alpha1.KafkaACL{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.KafkaACL{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "KafkaACL")
 			os.Exit(1)
 		}
 
-		if err = (&k8soperatorv1alpha1.KafkaSchema{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.KafkaSchema{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "KafkaSchema")
 			os.Exit(1)
 		}
 
-		if err = (&k8soperatorv1alpha1.ServiceIntegration{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&v1alpha1.ServiceIntegration{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "ServiceIntegration")
 			os.Exit(1)
 		}


### PR DESCRIPTION
This PR attempts to solve the race between deletion of a secret and deletion of a resource that still needs it to be reconciled with aiven. 

The idea is to add a finalizer `finalizers.aiven.io/needed-for-service-deletion` to a secret during creation of an instance. Deletion of that finalizer is handled in a new controller that checks if the finalizer is present and if the secret is used by any aiven resource. 