### PR TITLE
chore: update to the latest go-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aiven/aiven-operator
 go 1.18
 
 require (
-	github.com/aiven/aiven-go-client v1.7.1-0.20230210132513-62a95176f328
+	github.com/aiven/aiven-go-client v1.7.1-0.20230210144417-67543c45c148
 	github.com/aiven/aiven-go-client/tools/exp v0.0.0-20230210144417-67543c45c148
 	github.com/dave/jennifer v1.6.0
 	github.com/docker/go-units v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/aiven/aiven-go-client v1.7.1-0.20230210132513-62a95176f328 h1:zv1CtV4YY2OMZVTkCOV8bytwoizHzTLdtm5YdoLF49M=
-github.com/aiven/aiven-go-client v1.7.1-0.20230210132513-62a95176f328/go.mod h1:Eo0leGt6XAYlFXW3xtxsldToZ/FtBE5xdjpqY+PhYJI=
+github.com/aiven/aiven-go-client v1.7.1-0.20230210144417-67543c45c148 h1:5q2f74Y+wFgNa7AwRSZ2jecApRMrQ+ZSZdKFm9I1kf4=
+github.com/aiven/aiven-go-client v1.7.1-0.20230210144417-67543c45c148/go.mod h1:Eo0leGt6XAYlFXW3xtxsldToZ/FtBE5xdjpqY+PhYJI=
 github.com/aiven/aiven-go-client/tools/exp v0.0.0-20230210144417-67543c45c148 h1:BIFTpFYfP7wkeHFeCSk3xgq6vy+LWi3sza7cknEL3FQ=
 github.com/aiven/aiven-go-client/tools/exp v0.0.0-20230210144417-67543c45c148/go.mod h1:PEjz1ETUA7nlqD9gpbLWDyAEwkYbAU1JvhhKXtUQjwM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
The go-client is broken on my box and it is not latest as well. 