### PR TITLE
feat: add option to add prefix on each connInfoSecretTarget secrets' keys

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -32,6 +32,8 @@ type ConnInfoSecretTarget struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// Labels added to the secret
 	Labels map[string]string `json:"labels,omitempty"`
+	// Prefix added to all secret's keys
+	Prefix string `json:"prefix,omitempty"`
 }
 
 // ServiceStatus defines the observed state of service

--- a/charts/aiven-operator-crds/templates/aiven.io_cassandras.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_cassandras.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
@@ -71,6 +71,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhouseusers.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhouseusers.yaml
@@ -77,6 +77,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_connectionpools.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_connectionpools.yaml
@@ -86,6 +86,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_mysqls.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_mysqls.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
@@ -71,6 +71,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_postgresqls.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_postgresqls.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_projects.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_projects.yaml
@@ -113,6 +113,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_redis.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_redis.yaml
@@ -71,6 +71,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_serviceusers.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_serviceusers.yaml
@@ -83,6 +83,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_cassandras.yaml
+++ b/config/crd/bases/aiven.io_cassandras.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_clickhouses.yaml
+++ b/config/crd/bases/aiven.io_clickhouses.yaml
@@ -71,6 +71,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_clickhouseusers.yaml
+++ b/config/crd/bases/aiven.io_clickhouseusers.yaml
@@ -77,6 +77,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_connectionpools.yaml
+++ b/config/crd/bases/aiven.io_connectionpools.yaml
@@ -86,6 +86,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_grafanas.yaml
+++ b/config/crd/bases/aiven.io_grafanas.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_mysqls.yaml
+++ b/config/crd/bases/aiven.io_mysqls.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_opensearches.yaml
+++ b/config/crd/bases/aiven.io_opensearches.yaml
@@ -71,6 +71,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_postgresqls.yaml
+++ b/config/crd/bases/aiven.io_postgresqls.yaml
@@ -84,6 +84,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_projects.yaml
+++ b/config/crd/bases/aiven.io_projects.yaml
@@ -113,6 +113,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_redis.yaml
+++ b/config/crd/bases/aiven.io_redis.yaml
@@ -71,6 +71,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_serviceusers.yaml
+++ b/config/crd/bases/aiven.io_serviceusers.yaml
@@ -83,6 +83,9 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix added to all secret's keys
+                    type: string
                 required:
                 - name
                 type: object

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -135,7 +135,7 @@ func newSecret(o client.Object, target v1alpha1.ConnInfoSecretTarget, stringData
 	if target.Prefix != "" {
 		stringData_prefix := make(map[string]string)
 		for key, data := range stringData {
-			stringData_prefix[target.Prefix + key] = data
+			stringData_prefix[target.Prefix+key] = data
 		}
 		stringData = stringData_prefix
 	}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -132,6 +132,14 @@ func newSecret(o client.Object, target v1alpha1.ConnInfoSecretTarget, stringData
 		meta.Name = target.Name
 	}
 
+	if target.Prefix != "" {
+		stringData_prefix := make(map[string]string)
+		for key, data := range stringData {
+			stringData_prefix[target.Prefix + key] = data
+		}
+		stringData = stringData_prefix
+	}
+
 	return &corev1.Secret{
 		ObjectMeta: meta,
 		StringData: stringData,

--- a/docs/docs/api-reference/cassandra.md
+++ b/docs/docs/api-reference/cassandra.md
@@ -100,6 +100,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/clickhouse.md
+++ b/docs/docs/api-reference/clickhouse.md
@@ -91,6 +91,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/clickhouseuser.md
+++ b/docs/docs/api-reference/clickhouseuser.md
@@ -70,4 +70,5 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 

--- a/docs/docs/api-reference/connectionpool.md
+++ b/docs/docs/api-reference/connectionpool.md
@@ -78,4 +78,5 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 

--- a/docs/docs/api-reference/grafana.md
+++ b/docs/docs/api-reference/grafana.md
@@ -99,6 +99,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/kafka.md
+++ b/docs/docs/api-reference/kafka.md
@@ -92,6 +92,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/mysql.md
+++ b/docs/docs/api-reference/mysql.md
@@ -99,6 +99,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/opensearch.md
+++ b/docs/docs/api-reference/opensearch.md
@@ -92,6 +92,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/postgresql.md
+++ b/docs/docs/api-reference/postgresql.md
@@ -94,6 +94,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/project.md
+++ b/docs/docs/api-reference/project.md
@@ -80,4 +80,5 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 

--- a/docs/docs/api-reference/redis.md
+++ b/docs/docs/api-reference/redis.md
@@ -94,6 +94,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/serviceuser.md
+++ b/docs/docs/api-reference/serviceuser.md
@@ -71,4 +71,5 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix added to all secret's keys.
 


### PR DESCRIPTION
This PR adds the option to connInfoSecretTarget to add prefixes to all its secret keys.

This intends to help to avoid collision environment variables when the secrets created by the operator are used in any `env[].valueFrom.secretKeyRef`. This way there are easily identified as coming from the operator and the application/pod consuming them does not have to adjust to variable name collisions.