### PR TITLE
fix(charts): add required RBAC permissions to update finalizers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,10 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
+    ignore:
       - dependency-name: "k8s.io/api"
-        update-types: [ "version-update:semver-patch" ]
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "k8s.io/apimachinery"
-        update-types: [ "version-update:semver-patch" ]
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "k8s.io/client-go"
-        update-types: [ "version-update:semver-patch" ]
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add `rbac.create` and `rbac.scoped` options to Helm chart. Thanks to @ryaneorth
 - Explicitly delete `ProjectVPC` by `ID` to avoid conflicts 
 - Speed up `ProjectVPC` deletion by exiting on `DELETING` status
+- Fix missing RBAC permissions to update finalizers for various controllers 
 
 ## v0.9.0 - 2023-03-03
 

--- a/charts/aiven-operator/templates/cluster_role.yaml
+++ b/charts/aiven-operator/templates/cluster_role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.rbac.scoped -}}
+{{- if .Values.rbac.scoped }}
 kind: Role
 {{- else }}
 kind: ClusterRole
@@ -97,6 +97,12 @@ rules:
   - apiGroups:
       - aiven.io
     resources:
+      - clickhouseusers/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - aiven.io
+    resources:
       - clickhouseusers/status
     verbs:
       - get
@@ -114,6 +120,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - aiven.io
+    resources:
+      - connectionpools/finalizers
+    verbs:
+      - update
   - apiGroups:
       - aiven.io
     resources:
@@ -205,6 +217,12 @@ rules:
   - apiGroups:
       - aiven.io
     resources:
+      - kafkaconnectors/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - aiven.io
+    resources:
       - kafkaconnectors/status
     verbs:
       - get
@@ -225,6 +243,12 @@ rules:
   - apiGroups:
       - aiven.io
     resources:
+      - kafkaconnects/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - aiven.io
+    resources:
       - kafkaconnects/status
     verbs:
       - get
@@ -242,6 +266,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - aiven.io
+    resources:
+      - kafkas/finalizers
+    verbs:
+      - update
   - apiGroups:
       - aiven.io
     resources:
@@ -331,6 +361,12 @@ rules:
   - apiGroups:
       - aiven.io
     resources:
+      - opensearches/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - aiven.io
+    resources:
       - opensearches/status
     verbs:
       - get
@@ -351,6 +387,12 @@ rules:
   - apiGroups:
       - aiven.io
     resources:
+      - postgresqls/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - aiven.io
+    resources:
       - postgresqls/status
     verbs:
       - get
@@ -368,6 +410,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - aiven.io
+    resources:
+      - projects/finalizers
+    verbs:
+      - update
   - apiGroups:
       - aiven.io
     resources:
@@ -411,6 +459,12 @@ rules:
   - apiGroups:
       - aiven.io
     resources:
+      - redis/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - aiven.io
+    resources:
       - redis/status
     verbs:
       - get
@@ -447,6 +501,12 @@ rules:
       - list
       - update
       - watch
+  - apiGroups:
+      - aiven.io
+    resources:
+      - serviceusers/finalizers
+    verbs:
+      - update
   - apiGroups:
       - aiven.io
     resources:

--- a/charts/aiven-operator/templates/cluster_role_binding.yaml
+++ b/charts/aiven-operator/templates/cluster_role_binding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.rbac.scoped -}}
+{{- if .Values.rbac.scoped }}
 kind: RoleBinding
 {{- else }}
 kind: ClusterRoleBinding

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -91,6 +91,12 @@ rules:
 - apiGroups:
   - aiven.io
   resources:
+  - clickhouseusers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - aiven.io
+  resources:
   - clickhouseusers/status
   verbs:
   - get
@@ -108,6 +114,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - aiven.io
+  resources:
+  - connectionpools/finalizers
+  verbs:
+  - update
 - apiGroups:
   - aiven.io
   resources:
@@ -199,6 +211,12 @@ rules:
 - apiGroups:
   - aiven.io
   resources:
+  - kafkaconnectors/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - aiven.io
+  resources:
   - kafkaconnectors/status
   verbs:
   - get
@@ -219,6 +237,12 @@ rules:
 - apiGroups:
   - aiven.io
   resources:
+  - kafkaconnects/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - aiven.io
+  resources:
   - kafkaconnects/status
   verbs:
   - get
