### PR TITLE
Split console inputs and output examples in docs

### DIFF
--- a/docs/docs/installation/helm.md
+++ b/docs/docs/installation/helm.md
@@ -24,6 +24,7 @@ Verify the installation:
 ```shell
 kubectl api-resources --api-group=aiven.io
 ```
+The output is similar to the following:
 
 ```{ .shell .no-copy }
 NAME                  SHORTNAMES   APIVERSION          NAMESPACED   KIND
@@ -45,6 +46,8 @@ Verify the installation:
 ```shell
 helm status aiven-operator
 ```
+
+The output is similar to the following:
 
 ```{ .shell .no-copy }
 NAME: aiven-operator
@@ -75,6 +78,8 @@ Find out the name of your deployment:
 helm list
 ```
 
+The output has the name of each deployment similar to the following: 
+
 ```{ .shell .no-copy }
 NAME               	NAMESPACE	REVISION	UPDATED                                 	STATUS  	CHART                     	APP VERSION
 aiven-operator     	default  	1       	2021-09-09 10:56:14.623700249 +0200 CEST	deployed	aiven-operator-v0.1.0     	v0.1.0     
@@ -87,6 +92,8 @@ Remove the CRDs:
 helm uninstall aiven-operator-crds
 ```
 
+The confirmation message is similar to the following:
+
 ```{ .shell .no-copy }
 release "aiven-operator-crds" uninstalled
 ```
@@ -96,6 +103,8 @@ Remove the operator:
 ```shell
 helm uninstall aiven-operator
 ```
+
+The confirmation message is similar to the following:
 
 ```{ .shell .no-copy }
 release "aiven-operator" uninstalled

--- a/docs/docs/resources/kafka/connect.md
+++ b/docs/docs/resources/kafka/connect.md
@@ -185,7 +185,7 @@ spec:
     value.converter.schemas.enable: "true"
 ```
 
-With all the files create, let's apply the new Kubernetes resources:
+With all the files created, apply the new Kubernetes resources:
 
 ```shell
 kubectl apply \
@@ -196,7 +196,7 @@ kubectl apply \
   -f kafka-connector-connect.yaml
 ```
 
-It will take some time for all the services to be up and running. You can check all of them with the command below. The deployment is finished when all services have the state `RUNNING`:
+It will take some time for all the services to be up and running. You can check their status with the following command:
 
 ```shell
 kubectl get \
@@ -204,7 +204,11 @@ kubectl get \
     kafkaconnects.aiven.io/kafka-connect \
     postgresqls.aiven.io/pg-connect \
     kafkaconnectors.aiven.io/kafka-connector
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 NAME                                  PROJECT        REGION                PLAN         STATE
 kafka.aiven.io/kafka-sample-connect   your-project   google-europe-west1   business-4   RUNNING
 
@@ -217,6 +221,7 @@ postgresql.aiven.io/pg-connect   your-project   google-europe-west1   startup-4 
 NAME                                      SERVICE NAME           PROJECT        CONNECTOR CLASS                           STATE     TASKS TOTAL   TASKS RUNNING
 kafkaconnector.aiven.io/kafka-connector   kafka-sample-connect   your-project   io.aiven.connect.jdbc.JdbcSinkConnector   RUNNING   1             1
 ```
+The deployment is finished when all services have the state `RUNNING`.
 
 ## Testing
 To test the connection integration, let's produce a Kafka message using [kcat](https://github.com/edenhill/kcat) from within the Kubernetes cluster. We will deploy a Pod responsible for crafting a message and sending to the Kafka cluster, using the `kafka-auth` secret generate by the `Kafka` CRD.
@@ -274,7 +279,11 @@ The Pod will execute the commands and finish. You can confirm its `Completed` st
 
 ```shell
 kubectl get pod kafka-message
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 NAME            READY   STATUS      RESTARTS   AGE
 kafka-message   0/1     Completed   0          5m35s
 ```
@@ -307,11 +316,15 @@ Apply the file with:
 kubectl apply -f psql-connect.yaml
 ```
 
-After a couple of seconds, inspects its log with the command below. The output should be as follows:
+After a couple of seconds, inspect its log with this command: 
 
 ```shell
 kubectl logs psql-connect 
+```
 
