### PR TITLE
WIP: run kuttl in CI pipelines

### DIFF
--- a/test/e2e/kuttl-test.yaml
+++ b/test/e2e/kuttl-test.yaml
@@ -5,3 +5,7 @@ crdDir: config/crd/bases
 testDirs:
 - test/e2e/kafka
 - test/e2e/kafka-connector
+commands:
+- script: ENABLE_WEBHOOKS=false ./bin/manager
+  background: true
+  skipLogOutput: true


### PR DESCRIPTION
https://github.com/kudobuilder/kuttl/pull/318 enables us to run the manager outside of the cluster and still clean up finalizers. 

Once it is merged we can use kuttl in CI pipelines. 