### PR TITLE
fix links for prerequisite notes

### DIFF
--- a/docs/content/en/docs/resources/postgresql/_index.md
+++ b/docs/content/en/docs/resources/postgresql/_index.md
@@ -11,7 +11,7 @@ extender for location queries. Aiven for PostgreSQL is the perfect fit for your 
 
 With Aiven Kubernetes Operator, you can manage Aiven for PostgreSQL through the well defined Kubernetes API.
 
-> Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites/) with the [operator installed](../installation/), and a [Kubernetes Secret with an Aiven authentication token](../authentication/).
+> Before going through this guide, make sure you have a [Kubernetes cluster](../../installation/prerequisites/) with the [operator installed](../../installation/), and a [Kubernetes Secret with an Aiven authentication token](../../authentication/).
 
 ## Creating a PostgreSQL instance
 

--- a/docs/content/en/docs/resources/project-vpc/_index.md
+++ b/docs/content/en/docs/resources/project-vpc/_index.md
@@ -10,7 +10,7 @@ directly without going through the public internet.
 
 Within the Aiven Kubernetes Operator, you can create a `ProjectVPC` on Aiven's side to connect to your cloud provider.
 
-> Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites/) with the [operator installed](../installation/), and a [Kubernetes Secret with an Aiven authentication token](../authentication/).
+> Before going through this guide, make sure you have a [Kubernetes cluster](../../installation/prerequisites/) with the [operator installed](../../installation/), and a [Kubernetes Secret with an Aiven authentication token](../../authentication/).
 
 ## Creating an Aiven VPC
 

--- a/docs/content/en/docs/resources/project/_index.md
+++ b/docs/content/en/docs/resources/project/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Aiven Project"
 weight: 5
 ---
 
-> Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites/) with the [operator installed](../installation/) and a [Kubernetes Secret with an Aiven authentication token](../authentication/).
+> Before going through this guide, make sure you have a [Kubernetes cluster](../../installation/prerequisites/) with the [operator installed](../../installation/) and a [Kubernetes Secret with an Aiven authentication token](../../authentication/).
 
 The `Project` CRD allows you to create Aiven Projects, where your resources can be located.
 

--- a/docs/content/en/docs/resources/service-integrations/_index.md
+++ b/docs/content/en/docs/resources/service-integrations/_index.md
@@ -10,7 +10,7 @@ See
 our [Getting Started with Service Integrations guide](https://help.aiven.io/en/articles/1456441-getting-started-with-service-integrations)
 for more information.
 
-> Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites/) with the [operator installed](../installation/), and a [Kubernetes Secret with an Aiven authentication token](../authentication/).
+> Before going through this guide, make sure you have a [Kubernetes cluster](../../installation/prerequisites/) with the [operator installed](../../installation/), and a [Kubernetes Secret with an Aiven authentication token](../../authentication/).
 
 ## Send Kafka logs to a Kafka Topic
 


### PR DESCRIPTION
Looks like this was fixed for the Kafka page but not for the other pages. 