+The output is similar to the following: 
+
+```{ .shell .no-copy }
     text     
 -------------
  Hello World
@@ -319,7 +332,7 @@ kubectl logs psql-connect
 ```
 
 ## Clean up
-To clean up all the created resources, use the command below:
+To clean up all the created resources, use the following command:
 
 ```shell
 kubectl delete \

--- a/docs/docs/resources/kafka/index.md
+++ b/docs/docs/resources/kafka/index.md
@@ -11,7 +11,7 @@ you can get up and running with a suitably sized Apache Kafka service in a few m
     Before going through this guide, make sure you have a [Kubernetes cluster](../../installation/prerequisites/) with the [operator installed](../../installation/) 
     and a [Kubernetes Secret with an Aiven authentication token](../../authentication/).
 
-## Creating a `Kafka` instance
+## Creating a Kafka instance
 
 1\. Create a file named `kafka-sample.yaml`, and add the following content:
 
@@ -53,15 +53,21 @@ spec:
 kubectl apply -f kafka-sample.yaml 
 ```
 
-3\. Inspect the service created using the command below. After a couple of minutes, the `STATE` field is changed
-   to `RUNNING`, and is ready to be used.
+3\. Inspect the service created using the command below. 
 
 ```shell
 kubectl get kafka.aiven.io kafka-sample
+```
+
+The output has the project name and state, similar to the following:
+
+```{ .shell .no-copy }
 
 NAME           PROJECT          REGION                PLAN        STATE
 kafka-sample   <your-project>   google-europe-west1   startup-2   RUNNING
 ```
+
+ After a couple of minutes, the `STATE` field is changed to `RUNNING`, and is ready to be used.
 
 ## Using the connection Secret
 
@@ -70,7 +76,11 @@ name specified on the `connInfoSecretTarget` field.
 
 ```shell
 kubectl describe secret kafka-auth 
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 Name:         kafka-auth
 Namespace:    default
 Annotations:  <none>
@@ -92,6 +102,11 @@ You can use the [jq](https://github.com/stedolan/jq) to quickly decode the Secre
 
 ```shell
 kubectl get secret kafka-auth -o json | jq '.data | map_values(@base64d)'
