### PR TITLE
fix missing kafka acl rbac

### DIFF
--- a/api/v1alpha1/kafkaacl_webhook.go
+++ b/api/v1alpha1/kafkaacl_webhook.go
@@ -3,8 +3,6 @@
 package v1alpha1
 
 import (
-	"errors"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -44,7 +42,9 @@ func (r *KafkaACL) ValidateCreate() error {
 func (r *KafkaACL) ValidateUpdate(old runtime.Object) error {
 	kafkaacllog.Info("validate update", "name", r.Name)
 
-	return errors.New("cannot update a KafkaACL, it can only be created or deleted")
+	// TODO: validate that the spec does not get updated; this will fail on the aiven api
+
+	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -74,13 +74,19 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - aiven.io
   resources:
   - kafkaacls/status
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - watch
 - apiGroups:
   - aiven.io
   resources:

--- a/controllers/kafkaacl_controller.go
+++ b/controllers/kafkaacl_controller.go
@@ -24,8 +24,8 @@ type KafkaACLReconciler struct {
 
 type KafkaACLHandler struct{}
 
-// +kubebuilder:rbac:groups=aiven.io,resources=kafkaacls,verbs=get;list;watch;create;delete
-// +kubebuilder:rbac:groups=aiven.io,resources=kafkaacls/status,verbs=get
+// +kubebuilder:rbac:groups=aiven.io,resources=kafkaacls,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=aiven.io,resources=kafkaacls/status,verbs=get;list;watch;create;delete
 
 func (r *KafkaACLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, KafkaACLHandler{}, &v1alpha1.KafkaACL{})

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -169,7 +169,7 @@ func (h KafkaTopicHandler) checkPreconditions(avn *aiven.Client, i client.Object
 
 func (h KafkaTopicHandler) getState(avn *aiven.Client, topic *v1alpha1.KafkaTopic) (string, error) {
 	t, err := avn.KafkaTopics.Get(topic.Spec.Project, topic.Spec.ServiceName, topic.Name)
-	if err != nil && !aiven.IsNotFound(err) {
+	if err != nil {
 		if aivenError, ok := err.(aiven.Error); ok {
 			// Getting topic info can sometimes temporarily fail with 501 and 502. Don't
 			// treat that as fatal error but keep on retrying instead.
@@ -177,10 +177,8 @@ func (h KafkaTopicHandler) getState(avn *aiven.Client, topic *v1alpha1.KafkaTopi
 				return "", nil
 			}
 		}
-
 		return "", err
 	}
-
 	return t.State, nil
 }
 

--- a/test/e2e/kafka-topic/simple-kafka-topic/01-kafka-topic-acl.yaml
+++ b/test/e2e/kafka-topic/simple-kafka-topic/01-kafka-topic-acl.yaml
@@ -1,0 +1,15 @@
+apiVersion: aiven.io/v1alpha1
+kind: KafkaACL
+metadata:
+  name: k8s-test-kafka-topic-simple-kafka-topic-acl
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: aiven-ci-kubernetes-operator
+  serviceName: k8s-test-kafka-topic-simple-kafka-topic-kafka
+
+  topic: k8s-test-kafka-topic-simple-kafka-topic-topic
+  permission: readwrite
+  username: avnadmin

--- a/test/e2e/kafka-topic/simple-kafka-topic/02-check-services-running.yaml
+++ b/test/e2e/kafka-topic/simple-kafka-topic/02-check-services-running.yaml
@@ -14,3 +14,10 @@ commands:
     do
       sleep 10
     done
+- script: |
+      SERVICE=k8s-test-kafka-topic-simple-kafka-topic-kafka
+      ACLTARGET=k8s-test-kafka-topic-simple-kafka-topic-topic
+      while ! ( avn --auth-token $AIVEN_TOKEN service acl-list $SERVICE --project aiven-ci-kubernetes-operator | grep -q $ACLTARGET );
+      do
+        sleep 10
+      done


### PR DESCRIPTION
This PR fixes the issue that we are not able to manage kafka ACLs right now because of missing RBACs for the status