@@ -236,6 +260,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - aiven.io
+  resources:
+  - kafkas/finalizers
+  verbs:
+  - update
 - apiGroups:
   - aiven.io
   resources:
@@ -325,6 +355,12 @@ rules:
 - apiGroups:
   - aiven.io
   resources:
+  - opensearches/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - aiven.io
+  resources:
   - opensearches/status
   verbs:
   - get
@@ -345,6 +381,12 @@ rules:
 - apiGroups:
   - aiven.io
   resources:
+  - postgresqls/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - aiven.io
+  resources:
   - postgresqls/status
   verbs:
   - get
@@ -362,6 +404,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - aiven.io
+  resources:
+  - projects/finalizers
+  verbs:
+  - update
 - apiGroups:
   - aiven.io
   resources:
@@ -405,6 +453,12 @@ rules:
 - apiGroups:
   - aiven.io
   resources:
+  - redis/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - aiven.io
+  resources:
   - redis/status
   verbs:
   - get
@@ -441,6 +495,12 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - aiven.io
+  resources:
+  - serviceusers/finalizers
+  verbs:
+  - update
 - apiGroups:
   - aiven.io
   resources:

--- a/config/samples/aiven.io_v1alpha1_kafka.yaml
+++ b/config/samples/aiven.io_v1alpha1_kafka.yaml
@@ -14,7 +14,6 @@ spec:
 
   cloudName: google-europe-west1
   plan: startup-2
-  disk_space: 15Gib
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00