+```
+
+The output is similar to the following:
+
+```{ .json .no-copy }
 {
   "CA_CERT": "<secret-ca-cert>",
   "ACCESS_CERT": "<secret-cert>",
@@ -160,7 +175,11 @@ Once successfully applied, you have a log with the metadata information about th
 
 ```shell
 kubectl logs kafka-test-connection 
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 Metadata for all topics (from broker -1: ssl://kafka-sample-your-project.aivencloud.com:13041/bootstrap):
  3 brokers:
   broker 2 at 35.205.234.70:13041

--- a/docs/docs/resources/kafka/schema.md
+++ b/docs/docs/resources/kafka/schema.md
@@ -93,10 +93,13 @@ kubectl apply -f kafka-schema.yaml
 
 ```shell
 kubectl get kafkaschemas.aiven.io kafka-schema
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 NAME           SERVICE NAME   PROJECT          SUBJECT    COMPATIBILITY LEVEL   VERSION
 kafka-schema   kafka-sample   <your-project>   MySchema   BACKWARD              1
 ```
 
-Now you can follow [our official documentation](https://help.aiven.io/en/articles/2302613-using-schema-registry-with-aiven-for-apache-kafka)
-on how to use the schema created.
+Now you can follow the instructions to [use a schema registry in Java](https://docs.aiven.io/docs/products/kafka/howto/schema-registry) on how to use the schema created.

--- a/docs/docs/resources/opensearch.md
+++ b/docs/docs/resources/opensearch.md
@@ -56,7 +56,7 @@ kubectl describe opensearch.aiven.io os-sample
 
 The output is similar to the following:
 
-```shell
+```{ .shell .no-copy }
 ...
 Status:
   Conditions:
@@ -90,7 +90,7 @@ kubectl describe secret os-secret
 
 The output is similar to the following:
 
-```shell
+```{ .shell .no-copy }
 Name:         os-secret
 Namespace:    default
 Labels:       <none>
@@ -114,7 +114,7 @@ kubectl get secret os-secret -o json | jq '.data | map_values(@base64d)'
 
 The output is similar to the following:
 
-```json
+```{ .json .no-copy }
 {
   "HOST": "os-sample-your-project.aivencloud.com",
   "PASSWORD": "<secret>",
@@ -162,7 +162,7 @@ kubectl get secret os-service-user-secret -o json | jq '.data | map_values(@base
 
 The output is similar to the following:
 
-```json
+```{ .json .no-copy }
 {
   "ACCESS_CERT": "<secret>",
   "ACCESS_KEY": "<secret>",

--- a/docs/docs/resources/postgresql.md
+++ b/docs/docs/resources/postgresql.md
@@ -62,7 +62,11 @@ kubectl apply -f pg-sample.yaml
 
 ```shell
 kubectl get postgresqls.aiven.io pg-sample
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 NAME        PROJECT        REGION                PLAN        STATE
 pg-sample   your-project   google-europe-west1   startup-4   RUNNING
 ```
@@ -76,8 +80,12 @@ For your convenience, the operator automatically stores the PostgreSQL connectio
 the name specified on the `connInfoSecretTarget` field.
 
 ```shell
-kubectl describe secret pg-connection 
+kubectl describe secret pg-connection
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 Name:         pg-connection
 Namespace:    default
 Annotations:  <none>
@@ -99,7 +107,11 @@ You can use the [jq](https://github.com/stedolan/jq) to quickly decode the Secre
 
 ```shell
 kubectl get secret pg-connection -o json | jq '.data | map_values(@base64d)'
+```
 
+The output is similar to the following:
+
+```{ .json .no-copy }
 {
   "DATABASE_URI": "postgres://avnadmin:<secret-password>@pg-sample-your-project.aivencloud.com:13039/defaultdb?sslmode=require",
   "PGDATABASE": "defaultdb",
@@ -141,6 +153,10 @@ It runs once and stops, due to the `restartPolicy: Never` flag.
 
 ```shell
 kubectl logs psql-test-connection
+```
+
+The output is similar to the following:
+```{ .shell .no-copy }
                                            version                                           
 ---------------------------------------------------------------------------------------------
  PostgreSQL 11.12 on x86_64-pc-linux-gnu, compiled by gcc, a 68c5366192 p 6b9244f01a, 64-bit
@@ -210,7 +226,10 @@ named `pg-service-user-connection`:
 
 ```shell
 kubectl get secret pg-service-user-connection -o json | jq '.data | map_values(@base64d)'
+```
 
+The output has the password and username:
+```{ .json .no-copy }
 {
   "PASSWORD": "<secret-password>",
   "USERNAME": "pg-service-user"
@@ -223,12 +242,12 @@ the `pg-connection` Secret.
 ## Creating a PostgreSQL connection pool
 
 Connection pooling allows you to maintain very large numbers of connections to a database while minimizing the
-consumption of server resources. See more
-information [here](https://help.aiven.io/en/articles/964730-postgresql-connection-pooling). Aiven for PostgreSQL uses
+consumption of server resources. For more
+information, refer to the [connection pooling article](https://docs.aiven.io/docs/products/postgresql/concepts/pg-connection-pooling) in Aiven Docs. Aiven for PostgreSQL uses
 PGBouncer for connection pooling.
 
 You can create a connection pool with the `ConnectionPool` resource using the previously created `Database`
-and `ServiceUser`.
+and `ServiceUser`:
 
 Create a new file named `pg-connection-pool.yaml` with the following content:
 
@@ -258,7 +277,10 @@ field:
 
 ```shell
 kubectl get secret pg-connection-pool-connection -o json | jq '.data | map_values(@base64d)' 
+```
+The output is similar to the following: 
 
+```{ .json .no-copy }
 {
   "DATABASE_URI": "postgres://pg-service-user:<secret-password>@pg-sample-you-project.aivencloud.com:13040/pg-connection-pool?sslmode=require",
   "PGDATABASE": "pg-database-sample",

--- a/docs/docs/resources/project-vpc.md
+++ b/docs/docs/resources/project-vpc.md
@@ -48,7 +48,11 @@ kubectl apply -f vpc-sample.yaml
 
 ```shell
 kubectl get projects.aiven.io vpc-sample
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 NAME         PROJECT          CLOUD            NETWORK CIDR
 vpc-sample   <your-project>   aws-af-south-1   192.168.0.0/24
 ```

--- a/docs/docs/resources/project.md
+++ b/docs/docs/resources/project.md
@@ -36,9 +36,14 @@ kubectl apply -f project-sample.yaml
 ```
 
 Verify the newly created Project:
+
 ```shell
 kubectl get projects.aiven.io project-sample
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 NAME             AGE
 project-sample   22s
 ```

--- a/docs/docs/resources/redis.md
+++ b/docs/docs/resources/redis.md
@@ -60,7 +60,7 @@ kubectl describe redis.aiven.io redis-sample
 
 The output is similar to the following:
 
-```shell
+```{ .shell .no-copy }
 ...
 Status:
   Conditions:
@@ -94,7 +94,8 @@ kubectl describe secret redis-secret
 
 The output is similar to the following:
 
-```shell
+```{ .shell .no-copy }
+
 Name:         redis-secret
 Namespace:    default
 Labels:       <none>
@@ -119,7 +120,7 @@ kubectl get secret redis-secret -o json | jq '.data | map_values(@base64d)'
 
 The output is similar to the following:
 
-```shell
+```{ .shell .no-copy }
 {
   "HOST": "redis-sample-your-project.aivencloud.com",
   "PASSWORD": "<secret-password>",

--- a/docs/docs/resources/service-integrations.md
+++ b/docs/docs/resources/service-integrations.md
@@ -123,7 +123,11 @@ kubectl apply -f kafka-sample-topic.yaml
 
 ```shell
 kubectl get serviceintegrations.aiven.io service-integration-kafka-logs
+```
 
+The output is similar to the following:
+
+```{ .shell .no-copy }
 NAME                             PROJECT        TYPE         SOURCE SERVICE NAME   DESTINATION SERVICE NAME   SOURCE ENDPOINT ID   DESTINATION ENDPOINT ID
 service-integration-kafka-logs   your-project   kafka_logs   kafka-sample          kafka-sample                                    
 ```

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -13,7 +13,12 @@ Use the following checks to help you troubleshoot the Aiven Operator for Kuberne
 Verify that all the operator Pods are `READY`, and the `STATUS` is `Running`.
 
 ```shell
-kubectl get pod -n aiven-operator-system 
+kubectl get pod -n aiven-operator-system
+```
+
+The output is similar to the following:
+
+```{ .shell .no-copy }
 
 NAME                                                            READY   STATUS    RESTARTS   AGE
 aiven-operator-controller-manager-576d944499-ggttj   1/1     Running   0          12m
@@ -23,7 +28,11 @@ Verify that the `cert-manager` Pods are also running.
 
 ```shell
 kubectl get pod -n cert-manager
+```
 
+The output has the status:
+
+```{ .shell .no-copy }
 NAME                                       READY   STATUS    RESTARTS   AGE
 cert-manager-7dd5854bb4-85cpv              1/1     Running   0          76s
 cert-manager-cainjector-64c949654c-n2z8l   1/1     Running   0          77s
@@ -55,7 +64,7 @@ it and are working to fix it. If your problem isn't listed below, report it as a
 
 The following event appears on the operator Pod:
 
-```shell
+```{ .shell .no-copy }
 MountVolume.SetUp failed for volume "cert" : secret "webhook-server-cert" not found
 ```
 
@@ -69,7 +78,11 @@ Make sure that cert-manager is up and running.
 
 ```shell
 kubectl get pod -n cert-manager
+```
 
+The output shows the status of each cert-manager:
+
+```{ .shell .no-copy }
 NAME                                       READY   STATUS    RESTARTS   AGE
 cert-manager-7dd5854bb4-85cpv              1/1     Running   0          76s
 cert-manager-cainjector-64c949654c-n2z8l   1/1     Running   0          77s


### PR DESCRIPTION
Split up the input and output for console and removed the copy option for outputs. Also replaced a couple of outdated links.