### PR TITLE
feat: add rbac options to helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add Kafka `log_cleaner_min_cleanable_ratio` minimum and maximum validation rules
 - Remove Kafka version `3.2`, reached EOL
 - Remove PostgreSQL version `10`, reached EOL
+- Add `rbac.create` and `rbac.scoped` options to Helm chart
 
 ## v0.9.0 - 2023-03-03
 

--- a/charts/aiven-operator/templates/cluster_role.yaml
+++ b/charts/aiven-operator/templates/cluster_role.yaml
@@ -1,5 +1,10 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.scoped -}}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   name: {{ include "aiven-operator.fullname" . }}-role
   namespace: {{ include "aiven-operator.namespace" . }}
@@ -458,3 +463,4 @@ rules:
       - get
       - list
       - update
+{{- end }}

--- a/charts/aiven-operator/templates/cluster_role_binding.yaml
+++ b/charts/aiven-operator/templates/cluster_role_binding.yaml
@@ -1,5 +1,10 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.scoped -}}
+kind: RoleBinding
+{{- else }}
 kind: ClusterRoleBinding
+{{- end }}
 metadata:
   name: {{ include "aiven-operator.fullname" . }}-rolebinding
   namespace: {{ include "aiven-operator.namespace" . }}
@@ -13,3 +18,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "aiven-operator.serviceAccountName" . }}
   namespace: {{ include "aiven-operator.namespace" . }}
+{{- end }}

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -76,3 +76,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+rbac:
+  create: true
+  scoped: false


### PR DESCRIPTION
This change allows the Helm chart be installed without including the creation of cluster-wide resources (ClusterRoles/ClusterRoleBindings). Specifically, this change supports at least 2 use cases:

1. The scenario where the engineer installing the chart has limited (i.e. namespace only) access and cannot install cluster-wide resources. This change allows the cluster-wide resources to be installed separately by cluster administrators while still allowing the engineers to manage the operator itself without having full cluster-wide access.

2. The scenario where the operator only needs to manage resources in a specific namespace and not the entire cluster.

I believe this is the first pull request into this repository since moving the Aiven charts from its [dedicated repository](https://github.com/aiven/aiven-charts) so if a separate PR needs to be made there, let me know and I'd be happy to open one.