### PR TITLE
refactor(ip_filter): remove backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `minumim`, `maximum` validations for `number` type
 - Move helm charts to the operator repository
 - Add helm charts generator
+- Remove `ip_filter` backward compatability
 
 ## v0.9.0 - 2023-03-03
 

--- a/api/v1alpha1/userconfig/service/cassandra/cassandra.go
+++ b/api/v1alpha1/userconfig/service/cassandra/cassandra.go
@@ -3,8 +3,6 @@
 
 package cassandrauserconfig
 
-import "encoding/json"
-
 // cassandra configuration values
 type Cassandra struct {
 	// +kubebuilder:validation:Minimum=1
@@ -20,33 +18,6 @@ type Cassandra struct {
 	// +kubebuilder:validation:MaxLength=128
 	// Name of the datacenter to which nodes of this service belong. Can be set only when creating the service.
 	Datacenter *string `groups:"create,update" json:"datacenter,omitempty"`
-}
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
 }
 
 // CIDR address block, either as a string, or in a dict with an optional description field

--- a/api/v1alpha1/userconfig/service/clickhouse/clickhouse.go
+++ b/api/v1alpha1/userconfig/service/clickhouse/clickhouse.go
@@ -3,35 +3,6 @@
 
 package clickhouseuserconfig
 
