### PR TITLE
[bug]Setting config: min_cleanable_dirty_ratio: 0.1 does not apply

### DIFF
--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -206,6 +206,7 @@ func convertKafkaTopicConfig(topic *v1alpha1.KafkaTopic) aiven.KafkaTopicConfig 
 		MessageFormatVersion:            topic.Spec.Config.MessageFormatVersion,
 		MessageTimestampDifferenceMaxMs: topic.Spec.Config.MessageTimestampDifferenceMaxMs,
 		MessageTimestampType:            topic.Spec.Config.MessageTimestampType,
+		MinCleanableDirtyRatio:          topic.Spec.Config.MinCleanableDirtyRatio,
 		MinCompactionLagMs:              topic.Spec.Config.MinCompactionLagMs,
 		MinInsyncReplicas:               topic.Spec.Config.MinInsyncReplicas,
 		Preallocate:                     topic.Spec.Config.Preallocate,

--- a/controllers/kafkatopic_controller_test.go
+++ b/controllers/kafkatopic_controller_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Kafka Topic Controller", func() {
 			Expect(createdTopic.Status.State).Should(Equal("ACTIVE"))
 
 			By("by checking MinCleanableDirtyRatio")
-			Expect(*createdTopic.Spec.Config.MinCleanableDirtyRatio).Should(Equal(0.5))
+			Expect(*createdTopic.Spec.Config.MinCleanableDirtyRatio).Should(Equal(0.2))
 		})
 	})
 
@@ -119,7 +119,7 @@ func kafkaTopicSpec(service, topic, namespace string) *v1alpha1.KafkaTopic {
 				Key:  secretRefKey,
 			},
 			Config: v1alpha1.KafkaTopicConfig{
-				MinCleanableDirtyRatio: anyPointer(0.5),
+				MinCleanableDirtyRatio: anyPointer(0.2),
 			},
 		},
 	}


### PR DESCRIPTION
Hello, I bumped aiven-operator to 0.8.0 in our test cluster and tried to set: 

`apiVersion: aiven.io/v1alpha1
kind: KafkaTopic
metadata:
  name: aiven-kafka-topic
  namespace: kafka-sandbox
spec:
  authSecretRef:
    name: aiven-token
    key: token
  config:
    min_cleanable_dirty_ratio: 0.2
  termination_protection: false
  project: some-aiven-project
  serviceName: aiven-kafka-sandbox

  partitions: 1
  replication: 2⏎`
Aiven-Operator accepted the manifest but min_cleanable_dirty_ratio set was not reflected in Aiven console. There it was  set to 0.5 with source: "Kafka Default Configuration". 
I checked the commit and the MinCleanableDirtyRatio was missing from convertKafkaTopicConfig used in create/update func. Also if the tests is a full integration test running against some Aiven service using 0.5 as the test value would lead to a false negative result. 

Cheers
Tord