### PR TITLE
chore: fix typo for disk_space field

### DIFF
--- a/docs/docs/api-reference/examples/kafka.yaml
+++ b/docs/docs/api-reference/examples/kafka.yaml
@@ -13,7 +13,7 @@ spec:
   project: my-aiven-project
   cloudName: google-europe-west1
   plan: startup-2
-  disc_space: 15Gib
+  disk_space: 15Gib
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00

--- a/docs/docs/api-reference/kafka.md
+++ b/docs/docs/api-reference/kafka.md
@@ -20,7 +20,7 @@ spec:
   project: my-aiven-project
   cloudName: google-europe-west1
   plan: startup-2
-  disc_space: 15Gib
+  disk_space: 15Gib
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00

--- a/test/e2e/kafka-topic/simple-kafka-topic/01-kafka.yaml
+++ b/test/e2e/kafka-topic/simple-kafka-topic/01-kafka.yaml
@@ -14,7 +14,7 @@ spec:
 
   cloudName: google-europe-west1
   plan: business-4
-  disc_space: 15Gib
+  disk_space: 15Gib
 
   userConfig:
     kafka_connect: true

--- a/test/e2e/kafka/kafka-simple-cluster/01-kafka.yaml
+++ b/test/e2e/kafka/kafka-simple-cluster/01-kafka.yaml
@@ -14,7 +14,7 @@ spec:
 
   cloudName: google-europe-west1
   plan: startup-2
-  disc_space: 15Gib
+  disk_space: 15Gib
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00


### PR DESCRIPTION
The field is disk_space, not disc_space:
```
DiskSpace string `json:"disk_space,omitempty"`
```