### PR TITLE
chore(service_integration): remove signalfx type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix missing RBAC permissions to update finalizers for various controllers 
 - Refactor `ClickhouseUser` controller
 - Mark `ClickhouseUser.spec.project` and `ClickhouseUser.spec.serviceName` as immutable
+- Remove deprecated service integration type `signalfx`
 
 ## v0.9.0 - 2023-03-03
 

--- a/api/v1alpha1/serviceintegration_types.go
+++ b/api/v1alpha1/serviceintegration_types.go
@@ -25,7 +25,7 @@ type ServiceIntegrationSpec struct {
 	Project string `json:"project"`
 
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
-	// +kubebuilder:validation:Enum=datadog;kafka_logs;kafka_connect;metrics;dashboard;rsyslog;read_replica;schema_registry_proxy;signalfx;jolokia;internal_connectivity;external_google_cloud_logging;datasource;clickhouse_postgresql;clickhouse_kafka;logs;external_aws_cloudwatch_metrics
+	// +kubebuilder:validation:Enum=datadog;kafka_logs;kafka_connect;metrics;dashboard;rsyslog;read_replica;schema_registry_proxy;jolokia;internal_connectivity;external_google_cloud_logging;datasource;clickhouse_postgresql;clickhouse_kafka;logs;external_aws_cloudwatch_metrics
 	// Type of the service integration
 	IntegrationType string `json:"integrationType"`
 

--- a/charts/aiven-operator-crds/templates/aiven.io_serviceintegrations.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_serviceintegrations.yaml
@@ -313,7 +313,6 @@ spec:
                 - rsyslog
                 - read_replica
                 - schema_registry_proxy
-                - signalfx
                 - jolokia
                 - internal_connectivity
                 - external_google_cloud_logging

--- a/config/crd/bases/aiven.io_serviceintegrations.yaml
+++ b/config/crd/bases/aiven.io_serviceintegrations.yaml
@@ -313,7 +313,6 @@ spec:
                 - rsyslog
                 - read_replica
                 - schema_registry_proxy
-                - signalfx
                 - jolokia
                 - internal_connectivity
                 - external_google_cloud_logging

--- a/docs/docs/api-reference/serviceintegration.md
+++ b/docs/docs/api-reference/serviceintegration.md
@@ -43,7 +43,7 @@ ServiceIntegrationSpec defines the desired state of ServiceIntegration.
 
 **Required**
 
-- [`integrationType`](#spec.integrationType-property){: name='spec.integrationType-property'} (string, Enum: `datadog`, `kafka_logs`, `kafka_connect`, `metrics`, `dashboard`, `rsyslog`, `read_replica`, `schema_registry_proxy`, `signalfx`, `jolokia`, `internal_connectivity`, `external_google_cloud_logging`, `datasource`, `clickhouse_postgresql`, `clickhouse_kafka`, `logs`, `external_aws_cloudwatch_metrics`, Immutable). Type of the service integration.
+- [`integrationType`](#spec.integrationType-property){: name='spec.integrationType-property'} (string, Enum: `datadog`, `kafka_logs`, `kafka_connect`, `metrics`, `dashboard`, `rsyslog`, `read_replica`, `schema_registry_proxy`, `jolokia`, `internal_connectivity`, `external_google_cloud_logging`, `datasource`, `clickhouse_postgresql`, `clickhouse_kafka`, `logs`, `external_aws_cloudwatch_metrics`, Immutable). Type of the service integration.
 - [`project`](#spec.project-property){: name='spec.project-property'} (string, Immutable, MaxLength: 63). Project the integration belongs to.
 
 **Optional**

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/aiven/aiven-go-client v1.7.1-0.20230322225521-95b16e6cdbe8
-	github.com/aiven/go-api-schemas v1.1.0
+	github.com/aiven/go-api-schemas v1.2.0
 	github.com/dave/jennifer v1.6.1
 	github.com/docker/go-units v0.5.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/aiven/aiven-go-client v1.7.1-0.20230322225521-95b16e6cdbe8 h1:mjgonhRTE4qgfdY1DZq2m3VI0QpT3fMYTvZrw6QoNNA=
 github.com/aiven/aiven-go-client v1.7.1-0.20230322225521-95b16e6cdbe8/go.mod h1:Eo0leGt6XAYlFXW3xtxsldToZ/FtBE5xdjpqY+PhYJI=
-github.com/aiven/go-api-schemas v1.1.0 h1:2CiWDIGmz/WkNYzR4piGV8BNxyljLmrwSU6bStpL6Mo=
-github.com/aiven/go-api-schemas v1.1.0/go.mod h1:RmQ8MfxwxAP2ji9eJtP6dICOaTMcQD9b5aQT3Bp7uzI=
+github.com/aiven/go-api-schemas v1.2.0 h1:ClrMKLIMaVWmfzPAqJs5Kea4FIhQ5MJvW9ptkOykifU=
+github.com/aiven/go-api-schemas v1.2.0/go.mod h1:RmQ8MfxwxAP2ji9eJtP6dICOaTMcQD9b5aQT3Bp7uzI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
- Removes deprecated service integration type `signalfx`
- Bumps up `go-api-schemas` version