### PR TITLE
Allow overriding cloudName used in tests

### DIFF
--- a/tests/cassandra_test.go
+++ b/tests/cassandra_test.go
@@ -11,7 +11,7 @@ import (
 	cassandrauserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/cassandra"
 )
 
-func getCassandraYaml(project, name string) string {
+func getCassandraYaml(project, name, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Cassandra
@@ -23,7 +23,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: startup-4
   disk_space: 450Gib
 
@@ -40,7 +40,7 @@ spec:
         description: bar
       - network: 10.20.0.0/16
 
-`, project, name)
+`, project, name, cloudName)
 }
 
 func TestCassandra(t *testing.T) {
@@ -49,7 +49,7 @@ func TestCassandra(t *testing.T) {
 
 	// GIVEN
 	name := randName("cassandra")
-	yml := getCassandraYaml(testProject, name)
+	yml := getCassandraYaml(testProject, name, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/cassandra_test.go
+++ b/tests/cassandra_test.go
@@ -49,7 +49,7 @@ func TestCassandra(t *testing.T) {
 
 	// GIVEN
 	name := randName("cassandra")
-	yml := getCassandraYaml(testProject, name, testCloudName)
+	yml := getCassandraYaml(testProject, name, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/clickhouse_test.go
+++ b/tests/clickhouse_test.go
@@ -11,7 +11,7 @@ import (
 	clickhouseuserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/clickhouse"
 )
 
-func getClickhouseYaml(project, name string) string {
+func getClickhouseYaml(project, name, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Clickhouse
@@ -23,7 +23,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: startup-16
 
   tags:
@@ -36,7 +36,7 @@ spec:
         description: bar
       - network: 10.20.0.0/16
 
-`, project, name)
+`, project, name, cloudName)
 }
 
 func TestClickhouse(t *testing.T) {
@@ -45,7 +45,7 @@ func TestClickhouse(t *testing.T) {
 
 	// GIVEN
 	name := randName("clickhouse")
-	yml := getClickhouseYaml(testProject, name)
+	yml := getClickhouseYaml(testProject, name, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/clickhouse_test.go
+++ b/tests/clickhouse_test.go
@@ -45,7 +45,7 @@ func TestClickhouse(t *testing.T) {
 
 	// GIVEN
 	name := randName("clickhouse")
-	yml := getClickhouseYaml(testProject, name, testCloudName)
+	yml := getClickhouseYaml(testProject, name, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/clickhouseuser_test.go
+++ b/tests/clickhouseuser_test.go
@@ -56,7 +56,7 @@ func TestClickhouseUser(t *testing.T) {
 	// GIVEN
 	chName := randName("clickhouse-user")
 	userName := randName("clickhouse-user")
-	yml := getClickhouseUserYaml(testProject, chName, userName, testCloudName)
+	yml := getClickhouseUserYaml(testProject, chName, userName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/clickhouseuser_test.go
+++ b/tests/clickhouseuser_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getClickhouseUserYaml(project, chName, userName string) string {
+func getClickhouseUserYaml(project, chName, userName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Clickhouse
@@ -22,7 +22,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[4]s
   plan: startup-16
 
 ---
@@ -46,7 +46,7 @@ spec:
   project: %[1]s
   serviceName: %[2]s
 
-`, project, chName, userName)
+`, project, chName, userName, cloudName)
 }
 
 func TestClickhouseUser(t *testing.T) {
@@ -56,7 +56,7 @@ func TestClickhouseUser(t *testing.T) {
 	// GIVEN
 	chName := randName("clickhouse-user")
 	userName := randName("clickhouse-user")
-	yml := getClickhouseUserYaml(testProject, chName, userName)
+	yml := getClickhouseUserYaml(testProject, chName, userName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/connectionpool_test.go
+++ b/tests/connectionpool_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getConnectionPoolYaml(project, pgName, dbName, userName, poolName string) string {
+func getConnectionPoolYaml(project, pgName, dbName, userName, poolName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: PostgreSQL
@@ -22,7 +22,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[6]s
   plan: startup-4
 
 ---
@@ -70,7 +70,7 @@ spec:
   username: %[4]s
   poolMode: transaction
   poolSize: 25
-`, project, pgName, dbName, userName, poolName)
+`, project, pgName, dbName, userName, poolName, cloudName)
 }
 
 func TestConnectionPool(t *testing.T) {
@@ -82,7 +82,7 @@ func TestConnectionPool(t *testing.T) {
 	dbName := randName("connection-pool")
 	userName := randName("connection-pool")
 	poolName := randName("connection-pool")
-	yml := getConnectionPoolYaml(testProject, pgName, dbName, userName, poolName)
+	yml := getConnectionPoolYaml(testProject, pgName, dbName, userName, poolName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/connectionpool_test.go
+++ b/tests/connectionpool_test.go
@@ -82,7 +82,7 @@ func TestConnectionPool(t *testing.T) {
 	dbName := randName("connection-pool")
 	userName := randName("connection-pool")
 	poolName := randName("connection-pool")
-	yml := getConnectionPoolYaml(testProject, pgName, dbName, userName, poolName, testCloudName)
+	yml := getConnectionPoolYaml(testProject, pgName, dbName, userName, poolName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -52,7 +52,7 @@ func TestDatabase(t *testing.T) {
 	// GIVEN
 	pgName := randName("database")
 	dbName := randName("database")
-	yml := getDatabaseYaml(testProject, pgName, dbName, testCloudName)
+	yml := getDatabaseYaml(testProject, pgName, dbName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getDatabaseYaml(project, pgName, dbName string) string {
+func getDatabaseYaml(project, pgName, dbName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: PostgreSQL
@@ -22,7 +22,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[4]s
   plan: startup-4
 
 ---
@@ -42,7 +42,7 @@ spec:
   lcCtype: en_US.UTF-8
   lcCollate: en_US.UTF-8
 
-`, project, pgName, dbName)
+`, project, pgName, dbName, cloudName)
 }
 
 func TestDatabase(t *testing.T) {
@@ -52,7 +52,7 @@ func TestDatabase(t *testing.T) {
 	// GIVEN
 	pgName := randName("database")
 	dbName := randName("database")
-	yml := getDatabaseYaml(testProject, pgName, dbName)
+	yml := getDatabaseYaml(testProject, pgName, dbName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/grafana_test.go
+++ b/tests/grafana_test.go
@@ -11,7 +11,7 @@ import (
 	grafanauserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/grafana"
 )
 
-func getGrafanaYaml(project, name string) string {
+func getGrafanaYaml(project, name, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Grafana
@@ -23,7 +23,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: startup-1
 
   tags:
@@ -39,7 +39,7 @@ spec:
         description: bar
       - network: 10.20.0.0/16
 
-`, project, name)
+`, project, name, cloudName)
 }
 
 func TestGrafana(t *testing.T) {
@@ -48,7 +48,7 @@ func TestGrafana(t *testing.T) {
 
 	// GIVEN
 	name := randName("grafana")
-	yml := getGrafanaYaml(testProject, name)
+	yml := getGrafanaYaml(testProject, name, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/grafana_test.go
+++ b/tests/grafana_test.go
@@ -48,7 +48,7 @@ func TestGrafana(t *testing.T) {
 
 	// GIVEN
 	name := randName("grafana")
-	yml := getGrafanaYaml(testProject, name, testCloudName)
+	yml := getGrafanaYaml(testProject, name, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/kafka_test.go
+++ b/tests/kafka_test.go
@@ -11,7 +11,7 @@ import (
 	kafkauserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/kafka"
 )
 
-func getKafkaYaml(project, name string) string {
+func getKafkaYaml(project, name, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Kafka
@@ -23,7 +23,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: business-4
   disk_space: 600Gib
 
@@ -40,7 +40,7 @@ spec:
         description: bar
       - network: 10.20.0.0/16
 
-`, project, name)
+`, project, name, cloudName)
 }
 
 func TestKafka(t *testing.T) {
@@ -49,7 +49,7 @@ func TestKafka(t *testing.T) {
 
 	// GIVEN
 	name := randName("kafka")
-	yml := getKafkaYaml(testProject, name)
+	yml := getKafkaYaml(testProject, name, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/kafka_test.go
+++ b/tests/kafka_test.go
@@ -49,7 +49,7 @@ func TestKafka(t *testing.T) {
 
 	// GIVEN
 	name := randName("kafka")
-	yml := getKafkaYaml(testProject, name, testCloudName)
+	yml := getKafkaYaml(testProject, name, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/kafka_with_projectvpc_ref_test.go
+++ b/tests/kafka_with_projectvpc_ref_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getKafkaWithProjectVPCRefYaml(project, vpcName, kafkaName string) string {
+func getKafkaWithProjectVPCRefYaml(project, vpcName, kafkaName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: ProjectVPC
@@ -22,7 +22,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[4]s
   networkCidr: 10.0.0.0/24
 
 ---
@@ -37,12 +37,12 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: startup-2
 
   projectVPCRef:
     name: %[2]s
-`, project, vpcName, kafkaName)
+`, project, vpcName, kafkaName, cloudName)
 }
 
 // TestKafkaWithProjectVPCRef tests Kafka.Spec.ProjectVPCRef
@@ -53,7 +53,7 @@ func TestKafkaWithProjectVPCRef(t *testing.T) {
 	// GIVEN
 	vpcName := randName("kafka-vpc")
 	kafkaName := randName("kafka-vpc")
-	yml := getKafkaWithProjectVPCRefYaml(testProject, vpcName, kafkaName)
+	yml := getKafkaWithProjectVPCRefYaml(testProject, vpcName, kafkaName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/kafka_with_projectvpc_ref_test.go
+++ b/tests/kafka_with_projectvpc_ref_test.go
@@ -53,7 +53,7 @@ func TestKafkaWithProjectVPCRef(t *testing.T) {
 	// GIVEN
 	vpcName := randName("kafka-vpc")
 	kafkaName := randName("kafka-vpc")
-	yml := getKafkaWithProjectVPCRefYaml(testProject, vpcName, kafkaName, testCloudName)
+	yml := getKafkaWithProjectVPCRefYaml(testProject, vpcName, kafkaName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/kafkaacl_test.go
+++ b/tests/kafkaacl_test.go
@@ -71,7 +71,7 @@ func TestKafkaACL(t *testing.T) {
 	kafkaName := randName("kafka-acl")
 	topicName := randName("kafka-acl")
 	aclName := randName("kafka-acl")
-	yml := getKafkaACLYaml(testProject, kafkaName, topicName, aclName, testCloudName)
+	yml := getKafkaACLYaml(testProject, kafkaName, topicName, aclName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/kafkaacl_test.go
+++ b/tests/kafkaacl_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getKafkaACLYaml(project, kafka, topic, acl string) string {
+func getKafkaACLYaml(project, kafka, topic, acl, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Kafka
@@ -24,7 +24,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[5]s
   plan: startup-2
 
 ---
@@ -60,7 +60,7 @@ spec:
   topic: %[3]s
   username: my-user
   permission: admin
-`, project, kafka, topic, acl)
+`, project, kafka, topic, acl, cloudName)
 }
 
 func TestKafkaACL(t *testing.T) {
@@ -71,7 +71,7 @@ func TestKafkaACL(t *testing.T) {
 	kafkaName := randName("kafka-acl")
 	topicName := randName("kafka-acl")
 	aclName := randName("kafka-acl")
-	yml := getKafkaACLYaml(testProject, kafkaName, topicName, aclName)
+	yml := getKafkaACLYaml(testProject, kafkaName, topicName, aclName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/kafkaconnect_test.go
+++ b/tests/kafkaconnect_test.go
@@ -11,7 +11,7 @@ import (
 	kafkaconnectuserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/kafka_connect"
 )
 
-func getKafkaConnectYaml(project, name string) string {
+func getKafkaConnectYaml(project, name, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: KafkaConnect
@@ -27,7 +27,7 @@ spec:
     instance: foo
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: business-4
   
   userConfig:
@@ -39,7 +39,7 @@ spec:
       - network: 0.0.0.0/32
         description: bar
       - network: 10.20.0.0/16
-`, project, name)
+`, project, name, cloudName)
 }
 
 func TestKafkaConnect(t *testing.T) {
@@ -48,7 +48,7 @@ func TestKafkaConnect(t *testing.T) {
 
 	// GIVEN
 	name := randName("kafka-connect")
-	yml := getKafkaConnectYaml(testProject, name)
+	yml := getKafkaConnectYaml(testProject, name, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/kafkaconnect_test.go
+++ b/tests/kafkaconnect_test.go
@@ -48,7 +48,7 @@ func TestKafkaConnect(t *testing.T) {
 
 	// GIVEN
 	name := randName("kafka-connect")
-	yml := getKafkaConnectYaml(testProject, name, testCloudName)
+	yml := getKafkaConnectYaml(testProject, name, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/kafkaschema_test.go
+++ b/tests/kafkaschema_test.go
@@ -69,7 +69,7 @@ func TestKafkaSchema(t *testing.T) {
 	kafkaName := randName("kafka-schema")
 	schemaName := randName("kafka-schema")
 	subjectName := randName("kafka-schema")
-	yml := getKafkaSchemaYaml(testProject, kafkaName, schemaName, subjectName, testCloudName)
+	yml := getKafkaSchemaYaml(testProject, kafkaName, schemaName, subjectName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/kafkaschema_test.go
+++ b/tests/kafkaschema_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getKafkaSchemaYaml(project, kafkaName, schemaName, subjectName string) string {
+func getKafkaSchemaYaml(project, kafkaName, schemaName, subjectName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Kafka
@@ -24,7 +24,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[5]s
   plan: startup-2
   userConfig:
     schema_registry: true
@@ -58,7 +58,7 @@ spec:
         "namespace": "example_namespace",
         "type": "record"
     }
-`, project, kafkaName, schemaName, subjectName)
+`, project, kafkaName, schemaName, subjectName, cloudName)
 }
 
 func TestKafkaSchema(t *testing.T) {
@@ -69,7 +69,7 @@ func TestKafkaSchema(t *testing.T) {
 	kafkaName := randName("kafka-schema")
 	schemaName := randName("kafka-schema")
 	subjectName := randName("kafka-schema")
-	yml := getKafkaSchemaYaml(testProject, kafkaName, schemaName, subjectName)
+	yml := getKafkaSchemaYaml(testProject, kafkaName, schemaName, subjectName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/kafkatopic_test.go
+++ b/tests/kafkatopic_test.go
@@ -71,7 +71,7 @@ func TestKafkaTopic(t *testing.T) {
 
 	// GIVEN
 	ksName := randName("kafka-topic")
-	yml := getKafkaTopicNameYaml(testProject, ksName, testCloudName)
+	yml := getKafkaTopicNameYaml(testProject, ksName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/kafkatopic_test.go
+++ b/tests/kafkatopic_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getKafkaTopicNameYaml(project, ksName string) string {
+func getKafkaTopicNameYaml(project, ksName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Kafka
@@ -23,7 +23,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: startup-2
 
 ---
@@ -60,7 +60,7 @@ spec:
   topicName: bar_topic_name_with_underscores
   replication: 3
   partitions: 2
-`, project, ksName)
+`, project, ksName, cloudName)
 }
 
 // TestKafkaTopic creates two topics: one with metadata.name, another one with spec.topicName
@@ -71,7 +71,7 @@ func TestKafkaTopic(t *testing.T) {
 
 	// GIVEN
 	ksName := randName("kafka-topic")
-	yml := getKafkaTopicNameYaml(testProject, ksName)
+	yml := getKafkaTopicNameYaml(testProject, ksName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -48,7 +48,7 @@ func TestMySQL(t *testing.T) {
 
 	// GIVEN
 	name := randName("mysql")
-	yml := getMySQLYaml(testProject, name, testCloudName)
+	yml := getMySQLYaml(testProject, name, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -11,7 +11,7 @@ import (
 	mysqluserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/mysql"
 )
 
-func getMySQLYaml(project, name string) string {
+func getMySQLYaml(project, name, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: MySQL
@@ -23,7 +23,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: business-4
   disk_space: 100Gib
 
@@ -39,7 +39,7 @@ spec:
         description: bar
       - network: 10.20.0.0/16
 
-`, project, name)
+`, project, name, cloudName)
 }
 
 func TestMySQL(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMySQL(t *testing.T) {
 
 	// GIVEN
 	name := randName("mysql")
-	yml := getMySQLYaml(testProject, name)
+	yml := getMySQLYaml(testProject, name, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/opensearch_test.go
+++ b/tests/opensearch_test.go
@@ -11,7 +11,7 @@ import (
 	opensearchuserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/opensearch"
 )
 
-func getOpenSearchYaml(project, name string) string {
+func getOpenSearchYaml(project, name, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: OpenSearch
@@ -30,7 +30,7 @@ spec:
       baz: egg
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: startup-4
   disk_space: 240Gib
 
@@ -44,7 +44,7 @@ spec:
         description: bar
       - network: 10.20.0.0/16
 
-`, project, name)
+`, project, name, cloudName)
 }
 
 func TestOpenSearch(t *testing.T) {
@@ -53,7 +53,7 @@ func TestOpenSearch(t *testing.T) {
 
 	// GIVEN
 	name := randName("opensearch")
-	yml := getOpenSearchYaml(testProject, name)
+	yml := getOpenSearchYaml(testProject, name, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/opensearch_test.go
+++ b/tests/opensearch_test.go
@@ -53,7 +53,7 @@ func TestOpenSearch(t *testing.T) {
 
 	// GIVEN
 	name := randName("opensearch")
-	yml := getOpenSearchYaml(testProject, name, testCloudName)
+	yml := getOpenSearchYaml(testProject, name, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/postgresql_test.go
+++ b/tests/postgresql_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getPgReadReplicaYaml(project, masterName, replicaName string) string {
+func getPgReadReplicaYaml(project, masterName, replicaName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: PostgreSQL
@@ -22,7 +22,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[4]s
   plan: startup-4
 
   tags:
@@ -41,7 +41,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[4]s
   plan: startup-4
 
   serviceIntegrations:
@@ -58,7 +58,7 @@ spec:
       pg: true
       prometheus: true
 
-`, project, masterName, replicaName)
+`, project, masterName, replicaName, cloudName)
 }
 
 func TestPgReadReplica(t *testing.T) {
@@ -68,7 +68,7 @@ func TestPgReadReplica(t *testing.T) {
 	// GIVEN
 	masterName := randName("pg-master")
 	replicaName := randName("pg-replica")
-	yml := getPgReadReplicaYaml(testProject, masterName, replicaName)
+	yml := getPgReadReplicaYaml(testProject, masterName, replicaName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/postgresql_test.go
+++ b/tests/postgresql_test.go
@@ -68,7 +68,7 @@ func TestPgReadReplica(t *testing.T) {
 	// GIVEN
 	masterName := randName("pg-master")
 	replicaName := randName("pg-replica")
-	yml := getPgReadReplicaYaml(testProject, masterName, replicaName, testCloudName)
+	yml := getPgReadReplicaYaml(testProject, masterName, replicaName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/projectvpc_test.go
+++ b/tests/projectvpc_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getProjectVPCYaml(project, vpcName string) string {
+func getProjectVPCYaml(project, vpcName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: ProjectVPC
@@ -22,12 +22,12 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west2
+  cloudName: %[3]s
   networkCidr: 10.0.0.0/24
-`, project, vpcName)
+`, project, vpcName, cloudName)
 }
 
-func getKafkaForProjectVPCYaml(project, vpcID, kafkaName string) string {
+func getKafkaForProjectVPCYaml(project, vpcID, kafkaName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Kafka
@@ -39,10 +39,10 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west2
+  cloudName: %[4]s
   plan: startup-2
   projectVpcId: %[2]s
-`, project, vpcID, kafkaName)
+`, project, vpcID, kafkaName, cloudName)
 }
 
 // TestProjectVPCID Kafka.Spec.ProjectVPCID
@@ -53,7 +53,7 @@ func TestProjectVPCID(t *testing.T) {
 
 	// GIVEN
 	vpcName := randName("project-vpc-id")
-	vpcYaml := getProjectVPCYaml(testProject, vpcName)
+	vpcYaml := getProjectVPCYaml(testProject, vpcName, testSecondaryCloudName)
 	vpcSession := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards
@@ -79,7 +79,7 @@ func TestProjectVPCID(t *testing.T) {
 
 	// Creates Kafka with given vpcID
 	kafkaName := randName("project-vpc-id")
-	kafkaYaml := getKafkaForProjectVPCYaml(testProject, vpc.Status.ID, kafkaName)
+	kafkaYaml := getKafkaForProjectVPCYaml(testProject, vpc.Status.ID, kafkaName, testSecondaryCloudName)
 	kafkaSession := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/redis_test.go
+++ b/tests/redis_test.go
@@ -11,7 +11,7 @@ import (
 	redisuserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/redis"
 )
 
-func getRedisYaml(project, name string) string {
+func getRedisYaml(project, name, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Redis
@@ -23,7 +23,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[3]s
   plan: startup-4
 
   tags:
@@ -36,7 +36,7 @@ spec:
         description: bar
       - network: 10.20.0.0/16
 
-`, project, name)
+`, project, name, cloudName)
 }
 
 func TestRedis(t *testing.T) {
@@ -45,7 +45,7 @@ func TestRedis(t *testing.T) {
 
 	// GIVEN
 	name := randName("redis")
-	yml := getRedisYaml(testProject, name)
+	yml := getRedisYaml(testProject, name, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/redis_test.go
+++ b/tests/redis_test.go
@@ -45,7 +45,7 @@ func TestRedis(t *testing.T) {
 
 	// GIVEN
 	name := randName("redis")
-	yml := getRedisYaml(testProject, name, testCloudName)
+	yml := getRedisYaml(testProject, name, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/serviceintegration_test.go
+++ b/tests/serviceintegration_test.go
@@ -81,7 +81,7 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 	pgName := randName("clickhouse-postgresql")
 	siName := randName("clickhouse-postgresql")
 
-	yml := getClickhousePostgreSQLYaml(testProject, chName, pgName, siName, testCloudName)
+	yml := getClickhousePostgreSQLYaml(testProject, chName, pgName, siName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards
@@ -195,7 +195,7 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 	ktName := randName("kafka-logs")
 	siName := randName("kafka-logs")
 
-	yml := getKafkaLogsYaml(testProject, ksName, ktName, siName, testCloudName)
+	yml := getKafkaLogsYaml(testProject, ksName, ktName, siName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards
@@ -314,7 +314,7 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 	kcName := randName("kafka-connect")
 	siName := randName("kafka-connect")
 
-	yml := getSIKafkaConnectYaml(testProject, ksName, kcName, siName, testCloudName)
+	yml := getSIKafkaConnectYaml(testProject, ksName, kcName, siName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards
@@ -421,7 +421,7 @@ func TestServiceIntegrationDatadog(t *testing.T) {
 	pgName := randName("datadog")
 	siName := randName("datadog")
 
-	yml := getDatadogYaml(testProject, pgName, siName, endpointID, testCloudName)
+	yml := getDatadogYaml(testProject, pgName, siName, endpointID, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/serviceintegration_test.go
+++ b/tests/serviceintegration_test.go
@@ -12,7 +12,7 @@ import (
 	datadoguserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/integration/datadog"
 )
 
-func getClickhousePostgreSQLYaml(project, chName, pgName, siName string) string {
+func getClickhousePostgreSQLYaml(project, chName, pgName, siName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Clickhouse
@@ -24,7 +24,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[5]s
   plan: startup-16
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00
@@ -41,7 +41,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[5]s
   plan: startup-4
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00
@@ -69,7 +69,7 @@ spec:
     databases:
       - database: defaultdb
         schema: public
-`, project, chName, pgName, siName)
+`, project, chName, pgName, siName, cloudName)
 }
 
 func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
@@ -81,7 +81,7 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 	pgName := randName("clickhouse-postgresql")
 	siName := randName("clickhouse-postgresql")
 
-	yml := getClickhousePostgreSQLYaml(testProject, chName, pgName, siName)
+	yml := getClickhousePostgreSQLYaml(testProject, chName, pgName, siName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 
@@ -135,7 +135,7 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 	assert.True(t, siAvn.Enabled)
 }
 
-func getKafkaLogsYaml(project, ksName, ktName, siName string) string {
+func getKafkaLogsYaml(project, ksName, ktName, siName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Kafka
@@ -147,7 +147,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[5]s
   plan: business-4
 
 ---
@@ -184,7 +184,7 @@ spec:
 
   kafkaLogs:
     kafka_topic: %[3]s
-`, project, ksName, ktName, siName)
+`, project, ksName, ktName, siName, cloudName)
 }
 
 func TestServiceIntegrationKafkaLogs(t *testing.T) {
@@ -196,7 +196,7 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 	ktName := randName("kafka-logs")
 	siName := randName("kafka-logs")
 
-	yml := getKafkaLogsYaml(testProject, ksName, ktName, siName)
+	yml := getKafkaLogsYaml(testProject, ksName, ktName, siName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 
@@ -247,7 +247,7 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 	assert.Equal(t, ktName, si.Spec.KafkaLogsUserConfig.KafkaTopic)
 }
 
-func getSIKafkaConnectYaml(project, ksName, kcName, siName string) string {
+func getSIKafkaConnectYaml(project, ksName, kcName, siName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Kafka
@@ -259,7 +259,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[5]s
   plan: business-4
 
 ---
@@ -274,7 +274,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[5]s
   plan: business-4
 
   userConfig:
@@ -304,7 +304,7 @@ spec:
       group_id: "connect"
       status_storage_topic: "__connect_status"
       offset_storage_topic: "__connect_offsets"
-`, project, ksName, kcName, siName)
+`, project, ksName, kcName, siName, cloudName)
 }
 
 func TestServiceIntegrationKafkaConnect(t *testing.T) {
@@ -316,7 +316,7 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 	kcName := randName("kafka-connect")
 	siName := randName("kafka-connect")
 
-	yml := getSIKafkaConnectYaml(testProject, ksName, kcName, siName)
+	yml := getSIKafkaConnectYaml(testProject, ksName, kcName, siName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 
@@ -371,7 +371,7 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 	assert.Equal(t, "__connect_offsets", *si.Spec.KafkaConnectUserConfig.KafkaConnect.OffsetStorageTopic)
 }
 
-func getDatadogYaml(project, pgName, siName, endpointID string) string {
+func getDatadogYaml(project, pgName, siName, endpointID, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: PostgreSQL
@@ -383,7 +383,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[5]s
   plan: startup-4
 
 ---
@@ -407,7 +407,7 @@ spec:
     datadog_tags:
       - tag: env
         comment: test
-`, project, pgName, siName, endpointID)
+`, project, pgName, siName, endpointID, cloudName)
 }
 
 // todo: refactor when ServiceIntegrationEndpoint released
@@ -424,7 +424,7 @@ func TestServiceIntegrationDatadog(t *testing.T) {
 	pgName := randName("datadog")
 	siName := randName("datadog")
 
-	yml := getDatadogYaml(testProject, pgName, siName, endpointID)
+	yml := getDatadogYaml(testProject, pgName, siName, endpointID, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/serviceuser_test.go
+++ b/tests/serviceuser_test.go
@@ -55,7 +55,7 @@ func TestServiceUser(t *testing.T) {
 	// GIVEN
 	pgName := randName("connection-pool")
 	userName := randName("connection-pool")
-	yml := getServiceUserYaml(testProject, pgName, userName, testCloudName)
+	yml := getServiceUserYaml(testProject, pgName, userName, testPrimaryCloudName)
 	s := NewSession(k8sClient, avnClient, testProject)
 
 	// Cleans test afterwards

--- a/tests/serviceuser_test.go
+++ b/tests/serviceuser_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-func getServiceUserYaml(project, pgName, userName string) string {
+func getServiceUserYaml(project, pgName, userName, cloudName string) string {
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: PostgreSQL
@@ -22,7 +22,7 @@ spec:
     key: token
 
   project: %[1]s
-  cloudName: google-europe-west1
+  cloudName: %[4]s
   plan: startup-4
 
 ---
@@ -45,7 +45,7 @@ spec:
 
   project: %[1]s
   serviceName: %[2]s
-`, project, pgName, userName)
+`, project, pgName, userName, cloudName)
 }
 
 func TestServiceUser(t *testing.T) {
@@ -55,7 +55,7 @@ func TestServiceUser(t *testing.T) {
 	// GIVEN
 	pgName := randName("connection-pool")
 	userName := randName("connection-pool")
-	yml := getServiceUserYaml(testProject, pgName, userName)
+	yml := getServiceUserYaml(testProject, pgName, userName, testCloudName)
 	s, err := NewSession(k8sClient, avnClient, testProject, yml)
 	require.NoError(t, err)
 

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -24,6 +24,7 @@ import (
 
 var testEnv *envtest.Environment
 var testProject string
+var testCloudName string
 var k8sClient client.Client
 var avnClient *aiven.Client
 
@@ -59,6 +60,11 @@ func setupSuite() error {
 	testProject = os.Getenv("AIVEN_PROJECT_NAME")
 	if testProject == "" {
 		return fmt.Errorf("missing AIVEN_PROJECT_NAME set")
+	}
+
+	testCloudName = os.Getenv("AIVEN_CLOUD_NAME")
+	if testCloudName == "" {
+		testCloudName = "google-europe-west1"
 	}
 
 	enableLogs, _ := strconv.ParseBool(os.Getenv("ENABLE_DEBUG_LOGGING"))

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -24,7 +24,8 @@ import (
 
 var testEnv *envtest.Environment
 var testProject string
-var testCloudName string
+var testPrimaryCloudName string
+var testSecondaryCloudName string
 var k8sClient client.Client
 var avnClient *aiven.Client
 
@@ -62,9 +63,14 @@ func setupSuite() error {
 		return fmt.Errorf("missing AIVEN_PROJECT_NAME set")
 	}
 
-	testCloudName = os.Getenv("AIVEN_CLOUD_NAME")
-	if testCloudName == "" {
-		testCloudName = "google-europe-west1"
+	testPrimaryCloudName = os.Getenv("AIVEN_CLOUD_NAME")
+	if testPrimaryCloudName == "" {
+		testPrimaryCloudName = "google-europe-west1"
+	}
+
+	testSecondaryCloudName = os.Getenv("AIVEN_SECONDARY_CLOUD_NAME")
+	if testSecondaryCloudName == "" {
+		testSecondaryCloudName = "google-europe-west2"
 	}
 
 	enableLogs, _ := strconv.ParseBool(os.Getenv("ENABLE_DEBUG_LOGGING"))


### PR DESCRIPTION
This allows for using other cloud providers in cases where GCP has problems, like the case was today.