### PR TITLE
fix(tests): concurrent map access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ test-e2e-preinstalled:
 
 test: envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
-	go test ./tests/... -run=$(run) -v -timeout 42m -parallel 10 -cover -coverpkg=./controllers -covermode=count -coverprofile=coverage.out
+	go test ./tests/... -race -run=$(run) -v -timeout 42m -parallel 10 -cover -coverpkg=./controllers -covermode=atomic -coverprofile=coverage.out
 
 ##@ Build
 


### PR DESCRIPTION
- Fixes test suite concurrent map access by making resource deletion idempotent. "not found" error ignored, which may occur if resource deleted manually. 
- Test resources have to have unique names now, as objects get ID after they applied only, and that requires additional logic on delete. Especially when it panicked.
- Runs tests with race flag to detect race conditions
- Recovers panics in goroutines