### PR TITLE
remove "never" from dow choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Remove "never" from choices of maintenance dow
+
 ## v0.5.2 - 2022-12-09
 
 - Fix deployment release manifest generation

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -62,7 +62,7 @@ type ServiceCommonSpec struct {
 	// ProjectVPCRef reference to ProjectVPC resource to use its ID as ProjectVPCID automatically
 	ProjectVPCRef *ResourceReference `json:"projectVPCRef,omitempty"`
 
-	// +kubebuilder:validation:Enum=monday;tuesday;wednesday;thursday;friday;saturday;sunday;never
+	// +kubebuilder:validation:Enum=monday;tuesday;wednesday;thursday;friday;saturday;sunday
 	// Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
 	MaintenanceWindowDow string `json:"maintenanceWindowDow,omitempty"`
 

--- a/config/crd/bases/aiven.io_clickhouses.yaml
+++ b/config/crd/bases/aiven.io_clickhouses.yaml
@@ -69,7 +69,6 @@ spec:
                 - friday
                 - saturday
                 - sunday
-                - never
                 type: string
               maintenanceWindowTime:
                 description: Time of day when maintenance operations should be performed.

--- a/config/crd/bases/aiven.io_kafkaconnects.yaml
+++ b/config/crd/bases/aiven.io_kafkaconnects.yaml
@@ -64,7 +64,6 @@ spec:
                 - friday
                 - saturday
                 - sunday
-                - never
                 type: string
               maintenanceWindowTime:
                 description: Time of day when maintenance operations should be performed.

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -92,7 +92,6 @@ spec:
                 - friday
                 - saturday
                 - sunday
-                - never
                 type: string
               maintenanceWindowTime:
                 description: Time of day when maintenance operations should be performed.

--- a/config/crd/bases/aiven.io_opensearches.yaml
+++ b/config/crd/bases/aiven.io_opensearches.yaml
@@ -75,7 +75,6 @@ spec:
                 - friday
                 - saturday
                 - sunday
-                - never
                 type: string
               maintenanceWindowTime:
                 description: Time of day when maintenance operations should be performed.

--- a/config/crd/bases/aiven.io_postgresqls.yaml
+++ b/config/crd/bases/aiven.io_postgresqls.yaml
@@ -88,7 +88,6 @@ spec:
                 - friday
                 - saturday
                 - sunday
-                - never
                 type: string
               maintenanceWindowTime:
                 description: Time of day when maintenance operations should be performed.

--- a/config/crd/bases/aiven.io_redis.yaml
+++ b/config/crd/bases/aiven.io_redis.yaml
@@ -74,7 +74,6 @@ spec:
                 - friday
                 - saturday
                 - sunday
-                - never
                 type: string
               maintenanceWindowTime:
                 description: Time of day when maintenance operations should be performed.


### PR DESCRIPTION
Removes "never" from choices of maintenance dow,
because it's not available in api.