--- a/controllers/clickhouseuser_controller.go
+++ b/controllers/clickhouseuser_controller.go
@@ -30,6 +30,7 @@ type ClickhouseUserReconciler struct {
 
 //+kubebuilder:rbac:groups=aiven.io,resources=clickhouseusers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=aiven.io,resources=clickhouseusers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=aiven.io,resources=clickhouseusers/finalizers,verbs=update
 
 func (r *ClickhouseUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("clickhouseuser", req.NamespacedName)

--- a/controllers/connectionpool_controller.go
+++ b/controllers/connectionpool_controller.go
@@ -27,6 +27,7 @@ type ConnectionPoolHandler struct{}
 
 // +kubebuilder:rbac:groups=aiven.io,resources=connectionpools,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=aiven.io,resources=connectionpools/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=aiven.io,resources=connectionpools/finalizers,verbs=update
 
 func (r *ConnectionPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, ConnectionPoolHandler{}, &v1alpha1.ConnectionPool{})

--- a/controllers/kafka_controller.go
+++ b/controllers/kafka_controller.go
@@ -20,8 +20,9 @@ type KafkaReconciler struct {
 	Controller
 }
 
-// +kubebuilder:rbac:groups=aiven.io,resources=kafkas,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=aiven.io,resources=kafkas/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=aiven.io,resources=kafkas,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=aiven.io,resources=kafkas/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=aiven.io,resources=kafkas/finalizers,verbs=update
 
 func (r *KafkaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, newGenericServiceHandler(newKafkaAdapter), &v1alpha1.Kafka{})

--- a/controllers/kafkaconnect_controller.go
+++ b/controllers/kafkaconnect_controller.go
@@ -22,6 +22,7 @@ type KafkaConnectReconciler struct {
 
 // +kubebuilder:rbac:groups=aiven.io,resources=kafkaconnects,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=aiven.io,resources=kafkaconnects/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=aiven.io,resources=kafkaconnects/finalizers,verbs=update
 
 func (r *KafkaConnectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, newGenericServiceHandler(newKafkaConnectAdapter), &v1alpha1.KafkaConnect{})

--- a/controllers/kafkaconnector_controller.go
+++ b/controllers/kafkaconnector_controller.go
@@ -31,6 +31,7 @@ type KafkaConnectorHandler struct {
 
 //+kubebuilder:rbac:groups=aiven.io,resources=kafkaconnectors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=aiven.io,resources=kafkaconnectors/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=aiven.io,resources=kafkaconnectors/finalizers,verbs=update
 
 func (r *KafkaConnectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, KafkaConnectorHandler{k8s: r.Client}, &v1alpha1.KafkaConnector{})

--- a/controllers/opensearch_controller.go
+++ b/controllers/opensearch_controller.go
@@ -24,6 +24,7 @@ type OpenSearchHandler struct{}
 
 //+kubebuilder:rbac:groups=aiven.io,resources=opensearches,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=aiven.io,resources=opensearches/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=aiven.io,resources=opensearches/finalizers,verbs=update
 
 func (r *OpenSearchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, newGenericServiceHandler(newOpenSearchAdapter), &v1alpha1.OpenSearch{})

--- a/controllers/postgresql_controller.go
+++ b/controllers/postgresql_controller.go
@@ -20,8 +20,9 @@ type PostgreSQLReconciler struct {
 	Controller
 }
 
-// +kubebuilder:rbac:groups=aiven.io,resources=postgresqls,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=aiven.io,resources=postgresqls/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=aiven.io,resources=postgresqls,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=aiven.io,resources=postgresqls/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=aiven.io,resources=postgresqls/finalizers,verbs=update
 
 func (r *PostgreSQLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, newGenericServiceHandler(newPostgresSQLAdapter), &v1alpha1.PostgreSQL{})

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -28,6 +28,7 @@ type ProjectHandler struct{}
 
 // +kubebuilder:rbac:groups=aiven.io,resources=projects,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=aiven.io,resources=projects/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=aiven.io,resources=projects/finalizers,verbs=update
 
 func (r *ProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, ProjectHandler{}, &v1alpha1.Project{})

--- a/controllers/redis_controller.go
+++ b/controllers/redis_controller.go
@@ -24,6 +24,7 @@ type RedisHandler struct{}
 
 //+kubebuilder:rbac:groups=aiven.io,resources=redis,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=aiven.io,resources=redis/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=aiven.io,resources=redis/finalizers,verbs=update
 
 func (r *RedisReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, newGenericServiceHandler(newRedisAdapter), &v1alpha1.Redis{})

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -26,6 +26,7 @@ type ServiceUserHandler struct{}
 
 // +kubebuilder:rbac:groups=aiven.io,resources=serviceusers,verbs=update;get;list;watch;create;delete
 // +kubebuilder:rbac:groups=aiven.io,resources=serviceusers/status,verbs=get;update
+// +kubebuilder:rbac:groups=aiven.io,resources=serviceusers/finalizers,verbs=update
 
 func (r *ServiceUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconcileInstance(ctx, req, ServiceUserHandler{}, &v1alpha1.ServiceUser{})

--- a/docs/docs/api-reference/examples/kafka.yaml
+++ b/docs/docs/api-reference/examples/kafka.yaml
@@ -13,7 +13,6 @@ spec:
   project: my-aiven-project
   cloudName: google-europe-west1
   plan: startup-2
-  disk_space: 15Gib
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00

--- a/docs/docs/api-reference/kafka.md
+++ b/docs/docs/api-reference/kafka.md
@@ -20,7 +20,6 @@ spec:
   project: my-aiven-project
   cloudName: google-europe-west1
   plan: startup-2
-  disk_space: 15Gib
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00

--- a/generators/charts/cluster_roles.go
+++ b/generators/charts/cluster_roles.go
@@ -41,7 +41,7 @@ func updateClusterRole(operatorPath, crdCharts string) error {
 
 var clusterRoleTmpl = `{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.rbac.scoped -}}
+{{- if .Values.rbac.scoped }}
 kind: Role
 {{- else }}
 kind: ClusterRole

--- a/test/e2e/kafka-topic/simple-kafka-topic/01-kafka.yaml
+++ b/test/e2e/kafka-topic/simple-kafka-topic/01-kafka.yaml
@@ -14,7 +14,6 @@ spec:
 
   cloudName: google-europe-west1
   plan: business-4
-  disk_space: 15Gib
 
   userConfig:
     kafka_connect: true

--- a/test/e2e/kafka/kafka-simple-cluster/01-kafka.yaml
+++ b/test/e2e/kafka/kafka-simple-cluster/01-kafka.yaml
@@ -14,7 +14,6 @@ spec:
 
   cloudName: google-europe-west1
   plan: startup-2
-  disk_space: 15Gib
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00


### PR DESCRIPTION
- Fixes error `cannot set blockOwnerDeletion if an ownerReference refers to a resource you can’t set finalizers on`. Covered in Operator SDK [FAQ](https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-why-do-i-see-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-)
- Fixes kuttle tests
- Fixes dependabot config for k8s libs