### PR TITLE
Allow use of default aiven token instead of authSecretReference on resources

### DIFF
--- a/api/v1alpha1/clickhouse_types.go
+++ b/api/v1alpha1/clickhouse_types.go
@@ -11,7 +11,7 @@ type ClickhouseSpec struct {
 	ServiceCommonSpec `json:",inline"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/clickhouseuser_types.go
+++ b/api/v1alpha1/clickhouseuser_types.go
@@ -25,7 +25,7 @@ type ClickhouseUserSpec struct {
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ClickhouseUserStatus defines the observed state of ClickhouseUser

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -8,9 +8,13 @@ import (
 // AuthSecretReference references a Secret containing an Aiven authentication token
 type AuthSecretReference struct {
 	// +kubebuilder:validation:MinLength=1
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// +kubebuilder:validation:MinLength=1
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
+}
+
+func (r AuthSecretReference) IsValid() bool {
+	return len(r.Name) > 0 && len(r.Key) > 0
 }
 
 // ConnInfoSecretTarget contains information secret name

--- a/api/v1alpha1/connectionpool_types.go
+++ b/api/v1alpha1/connectionpool_types.go
@@ -38,7 +38,7 @@ type ConnectionPoolSpec struct {
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ConnectionPoolStatus defines the observed state of ConnectionPool

--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -31,7 +31,7 @@ type DatabaseSpec struct {
 	TerminationProtection bool `json:"terminationProtection,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // DatabaseStatus defines the observed state of Database

--- a/api/v1alpha1/kafka_types.go
+++ b/api/v1alpha1/kafka_types.go
@@ -15,7 +15,7 @@ type KafkaSpec struct {
 	DiskSpace string `json:"disk_space,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/kafkaacl_types.go
+++ b/api/v1alpha1/kafkaacl_types.go
@@ -28,7 +28,7 @@ type KafkaACLSpec struct {
 	Username string `json:"username"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // KafkaACLStatus defines the observed state of KafkaACL

--- a/api/v1alpha1/kafkaconnect_types.go
+++ b/api/v1alpha1/kafkaconnect_types.go
@@ -11,7 +11,7 @@ type KafkaConnectSpec struct {
 	ServiceCommonSpec `json:",inline"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// PostgreSQL specific user configuration options
 	UserConfig KafkaConnectUserConfig `json:"userConfig,omitempty"`

--- a/api/v1alpha1/kafkaconnector_types.go
+++ b/api/v1alpha1/kafkaconnector_types.go
@@ -18,7 +18,7 @@ type KafkaConnectorSpec struct {
 	ServiceName string `json:"serviceName"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// +kubebuilder:validation:MaxLength=1024
 	// The Java class of the connector.

--- a/api/v1alpha1/kafkaschema_types.go
+++ b/api/v1alpha1/kafkaschema_types.go
@@ -29,7 +29,7 @@ type KafkaSchemaSpec struct {
 	CompatibilityLevel string `json:"compatibilityLevel,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // KafkaSchemaStatus defines the observed state of KafkaSchema

--- a/api/v1alpha1/kafkatopic_types.go
+++ b/api/v1alpha1/kafkatopic_types.go
@@ -38,7 +38,7 @@ type KafkaTopicSpec struct {
 	TerminationProtection bool `json:"termination_protection,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 type KafkaTopicTag struct {

--- a/api/v1alpha1/opensearch_types.go
+++ b/api/v1alpha1/opensearch_types.go
@@ -15,7 +15,7 @@ type OpenSearchSpec struct {
 	DiskSpace string `json:"disk_space,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/postgresql_types.go
+++ b/api/v1alpha1/postgresql_types.go
@@ -15,7 +15,7 @@ type PostgreSQLSpec struct {
 	DiskSpace string `json:"disk_space,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -61,7 +61,7 @@ type ProjectSpec struct {
 	Tags map[string]string `json:"tags,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ProjectStatus defines the observed state of Project

--- a/api/v1alpha1/projectvpc_types.go
+++ b/api/v1alpha1/projectvpc_types.go
@@ -22,7 +22,7 @@ type ProjectVPCSpec struct {
 	NetworkCidr string `json:"networkCidr"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ProjectVPCStatus defines the observed state of ProjectVPC

--- a/api/v1alpha1/redis_types.go
+++ b/api/v1alpha1/redis_types.go
@@ -14,7 +14,7 @@ type RedisSpec struct {
 	DiskSpace string `json:"disk_space,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`

--- a/api/v1alpha1/serviceintegration_types.go
+++ b/api/v1alpha1/serviceintegration_types.go
@@ -42,7 +42,7 @@ type ServiceIntegrationSpec struct {
 	MetricsUserConfig ServiceIntegrationMetricsUserConfig `json:"metrics,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ServiceIntegrationStatus defines the observed state of ServiceIntegration

--- a/api/v1alpha1/serviceuser_types.go
+++ b/api/v1alpha1/serviceuser_types.go
@@ -25,7 +25,7 @@ type ServiceUserSpec struct {
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`
 
 	// Authentication reference to Aiven token in a secret
-	AuthSecretRef AuthSecretReference `json:"authSecretRef"`
+	AuthSecretRef AuthSecretReference `json:"authSecretRef,omitempty"`
 }
 
 // ServiceUserStatus defines the observed state of ServiceUser

--- a/config/crd/bases/aiven.io_clickhouses.yaml
+++ b/config/crd/bases/aiven.io_clickhouses.yaml
@@ -44,9 +44,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               cloudName:
                 description: Cloud the service runs in.
@@ -131,7 +128,6 @@ spec:
                     type: string
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_clickhouseusers.yaml
+++ b/config/crd/bases/aiven.io_clickhouseusers.yaml
@@ -54,9 +54,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               authentication:
                 description: Authentication details
@@ -83,7 +80,6 @@ spec:
                 maxLength: 63
                 type: string
             required:
-            - authSecretRef
             - project
             - serviceName
             type: object

--- a/config/crd/bases/aiven.io_connectionpools.yaml
+++ b/config/crd/bases/aiven.io_connectionpools.yaml
@@ -63,9 +63,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               connInfoSecretTarget:
                 description: Information regarding secret creation
@@ -105,7 +102,6 @@ spec:
                 maxLength: 64
                 type: string
             required:
-            - authSecretRef
             - databaseName
             - project
             - serviceName

--- a/config/crd/bases/aiven.io_databases.yaml
+++ b/config/crd/bases/aiven.io_databases.yaml
@@ -51,9 +51,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               lcCollate:
                 description: 'Default string sort order (LC_COLLATE) of the database.
@@ -81,7 +78,6 @@ spec:
                   data.
                 type: boolean
             required:
-            - authSecretRef
             - project
             - serviceName
             type: object

--- a/config/crd/bases/aiven.io_kafkaacls.yaml
+++ b/config/crd/bases/aiven.io_kafkaacls.yaml
@@ -60,9 +60,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               permission:
                 description: Kafka permission to grant (admin, read, readwrite, write)
@@ -88,7 +85,6 @@ spec:
                 description: Username pattern for the ACL entry
                 type: string
             required:
-            - authSecretRef
             - permission
             - project
             - serviceName

--- a/config/crd/bases/aiven.io_kafkaconnectors.yaml
+++ b/config/crd/bases/aiven.io_kafkaconnectors.yaml
@@ -63,9 +63,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               connectorClass:
                 description: The Java class of the connector.
@@ -88,7 +85,6 @@ spec:
                   }}` is provided when interpreting the keys
                 type: object
             required:
-            - authSecretRef
             - connectorClass
             - project
             - serviceName

--- a/config/crd/bases/aiven.io_kafkaconnects.yaml
+++ b/config/crd/bases/aiven.io_kafkaconnects.yaml
@@ -48,9 +48,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               cloudName:
                 description: Cloud the service runs in.
@@ -189,7 +186,6 @@ spec:
                     type: integer
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -57,9 +57,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               cloudName:
                 description: Cloud the service runs in.
@@ -658,7 +655,6 @@ spec:
                     type: object
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_kafkaschemas.yaml
+++ b/config/crd/bases/aiven.io_kafkaschemas.yaml
@@ -60,9 +60,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               compatibilityLevel:
                 description: Kafka Schemas compatibility level
@@ -93,7 +90,6 @@ spec:
                 maxLength: 63
                 type: string
             required:
-            - authSecretRef
             - project
             - schema
             - serviceName

--- a/config/crd/bases/aiven.io_kafkatopics.yaml
+++ b/config/crd/bases/aiven.io_kafkatopics.yaml
@@ -57,9 +57,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               config:
                 description: Kafka topic configuration
@@ -192,7 +189,6 @@ spec:
                   data.
                 type: boolean
             required:
-            - authSecretRef
             - partitions
             - project
             - replication

--- a/config/crd/bases/aiven.io_opensearches.yaml
+++ b/config/crd/bases/aiven.io_opensearches.yaml
@@ -44,9 +44,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               cloudName:
                 description: Cloud the service runs in.
@@ -493,7 +490,6 @@ spec:
                     type: boolean
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_postgresqls.yaml
+++ b/config/crd/bases/aiven.io_postgresqls.yaml
@@ -57,9 +57,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               cloudName:
                 description: Cloud the service runs in.
@@ -616,7 +613,6 @@ spec:
                     type: integer
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_projects.yaml
+++ b/config/crd/bases/aiven.io_projects.yaml
@@ -48,9 +48,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               billingAddress:
                 description: Billing name and address of the project
@@ -124,8 +121,6 @@ spec:
                   type: string
                 maxItems: 10
                 type: array
-            required:
-            - authSecretRef
             type: object
           status:
             description: ProjectStatus defines the observed state of Project

--- a/config/crd/bases/aiven.io_projectvpcs.yaml
+++ b/config/crd/bases/aiven.io_projectvpcs.yaml
@@ -57,9 +57,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               cloudName:
                 description: Cloud the VPC is in
@@ -75,7 +72,6 @@ spec:
                 maxLength: 63
                 type: string
             required:
-            - authSecretRef
             - cloudName
             - networkCidr
             - project

--- a/config/crd/bases/aiven.io_redis.yaml
+++ b/config/crd/bases/aiven.io_redis.yaml
@@ -44,9 +44,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               cloudName:
                 description: Cloud the service runs in.
@@ -297,7 +294,6 @@ spec:
                     type: boolean
                 type: object
             required:
-            - authSecretRef
             - project
             type: object
           status:

--- a/config/crd/bases/aiven.io_serviceintegrations.yaml
+++ b/config/crd/bases/aiven.io_serviceintegrations.yaml
@@ -64,9 +64,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               datadog:
                 description: Datadog specific user configuration options
@@ -204,7 +201,6 @@ spec:
                 description: Source service for the integration (if any)
                 type: string
             required:
-            - authSecretRef
             - integrationType
             - project
             type: object

--- a/config/crd/bases/aiven.io_serviceusers.yaml
+++ b/config/crd/bases/aiven.io_serviceusers.yaml
@@ -54,9 +54,6 @@ spec:
                   name:
                     minLength: 1
                     type: string
-                required:
-                - key
-                - name
                 type: object
               authentication:
                 description: Authentication details
@@ -83,7 +80,6 @@ spec:
                 maxLength: 63
                 type: string
             required:
-            - authSecretRef
             - project
             - serviceName
             type: object

--- a/controllers/redis_controller_test.go
+++ b/controllers/redis_controller_test.go
@@ -4,21 +4,20 @@ package controllers
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/aiven/aiven-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Redis Controller", func() {
+var _ = Describe("Redis Controller using secret", func() {
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
 		namespace = "default"
@@ -35,8 +34,8 @@ var _ = Describe("Redis Controller", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		serviceName = "k8s-test-redis-acc-" + generateRandomID()
-		redis = redisSpec(serviceName, namespace)
+		serviceName = "k8s-test-redis-acc-with-secret-" + generateRandomID()
+		redis = redisSpec(serviceName, namespace, true)
 
 		By("Creating a new Redis CR instance")
 		Expect(k8sClient.Create(ctx, redis)).Should(Succeed())
@@ -91,7 +90,87 @@ var _ = Describe("Redis Controller", func() {
 	})
 })
 
-func redisSpec(serviceName, namespace string) *v1alpha1.Redis {
+var _ = Describe("Redis Controller using default token", func() {
+	// Define utility constants for object names and testing timeouts/durations and intervals.
+	const (
+		namespace = "default"
+
+		timeout  = time.Minute * 20
+		interval = time.Second * 10
+	)
+
+	var (
+		redis       *v1alpha1.Redis
+		serviceName string
+		ctx         context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		serviceName = "k8s-test-redis-acc-default-token-" + generateRandomID()
+		redis = redisSpec(serviceName, namespace, false)
+
+		By("Creating a new Redis CR instance")
+		Expect(k8sClient.Create(ctx, redis)).Should(Succeed())
+
+		rLookupKey := types.NamespacedName{Name: serviceName, Namespace: namespace}
+		createdRedis := &v1alpha1.Redis{}
+		// We'll need to retry getting this newly created Redis,
+		// given that creation may not immediately happen.
+		By("by retrieving redis instance from k8s")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, rLookupKey, createdRedis)
+
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+
+		By("by waiting Redis service status to become RUNNING")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, rLookupKey, createdRedis)
+			if err == nil {
+				return meta.IsStatusConditionTrue(createdRedis.Status.Conditions, conditionTypeRunning)
+			}
+			return false
+		}, timeout, interval).Should(BeTrue())
+
+		By("by checking finalizers")
+		Expect(createdRedis.GetFinalizers()).ToNot(BeEmpty())
+	})
+
+	Context("Validating Redis reconciler behaviour", func() {
+		It("should createOrUpdate a new Redis service", func() {
+			createdRedis := &v1alpha1.Redis{}
+			lookupKey := types.NamespacedName{Name: serviceName, Namespace: namespace}
+
+			Expect(k8sClient.Get(ctx, lookupKey, createdRedis)).Should(Succeed())
+
+			By("by checking that after creation of a Redis service secret is created")
+			createdSecret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: namespace}, createdSecret)).Should(Succeed())
+
+			Expect(createdSecret.Data["HOST"]).NotTo(BeEmpty())
+			Expect(createdSecret.Data["PORT"]).NotTo(BeEmpty())
+			Expect(createdSecret.Data["USER"]).NotTo(BeEmpty())
+			Expect(createdSecret.Data["PASSWORD"]).NotTo(BeEmpty())
+
+			Expect(createdRedis.Status.State).Should(Equal("RUNNING"))
+		})
+	})
+
+	AfterEach(func() {
+		By("Ensures that Redis instance was deleted")
+		ensureDelete(ctx, redis)
+	})
+})
+
+func redisSpec(serviceName, namespace string, useSecret bool) *v1alpha1.Redis {
+	var authSecretReference v1alpha1.AuthSecretReference
+	if useSecret {
+		authSecretReference = v1alpha1.AuthSecretReference{
+			Name: secretRefName,
+			Key:  secretRefKey,
+		}
+	}
 	return &v1alpha1.Redis{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "aiven.io/v1alpha1",
@@ -107,11 +186,8 @@ func redisSpec(serviceName, namespace string) *v1alpha1.Redis {
 				Plan:      "business-4",
 				CloudName: "google-europe-west1",
 			},
-			UserConfig: v1alpha1.RedisUserConfig{},
-			AuthSecretRef: v1alpha1.AuthSecretReference{
-				Name: secretRefName,
-				Key:  secretRefKey,
-			},
+			UserConfig:    v1alpha1.RedisUserConfig{},
+			AuthSecretRef: authSecretReference,
 		},
 	}
 }

--- a/controllers/redis_controller_test.go
+++ b/controllers/redis_controller_test.go
@@ -4,11 +4,12 @@ package controllers
 
 import (
 	"context"
+	"os"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
-	"os"
-	"time"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -60,8 +60,8 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
 	}
 
-	token := os.Getenv("AIVEN_TOKEN")
-	if token == "" {
+	aivenToken := os.Getenv("AIVEN_TOKEN")
+	if aivenToken == "" {
 		Fail("cannot createOrUpdate Aiven API client, `AIVEN_TOKEN` is required")
 	}
 
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func() {
 			Namespace: "default",
 		},
 		StringData: map[string]string{
-			secretRefKey: os.Getenv("AIVEN_TOKEN"),
+			secretRefKey: aivenToken,
 		},
 	}
 
@@ -237,10 +237,11 @@ var _ = BeforeSuite(func() {
 	// set-up Redis reconciler
 	err = (&RedisReconciler{
 		Controller{
-			Client:   k8sManager.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("Redis"),
-			Scheme:   k8sManager.GetScheme(),
-			Recorder: k8sManager.GetEventRecorderFor("redis-reconciler"),
+			Client:       k8sManager.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("Redis"),
+			Scheme:       k8sManager.GetScheme(),
+			Recorder:     k8sManager.GetEventRecorderFor("redis-reconciler"),
+			DefaultToken: aivenToken,
 		},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -53,20 +53,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	defaultToken := os.Getenv("DEFAULT_AIVEN_TOKEN")
+
 	if err = (&controllers.SecretFinalizerGCController{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("SecretFinalizerGCController"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, len(defaultToken) > 0); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SecretFinalizerGCController")
 		os.Exit(1)
 	}
 
 	if err = (&controllers.ProjectReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("Project"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("project-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("Project"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("project-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Project")
@@ -75,10 +78,11 @@ func main() {
 
 	if err = (&controllers.PostgreSQLReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("PostgreSQL"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("postgresql-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("PostgreSQL"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("postgresql-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PostgreSQL")
@@ -87,10 +91,11 @@ func main() {
 
 	if err = (&controllers.ConnectionPoolReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("ConnectionPool"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("connection-pool-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("ConnectionPool"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("connection-pool-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ConnectionPool")
@@ -99,10 +104,11 @@ func main() {
 
 	if err = (&controllers.DatabaseReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("Database"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("database-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("Database"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("database-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Database")
@@ -111,10 +117,11 @@ func main() {
 
 	if err = (&controllers.KafkaReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("Kafka"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("kafka-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("Kafka"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("kafka-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Kafka")
@@ -123,10 +130,11 @@ func main() {
 
 	if err = (&controllers.ProjectVPCReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("ProjectVPC"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("project-vpc-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("ProjectVPC"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("project-vpc-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ProjectVPC")
@@ -135,10 +143,11 @@ func main() {
 
 	if err = (&controllers.KafkaTopicReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("KafkaTopic"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("kafka-topic-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("KafkaTopic"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("kafka-topic-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaTopic")
@@ -147,10 +156,11 @@ func main() {
 
 	if err = (&controllers.KafkaACLReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("KafkaACL"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("kafka-acl-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("KafkaACL"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("kafka-acl-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaACL")
@@ -159,10 +169,11 @@ func main() {
 
 	if err = (&controllers.KafkaConnectReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("KafkaConnect"),
-			Recorder: mgr.GetEventRecorderFor("kafka-connect-reconciler"),
-			Scheme:   mgr.GetScheme(),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("KafkaConnect"),
+			Recorder:     mgr.GetEventRecorderFor("kafka-connect-reconciler"),
+			Scheme:       mgr.GetScheme(),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaConnect")
@@ -171,10 +182,11 @@ func main() {
 
 	if err = (&controllers.ServiceUserReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("ServiceUser"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("service-user-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("ServiceUser"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("service-user-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServiceUser")
@@ -183,10 +195,11 @@ func main() {
 
 	if err = (&controllers.KafkaSchemaReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("KafkaSchema"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("kafka-schema-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("KafkaSchema"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("kafka-schema-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaSchema")
@@ -195,10 +208,11 @@ func main() {
 
 	if err = (&controllers.ServiceIntegrationReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("ServiceIntegration"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("service-integration-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("ServiceIntegration"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("service-integration-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServiceIntegration")
@@ -206,10 +220,11 @@ func main() {
 	}
 	if err = (&controllers.KafkaConnectorReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("KafkaConnector"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("kafka-connector-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("KafkaConnector"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("kafka-connector-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaConnector")
@@ -218,10 +233,11 @@ func main() {
 
 	if err = (&controllers.RedisReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("Redis"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("redis-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("Redis"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("redis-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Redis")
@@ -230,10 +246,11 @@ func main() {
 
 	if err = (&controllers.OpenSearchReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("OpenSearch"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("opensearch-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("OpenSearch"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("opensearch-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenSearch")
@@ -242,10 +259,11 @@ func main() {
 
 	if err = (&controllers.ClickhouseReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("Clickhouse"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("clickhouse-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("Clickhouse"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("clickhouse-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Clickhouse")
@@ -254,10 +272,11 @@ func main() {
 
 	if err = (&controllers.ClickhouseUserReconciler{
 		Controller: controllers.Controller{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("ClickhouseUser"),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorderFor("clickhouse-reconciler"),
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("ClickhouseUser"),
+			Scheme:       mgr.GetScheme(),
+			Recorder:     mgr.GetEventRecorderFor("clickhouse-reconciler"),
+			DefaultToken: defaultToken,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClickhouseUser")


### PR DESCRIPTION
This will allow running the operator with a default token, instead of having to add a secret in every namespace where resources are created.

We had some trouble deciding on how to test this, so we made only a minimal change adding an additional test to redis_controller_test.go. This doesn't really cover the different cases properly, but we were unable to find a suitable way to do it. We are unfamiliar with Ginkgo, so might be some tricks we didn't find that would have solved it.

Since the test is mostly a simple cut&paste and minor change, we didn't want to do it for all controllers, when the actual logic change is in common code.

We tried running `make test-e2e` to get a proper check that it worked, but that didn't seem to run even before our changes.
`make test-acc` works as it should.

Fixes #183