-import "encoding/json"
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
-}
-
 // CIDR address block, either as a string, or in a dict with an optional description field
 type IpFilter struct {
 	// +kubebuilder:validation:MaxLength=1024

--- a/api/v1alpha1/userconfig/service/grafana/grafana.go
+++ b/api/v1alpha1/userconfig/service/grafana/grafana.go
@@ -3,8 +3,6 @@
 
 package grafanauserconfig
 
-import "encoding/json"
-
 // Azure AD OAuth integration
 type AuthAzuread struct {
 	// Automatically sign-up users on successful sign-in
@@ -220,33 +218,6 @@ type ExternalImageStorage struct {
 	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9/+=]+$`
 	// S3 secret key
 	SecretKey string `groups:"create,update" json:"secret_key"`
-}
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
 }
 
 // CIDR address block, either as a string, or in a dict with an optional description field

--- a/api/v1alpha1/userconfig/service/kafka/kafka.go
+++ b/api/v1alpha1/userconfig/service/kafka/kafka.go
@@ -3,35 +3,6 @@
 
 package kafkauserconfig
 
-import "encoding/json"
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
-}
-
 // CIDR address block, either as a string, or in a dict with an optional description field
 type IpFilter struct {
 	// +kubebuilder:validation:MaxLength=1024

--- a/api/v1alpha1/userconfig/service/kafka_connect/kafka_connect.go
+++ b/api/v1alpha1/userconfig/service/kafka_connect/kafka_connect.go
@@ -3,35 +3,6 @@
 
 package kafkaconnectuserconfig
 
-import "encoding/json"
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
-}
-
 // CIDR address block, either as a string, or in a dict with an optional description field
 type IpFilter struct {
 	// +kubebuilder:validation:MaxLength=1024

--- a/api/v1alpha1/userconfig/service/mysql/mysql.go
+++ b/api/v1alpha1/userconfig/service/mysql/mysql.go
@@ -3,35 +3,6 @@
 
 package mysqluserconfig
 
-import "encoding/json"
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
-}
-
 // CIDR address block, either as a string, or in a dict with an optional description field
 type IpFilter struct {
 	// +kubebuilder:validation:MaxLength=1024

--- a/api/v1alpha1/userconfig/service/opensearch/opensearch.go
+++ b/api/v1alpha1/userconfig/service/opensearch/opensearch.go
@@ -3,8 +3,6 @@
 
 package opensearchuserconfig
 
-import "encoding/json"
-
 // Allows you to create glob style patterns and set a max number of indexes matching this pattern you want to keep. Creating indexes exceeding this value will cause the oldest one to get deleted. You could for example create a pattern looking like 'logs.?' and then create index logs.1, logs.2 etc, it will delete logs.1 once you create logs.6. Do note 'logs.?' does not apply to logs.10. Note: Setting max_index_count to 0 will do nothing and the pattern gets ignored.
 type IndexPatterns struct {
 	// +kubebuilder:validation:Minimum=0
@@ -37,33 +35,6 @@ type IndexTemplate struct {
 	// +kubebuilder:validation:Maximum=1024
 	// The number of primary shards that an index should have.
 	NumberOfShards *int `groups:"create,update" json:"number_of_shards,omitempty"`
-}
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
 }
 
 // CIDR address block, either as a string, or in a dict with an optional description field

--- a/api/v1alpha1/userconfig/service/pg/pg.go
+++ b/api/v1alpha1/userconfig/service/pg/pg.go
@@ -3,35 +3,6 @@
 
 package pguserconfig
 
-import "encoding/json"
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
-}
-
 // CIDR address block, either as a string, or in a dict with an optional description field
 type IpFilter struct {
 	// +kubebuilder:validation:MaxLength=1024

--- a/api/v1alpha1/userconfig/service/redis/redis.go
+++ b/api/v1alpha1/userconfig/service/redis/redis.go
@@ -3,35 +3,6 @@
 
 package redisuserconfig
 
-import "encoding/json"
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
-}
-
 // CIDR address block, either as a string, or in a dict with an optional description field
 type IpFilter struct {
 	// +kubebuilder:validation:MaxLength=1024

--- a/generators/userconfigs/generator.go
+++ b/generators/userconfigs/generator.go
@@ -244,11 +244,6 @@ func addObject(file *jen.File, obj *object) error {
 		s = jen.Comment(fmtComment(obj)).Line().Add(s)
 	}
 
-	// Hacks!
-	if obj.jsonName == "ip_filter" {
-		file.Line().Op(ipFilterCustomUnmarshal)
-	}
-
 	file.Add(s)
 	return nil
 }
@@ -435,33 +430,3 @@ func objMinimum(obj *object) string {
 	}
 	return fmt.Sprint(f)
 }
-
-// ipFilterCustomUnmarshal adds custom UnmarshalJSON that supports both strings and object type
-const ipFilterCustomUnmarshal = `
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == ` + "`" + `""` + "`" + ` {
-        return nil
-    }
-	
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network string ` + "`" + `json:"network"` + "`" + `
-		Description *string ` + "`" + `json:"description,omitempty" ` + "`" + `
-	}
-	
-	var t *this 
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
-}
-`

--- a/generators/userconfigs/generator_test.go
+++ b/generators/userconfigs/generator_test.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"encoding/json"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-
-	pgtestuserconfig "github.com/aiven/aiven-operator/generators/userconfigs/pg"
 )
 
 func TestNewUserConfigFile(t *testing.T) {
@@ -22,63 +19,11 @@ func TestNewUserConfigFile(t *testing.T) {
 	expected, err := os.ReadFile(`pg/pg.go`)
 	assert.NoError(t, err)
 
-	actual, err := newUserConfigFile("pg_test_user_config", obj)
+	actual, err := newUserConfigFile("pg_test", obj)
 	assert.NoError(t, err)
 
 	// Leave the var for debugging with a break point
 	expectedStr := string(expected)
 	actualStr := string(actual)
 	assert.Equal(t, expectedStr, actualStr)
-}
-
-func TestIpFilterString(t *testing.T) {
-	var c pgtestuserconfig.PgTestUserConfig
-	s := `{
-		"ip_filter": [
-			"foo",
-			"bar"
-		]
-	}`
-
-	err := json.Unmarshal([]byte(s), &c)
-	assert.NoError(t, err)
-	assert.Len(t, c.IpFilter, 2)
-	assert.Equal(t, c.IpFilter[0].Network, "foo")
-	assert.Nil(t, c.IpFilter[0].Description)
-	assert.Equal(t, c.IpFilter[1].Network, "bar")
-	assert.Nil(t, c.IpFilter[1].Description)
-}
-
-func TestIpFilterObjects(t *testing.T) {
-	var c pgtestuserconfig.PgTestUserConfig
-	s := `{
-		"ip_filter": [
-			{
-				"network": "foo",
-				"description": "foo description"
-			},
-			{
-				"network": "bar"
-			}
-		]
-	}`
-
-	err := json.Unmarshal([]byte(s), &c)
-	assert.NoError(t, err)
-	assert.Len(t, c.IpFilter, 2)
-	assert.Equal(t, c.IpFilter[0].Network, "foo")
-	assert.Equal(t, *c.IpFilter[0].Description, "foo description")
-	assert.Equal(t, c.IpFilter[1].Network, "bar")
-	assert.Nil(t, c.IpFilter[1].Description)
-}
-
-func TestIpFilterEmpty(t *testing.T) {
-	var c pgtestuserconfig.PgTestUserConfig
-	s := `{
-		"ip_filter": []
-	}`
-
-	err := json.Unmarshal([]byte(s), &c)
-	assert.NoError(t, err)
-	assert.Len(t, c.IpFilter, 0)
 }

--- a/generators/userconfigs/pg/pg.go
+++ b/generators/userconfigs/pg/pg.go
@@ -3,35 +3,6 @@
 
 package pgtestuserconfig
 
-import "encoding/json"
-
-func (ip *IpFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" || string(data) == `""` {
-		return nil
-	}
-
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err == nil {
-		ip.Network = s
-		return nil
-	}
-
-	type this struct {
-		Network     string  `json:"network"`
-		Description *string `json:"description,omitempty" `
-	}
-
-	var t *this
-	err = json.Unmarshal(data, &t)
-	if err != nil {
-		return err
-	}
-	ip.Network = t.Network
-	ip.Description = t.Description
-	return nil
-}
-
 // CIDR address block, either as a string, or in a dict with an optional description field
 type IpFilter struct {
 	// +kubebuilder:validation:MaxLength=1024
@@ -80,6 +51,8 @@ type Migration struct {
 
 // postgresql.conf configuration values
 type Pg struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
 	// Specifies a fraction of the table size to add to autovacuum_analyze_threshold when deciding whether to trigger an ANALYZE. The default is 0.2 (20% of table size)
 	AutovacuumAnalyzeScaleFactor *float64 `groups:"create,update" json:"autovacuum_analyze_scale_factor,omitempty"`
 
@@ -113,6 +86,8 @@ type Pg struct {
 	// Specifies the cost limit value that will be used in automatic VACUUM operations. If -1 is specified (which is the default), the regular vacuum_cost_limit value will be used.
 	AutovacuumVacuumCostLimit *int `groups:"create,update" json:"autovacuum_vacuum_cost_limit,omitempty"`
 
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1
 	// Specifies a fraction of the table size to add to autovacuum_vacuum_threshold when deciding whether to trigger a VACUUM. The default is 0.2 (20% of table size)
 	AutovacuumVacuumScaleFactor *float64 `groups:"create,update" json:"autovacuum_vacuum_scale_factor,omitempty"`
 
@@ -136,6 +111,8 @@ type Pg struct {
 	// In each round, no more than this many buffers will be written by the background writer. Setting this to zero disables background writing. Default is 100.
 	BgwriterLruMaxpages *int `groups:"create,update" json:"bgwriter_lru_maxpages,omitempty"`
 
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=10
 	// The average recent need for new buffers is multiplied by bgwriter_lru_multiplier to arrive at an estimate of the number that will be needed during the next round, (up to bgwriter_lru_maxpages). 1.0 represents a “just in time” policy of writing exactly the number of buffers predicted to be needed. Larger values provide some cushion against spikes in demand, while smaller values intentionally leave writes to be done by server processes. The default is 2.0.
 	BgwriterLruMultiplier *float64 `groups:"create,update" json:"bgwriter_lru_multiplier,omitempty"`
 
@@ -486,6 +463,8 @@ type PgTestUserConfig struct {
 	// Name of another service to fork from. This has effect only when a new service is being created.
 	ServiceToForkFrom *string `groups:"create" json:"service_to_fork_from,omitempty"`
 
+	// +kubebuilder:validation:Minimum=20
+	// +kubebuilder:validation:Maximum=60
 	// Percentage of total RAM that the database server uses for shared memory buffers. Valid range is 20-60 (float), which corresponds to 20% - 60%. This setting adjusts the shared_buffers configuration value.
 	SharedBuffersPercentage *float64 `groups:"create,update" json:"shared_buffers_percentage,omitempty"`
 


### PR DESCRIPTION
Ip filter objects introduced in v0.8.0.
Since we had some breaking changes there, this compatibility layer doesn't help at all.