### PR TITLE
fix enum generation

### DIFF
--- a/userconfigs_generator/generator.go
+++ b/userconfigs_generator/generator.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/dave/jennifer/jen"
@@ -315,7 +316,7 @@ func addFieldComments(s *jen.Statement, obj *object) *jen.Statement {
 	if len(obj.Enum) != 0 {
 		enum := make([]string, len(obj.Enum))
 		for i, s := range obj.Enum {
-			enum[i] = s.Value
+			enum[i] = safeEnum(s.Value)
 		}
 		c = append(c, fmt.Sprintf("// +kubebuilder:validation:Enum=%s", strings.Join(enum, ";")))
 	}
@@ -359,4 +360,15 @@ func fmtComment(obj *object) string {
 // toCamelCase some fields has dots within, makes cleaner camelCase
 func toCamelCase(s string) string {
 	return strcase.UpperCamelCase(strings.ReplaceAll(s, ".", "_"))
+}
+
+// safeEnumRe operator sdk won't compile enums with special characters
+var safeEnumRe = regexp.MustCompile(`[^\w-]`)
+
+// safeEnum returns quoted enum if it contains special characters
+func safeEnum(s string) string {
+	if safeEnumRe.MatchString(s) {
+		return fmt.Sprintf("%q", s)
+	}
+	return s
 }

--- a/userconfigs_generator/generator_test.go
+++ b/userconfigs_generator/generator_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -30,4 +31,35 @@ func TestNewUserConfigFile(t *testing.T) {
 	// Leave the var for debugging with a break point
 	actual := file.GoString()
 	assert.Equal(t, expectedStr, actual)
+}
+
+func TestSafeEnumKeepsOriginal(t *testing.T) {
+	cases := []string{
+		"1",
+		"foo",
+		"foo_bar",
+		"foo-bar",
+		"Foo",
+		"foo123",
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			assert.Equal(t, s, safeEnum(s))
+		})
+	}
+}
+
+func TestSafeEnumAddsQuotes(t *testing.T) {
+	cases := []string{
+		"foo%p",
+		"foo{}",
+		"[foo]",
+		"foo bar",
+		"foo,bar",
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			assert.Equal(t, fmt.Sprintf("%q", s), safeEnum(s))
+		})
+	}
 }

--- a/userconfigs_generator/generator_test_expected.go
+++ b/userconfigs_generator/generator_test_expected.go
@@ -144,7 +144,7 @@ type Pg struct {
 	// LogErrorVerbosity Controls the amount of detail written in the server log for each message that is logged.
 	LogErrorVerbosity *string `groups:"create,update" json:"log_error_verbosity,omitempty"`
 
-	// +kubebuilder:validation:Enum='pid=%p,user=%u,db=%d,app=%a,client=%h ';'%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h ';'%m [%p] %q[user=%u,db=%d,app=%a] '
+	// +kubebuilder:validation:Enum="'pid=%p,user=%u,db=%d,app=%a,client=%h '";"'%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h '";"'%m [%p] %q[user=%u,db=%d,app=%a] '"
 	// LogLinePrefix Choose from one of the available log-formats. These can support popular log analyzers like pgbadger, pganalyze etc.
 	LogLinePrefix *string `groups:"create,update" json:"log_line_prefix,omitempty"`
 


### PR DESCRIPTION
Must be quoted if contains special characters. Otherwise, manifest generation fails with an error "extra arguments provided"