### PR TITLE
loosen service version validation

### DIFF
--- a/api/v1alpha1/kafka_types.go
+++ b/api/v1alpha1/kafka_types.go
@@ -28,7 +28,6 @@ type KafkaSpec struct {
 }
 
 type KafkaUserConfig struct {
-	// +kubebuilder:validation:Enum="1.0";"1.1";"2.0";"2.1";"2.2";"2.3";"2.4";"2.5";"2.6";"2.7";"2.8";"3.0"
 	// Kafka major version
 	KafkaVersion string `json:"kafka_version,omitempty"`
 

--- a/api/v1alpha1/opensearch_types.go
+++ b/api/v1alpha1/opensearch_types.go
@@ -213,7 +213,6 @@ type OpenSearchPrivatelinkAccess struct {
 }
 
 type OpenSearchUserConfig struct {
-	// +kubebuilder:validation:Enum=1
 	// OpenSearch major version
 	OpensearchVersion string `json:"opensearch_version,omitempty"`
 

--- a/api/v1alpha1/postgresql_types.go
+++ b/api/v1alpha1/postgresql_types.go
@@ -25,7 +25,6 @@ type PostgreSQLSpec struct {
 }
 
 type PostgreSQLUserconfig struct {
-	// +kubebuilder:validation:Enum="9.5";"9.6";"10";"11";"12"
 	// PostgreSQL major version
 	PgVersion string `json:"pg_version,omitempty"`
 

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -613,19 +613,6 @@ spec:
                     type: object
                   kafka_version:
                     description: Kafka major version
-                    enum:
-                    - "1.0"
-                    - "1.1"
-                    - "2.0"
-                    - "2.1"
-                    - "2.2"
-                    - "2.3"
-                    - "2.4"
-                    - "2.5"
-                    - "2.6"
-                    - "2.7"
-                    - "2.8"
-                    - "3.0"
                     type: string
                   private_access:
                     description: Allow access to selected service ports from private

--- a/config/crd/bases/aiven.io_opensearches.yaml
+++ b/config/crd/bases/aiven.io_opensearches.yaml
@@ -416,8 +416,6 @@ spec:
                     type: object
                   opensearch_version:
                     description: OpenSearch major version
-                    enum:
-                    - 1
                     type: string
                   private_access:
                     description: Allow access to selected service ports from private

--- a/config/crd/bases/aiven.io_postgresqls.yaml
+++ b/config/crd/bases/aiven.io_postgresqls.yaml
@@ -486,12 +486,6 @@ spec:
                     type: string
                   pg_version:
                     description: PostgreSQL major version
-                    enum:
-                    - "9.5"
-                    - "9.6"
-                    - "10"
-                    - "11"
-                    - "12"
                     type: string
                   pgbouncer:
                     description: PGBouncer connection pooling settings


### PR DESCRIPTION
We are not releasing K8s operator often these days and more important translation of user configuration options to K8s CRD's is mostly manual process and will be automated soon. This PR proposes to remove service version validation before we automate generation of user configuration options for K8s operator.