### PR TITLE
feat(chart): allow to disable helm capabilities check

### DIFF
--- a/charts/aiven-operator/Chart.yaml
+++ b/charts/aiven-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aiven-operator
 description: A Helm chart to deploy the aiven operator
 type: application
-version: v0.10.0
+version: v0.10.1
 appVersion: v0.10.0
 maintainers:
   - name: mhoffm-aiven

--- a/charts/aiven-operator/templates/ensure_cert_manager_if_webhooks_are_enabled.yaml
+++ b/charts/aiven-operator/templates/ensure_cert_manager_if_webhooks_are_enabled.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.webhooks.enabled }}
 
+{{- if .Values.webhooks.checkCapabilities }}
 {{- if not (.Capabilities.APIVersions.Has "cert-manager.io/v1") -}}
     {{- fail "Required Cert Manager CRDs are missing even though Webhooks are enabled and Cert Manager is required" }}
+{{ end }}
 {{ end }}
 
 {{ end }}

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -21,6 +21,7 @@ defaultTokenSecret:
 # webhhook configuration
 webhooks:
   enabled: true
+  checkCapabilities: true
   servicePort: 443
   # Set 10250 for GKE, default is 9443
   # containerPort: 9443


### PR DESCRIPTION
Kustomize does not play nicely with helm .Capabilities as it doesn't currently let you pass those values.
See: https://github.com/kubernetes-sigs/kustomize/issues/4256

This just allows to disable the capability check. Still enabled by default.