### PR TITLE
feat(secrets): use kind name as default secret's prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Fix service tags create/update. Thanks to @mortenlj
+- Add prefix name option for secrets. Thanks to @jordiclariana
+- Use kind name as default prefix for secrets to avoid collisions. Please migrate your applications before legacy names removed
 
 ## v0.11.0 - 2023-04-25
 

--- a/api/v1alpha1/cassandra_types.go
+++ b/api/v1alpha1/cassandra_types.go
@@ -51,6 +51,10 @@ func (in *Cassandra) GetRefs() []*ResourceReferenceObject {
 	return in.Spec.GetRefs(in.GetNamespace())
 }
 
+func (in *Cassandra) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 //+kubebuilder:object:root=true
 
 // CassandraList contains a list of Cassandra

--- a/api/v1alpha1/clickhouse_types.go
+++ b/api/v1alpha1/clickhouse_types.go
@@ -55,6 +55,10 @@ func (in *Clickhouse) GetRefs() []*ResourceReferenceObject {
 	return in.Spec.GetRefs(in.GetNamespace())
 }
 
+func (in *Clickhouse) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 func init() {
 	SchemeBuilder.Register(&Clickhouse{}, &ClickhouseList{})
 }

--- a/api/v1alpha1/clickhouseuser_types.go
+++ b/api/v1alpha1/clickhouseuser_types.go
@@ -55,6 +55,10 @@ func (u ClickhouseUser) AuthSecretRef() *AuthSecretReference {
 	return u.Spec.AuthSecretRef
 }
 
+func (in *ClickhouseUser) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 //+kubebuilder:object:root=true
 
 // ClickhouseUserList contains a list of ClickhouseUser

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -32,6 +32,10 @@ type ConnInfoSecretTarget struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// Labels added to the secret
 	Labels map[string]string `json:"labels,omitempty"`
+	// Prefix for the secret's keys.
+	// Added "as is" without any transformations.
+	// By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+	Prefix string `json:"prefix,omitempty"`
 }
 
 // ServiceStatus defines the observed state of service

--- a/api/v1alpha1/connectionpool_types.go
+++ b/api/v1alpha1/connectionpool_types.go
@@ -69,6 +69,10 @@ func (cp ConnectionPool) AuthSecretRef() *AuthSecretReference {
 	return cp.Spec.AuthSecretRef
 }
 
+func (in *ConnectionPool) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 // +kubebuilder:object:root=true
 
 // ConnectionPoolList contains a list of ConnectionPool

--- a/api/v1alpha1/grafana_types.go
+++ b/api/v1alpha1/grafana_types.go
@@ -51,6 +51,10 @@ func (in *Grafana) GetRefs() []*ResourceReferenceObject {
 	return in.Spec.GetRefs(in.GetNamespace())
 }
 
+func (in *Grafana) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 //+kubebuilder:object:root=true
 
 // GrafanaList contains a list of Grafana

--- a/api/v1alpha1/kafka_types.go
+++ b/api/v1alpha1/kafka_types.go
@@ -53,6 +53,10 @@ func (in *Kafka) GetRefs() []*ResourceReferenceObject {
 	return in.Spec.GetRefs(in.GetNamespace())
 }
 
+func (in *Kafka) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 // +kubebuilder:object:root=true
 
 // KafkaList contains a list of Kafka

--- a/api/v1alpha1/mysql_types.go
+++ b/api/v1alpha1/mysql_types.go
@@ -49,6 +49,10 @@ func (in *MySQL) GetRefs() []*ResourceReferenceObject {
 	return in.Spec.GetRefs(in.GetNamespace())
 }
 
+func (in *MySQL) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 //+kubebuilder:object:root=true
 
 // MySQLList contains a list of MySQL

--- a/api/v1alpha1/opensearch_types.go
+++ b/api/v1alpha1/opensearch_types.go
@@ -55,6 +55,10 @@ func (in *OpenSearch) GetRefs() []*ResourceReferenceObject {
 	return in.Spec.GetRefs(in.GetNamespace())
 }
 
+func (in *OpenSearch) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 func init() {
 	SchemeBuilder.Register(&OpenSearch{}, &OpenSearchList{})
 }

--- a/api/v1alpha1/postgresql_types.go
+++ b/api/v1alpha1/postgresql_types.go
@@ -51,6 +51,10 @@ func (in *PostgreSQL) GetRefs() []*ResourceReferenceObject {
 	return in.Spec.GetRefs(in.GetNamespace())
 }
 
+func (in *PostgreSQL) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 // +kubebuilder:object:root=true
 
 // PostgreSQLList contains a list of PostgreSQL instances

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -102,6 +102,10 @@ func (proj Project) AuthSecretRef() *AuthSecretReference {
 	return proj.Spec.AuthSecretRef
 }
 
+func (in *Project) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 // +kubebuilder:object:root=true
 
 // ProjectList contains a list of Project

--- a/api/v1alpha1/redis_types.go
+++ b/api/v1alpha1/redis_types.go
@@ -47,6 +47,10 @@ func (in *Redis) GetRefs() []*ResourceReferenceObject {
 	return in.Spec.GetRefs(in.GetNamespace())
 }
 
+func (in *Redis) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 //+kubebuilder:object:root=true
 
 // RedisList contains a list of Redis

--- a/api/v1alpha1/serviceuser_types.go
+++ b/api/v1alpha1/serviceuser_types.go
@@ -56,6 +56,10 @@ func (svcusr ServiceUser) AuthSecretRef() *AuthSecretReference {
 	return svcusr.Spec.AuthSecretRef
 }
 
+func (in *ServiceUser) GetConnInfoSecretTarget() ConnInfoSecretTarget {
+	return in.Spec.ConnInfoSecretTarget
+}
+
 // +kubebuilder:object:root=true
 
 // ServiceUserList contains a list of ServiceUser

--- a/charts/aiven-operator-crds/templates/aiven.io_cassandras.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_cassandras.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
@@ -71,6 +71,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhouseusers.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhouseusers.yaml
@@ -77,6 +77,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_connectionpools.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_connectionpools.yaml
@@ -86,6 +86,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_mysqls.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_mysqls.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
@@ -71,6 +71,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_postgresqls.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_postgresqls.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_projects.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_projects.yaml
@@ -113,6 +113,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_redis.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_redis.yaml
@@ -71,6 +71,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_serviceusers.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_serviceusers.yaml
@@ -83,6 +83,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_cassandras.yaml
+++ b/config/crd/bases/aiven.io_cassandras.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_clickhouses.yaml
+++ b/config/crd/bases/aiven.io_clickhouses.yaml
@@ -71,6 +71,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_clickhouseusers.yaml
+++ b/config/crd/bases/aiven.io_clickhouseusers.yaml
@@ -77,6 +77,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_connectionpools.yaml
+++ b/config/crd/bases/aiven.io_connectionpools.yaml
@@ -86,6 +86,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_grafanas.yaml
+++ b/config/crd/bases/aiven.io_grafanas.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_mysqls.yaml
+++ b/config/crd/bases/aiven.io_mysqls.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_opensearches.yaml
+++ b/config/crd/bases/aiven.io_opensearches.yaml
@@ -71,6 +71,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_postgresqls.yaml
+++ b/config/crd/bases/aiven.io_postgresqls.yaml
@@ -84,6 +84,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_projects.yaml
+++ b/config/crd/bases/aiven.io_projects.yaml
@@ -113,6 +113,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_redis.yaml
+++ b/config/crd/bases/aiven.io_redis.yaml
@@ -71,6 +71,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/aiven.io_serviceusers.yaml
+++ b/config/crd/bases/aiven.io_serviceusers.yaml
@@ -83,6 +83,11 @@ spec:
                     description: Name of the secret resource to be created. By default,
                       is equal to the resource name
                     type: string
+                  prefix:
+                    description: Prefix for the secret's keys. Added "as is" without
+                      any transformations. By default, is equal to the kind name in
+                      uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
+                    type: string
                 required:
                 - name
                 type: object

--- a/controllers/cassandra_controller.go
+++ b/controllers/cassandra_controller.go
@@ -68,15 +68,15 @@ func (a *cassandraAdapter) getUserConfig() any {
 
 func (a *cassandraAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
 	stringData := map[string]string{
-		"CASSANDRA_HOST":     s.URIParams["host"],
-		"CASSANDRA_PORT":     s.URIParams["port"],
-		"CASSANDRA_USER":     s.URIParams["user"],
-		"CASSANDRA_PASSWORD": s.URIParams["password"],
-		"CASSANDRA_URI":      s.URI,
-		"CASSANDRA_HOSTS":    strings.Join(s.ConnectionInfo.CassandraHosts, ","),
+		"HOST":     s.URIParams["host"],
+		"PORT":     s.URIParams["port"],
+		"USER":     s.URIParams["user"],
+		"PASSWORD": s.URIParams["password"],
+		"URI":      s.URI,
+		"HOSTS":    strings.Join(s.ConnectionInfo.CassandraHosts, ","),
 	}
 
-	return newSecret(a, a.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(a, stringData, true), nil
 }
 
 func (a *cassandraAdapter) getServiceType() string {

--- a/controllers/clickhouse_controller.go
+++ b/controllers/clickhouse_controller.go
@@ -66,14 +66,20 @@ func (a *clickhouseAdapter) getUserConfig() any {
 }
 
 func (a *clickhouseAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
+	prefix := getSecretPrefix(a)
 	stringData := map[string]string{
+		prefix + "HOST":     s.URIParams["host"],
+		prefix + "PASSWORD": s.URIParams["password"],
+		prefix + "PORT":     s.URIParams["port"],
+		prefix + "USER":     s.URIParams["user"],
+		// todo: remove in future releases
 		"HOST":     s.URIParams["host"],
 		"PASSWORD": s.URIParams["password"],
 		"PORT":     s.URIParams["port"],
 		"USER":     s.URIParams["user"],
 	}
 
-	return newSecret(a, a.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(a, stringData, false), nil
 }
 
 func (a *clickhouseAdapter) getServiceType() string {

--- a/controllers/clickhouseuser_controller.go
+++ b/controllers/clickhouseuser_controller.go
@@ -113,14 +113,20 @@ func (h *clickhouseUserHandler) get(avn *aiven.Client, obj client.Object) (*core
 		return nil, err
 	}
 
+	prefix := getSecretPrefix(user)
 	stringData := map[string]string{
+		prefix + "HOST":     s.URIParams["host"],
+		prefix + "PORT":     s.URIParams["port"],
+		prefix + "PASSWORD": password,
+		prefix + "USERNAME": user.Name,
+		// todo: remove in future releases
 		"HOST":     s.URIParams["host"],
 		"PORT":     s.URIParams["port"],
 		"PASSWORD": password,
 		"USERNAME": user.Name,
 	}
 
-	secret := newSecret(user, user.Spec.ConnInfoSecretTarget, stringData)
+	secret := newSecret(user, stringData, false)
 
 	meta.SetStatusCondition(&user.Status.Conditions,
 		getRunningCondition(metav1.ConditionTrue, "CheckRunning",

--- a/controllers/connectionpool_controller.go
+++ b/controllers/connectionpool_controller.go
@@ -142,7 +142,16 @@ func (h ConnectionPoolHandler) get(avn *aiven.Client, i client.Object) (*corev1.
 			"Instance is running on Aiven side"))
 
 	if len(connPool.Spec.Username) == 0 {
+		prefix := getSecretPrefix(connPool)
 		stringData := map[string]string{
+			prefix + "HOST":         s.URIParams["host"],
+			prefix + "PORT":         s.URIParams["port"],
+			prefix + "DATABASE":     cp.Database,
+			prefix + "USER":         s.URIParams["user"],
+			prefix + "PASSWORD":     s.URIParams["password"],
+			prefix + "SSLMODE":      s.URIParams["sslmode"],
+			prefix + "DATABASE_URI": cp.ConnectionURI,
+			// todo: remove in future releases
 			"PGHOST":       s.URIParams["host"],
 			"PGPORT":       s.URIParams["port"],
 			"PGDATABASE":   cp.Database,
@@ -152,7 +161,7 @@ func (h ConnectionPoolHandler) get(avn *aiven.Client, i client.Object) (*corev1.
 			"DATABASE_URI": cp.ConnectionURI,
 		}
 
-		return newSecret(connPool, connPool.Spec.ConnInfoSecretTarget, stringData), nil
+		return newSecret(connPool, stringData, false), nil
 	}
 
 	u, err := avn.ServiceUsers.Get(connPool.Spec.Project, connPool.Spec.ServiceName, connPool.Spec.Username)
@@ -160,7 +169,16 @@ func (h ConnectionPoolHandler) get(avn *aiven.Client, i client.Object) (*corev1.
 		return nil, fmt.Errorf("cannot get user: %w", err)
 	}
 
+	prefix := getSecretPrefix(connPool)
 	stringData := map[string]string{
+		prefix + "HOST":         s.URIParams["host"],
+		prefix + "PORT":         s.URIParams["port"],
+		prefix + "DATABASE":     cp.Database,
+		prefix + "USER":         cp.Username,
+		prefix + "PASSWORD":     u.Password,
+		prefix + "SSLMODE":      s.URIParams["sslmode"],
+		prefix + "DATABASE_URI": cp.ConnectionURI,
+		// todo: remove in future releases
 		"PGHOST":       s.URIParams["host"],
 		"PGPORT":       s.URIParams["port"],
 		"PGDATABASE":   cp.Database,
@@ -169,7 +187,7 @@ func (h ConnectionPoolHandler) get(avn *aiven.Client, i client.Object) (*corev1.
 		"PGSSLMODE":    s.URIParams["sslmode"],
 		"DATABASE_URI": cp.ConnectionURI,
 	}
-	return newSecret(connPool, connPool.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(connPool, stringData, false), nil
 }
 
 func (h ConnectionPoolHandler) checkPreconditions(avn *aiven.Client, i client.Object) (bool, error) {

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -68,15 +68,15 @@ func (a *grafanaAdapter) getUserConfig() any {
 
 func (a *grafanaAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
 	stringData := map[string]string{
-		"GRAFANA_HOST":     s.URIParams["host"],
-		"GRAFANA_PORT":     s.URIParams["port"],
-		"GRAFANA_USER":     s.URIParams["user"],
-		"GRAFANA_PASSWORD": s.URIParams["password"],
-		"GRAFANA_URI":      s.URI,
-		"GRAFANA_HOSTS":    strings.Join(s.ConnectionInfo.GrafanaURIs, ","),
+		"HOST":     s.URIParams["host"],
+		"PORT":     s.URIParams["port"],
+		"USER":     s.URIParams["user"],
+		"PASSWORD": s.URIParams["password"],
+		"URI":      s.URI,
+		"HOSTS":    strings.Join(s.ConnectionInfo.GrafanaURIs, ","),
 	}
 
-	return newSecret(a, a.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(a, stringData, true), nil
 }
 
 func (a *grafanaAdapter) getServiceType() string {

--- a/controllers/kafka_controller.go
+++ b/controllers/kafka_controller.go
@@ -77,7 +77,16 @@ func (a *kafkaAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
 		return nil, fmt.Errorf("aiven client error %w", err)
 	}
 
+	prefix := getSecretPrefix(a)
 	stringData := map[string]string{
+		prefix + "HOST":        s.URIParams["host"],
+		prefix + "PORT":        s.URIParams["port"],
+		prefix + "PASSWORD":    password,
+		prefix + "USERNAME":    userName,
+		prefix + "ACCESS_CERT": s.ConnectionInfo.KafkaAccessCert,
+		prefix + "ACCESS_KEY":  s.ConnectionInfo.KafkaAccessKey,
+		prefix + "CA_CERT":     caCert,
+		// todo: remove in future releases
 		"HOST":        s.URIParams["host"],
 		"PORT":        s.URIParams["port"],
 		"PASSWORD":    password,
@@ -87,7 +96,7 @@ func (a *kafkaAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
 		"CA_CERT":     caCert,
 	}
 
-	return newSecret(a, a.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(a, stringData, false), nil
 }
 
 func (a *kafkaAdapter) getServiceType() string {

--- a/controllers/mysql_controller.go
+++ b/controllers/mysql_controller.go
@@ -67,17 +67,17 @@ func (a *mySQLAdapter) getUserConfig() any {
 
 func (a *mySQLAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
 	stringData := map[string]string{
-		"MYSQL_HOST":        s.URIParams["host"],
-		"MYSQL_PORT":        s.URIParams["port"],
-		"MYSQL_DATABASE":    s.URIParams["dbname"],
-		"MYSQL_USER":        s.URIParams["user"],
-		"MYSQL_PASSWORD":    s.URIParams["password"],
-		"MYSQL_SSL_MODE":    s.URIParams["ssl-mode"],
-		"MYSQL_URI":         s.URI,
-		"MYSQL_REPLICA_URI": s.ConnectionInfo.MySQLReplicaURI,
+		"HOST":        s.URIParams["host"],
+		"PORT":        s.URIParams["port"],
+		"DATABASE":    s.URIParams["dbname"],
+		"USER":        s.URIParams["user"],
+		"PASSWORD":    s.URIParams["password"],
+		"SSL_MODE":    s.URIParams["ssl-mode"],
+		"URI":         s.URI,
+		"REPLICA_URI": s.ConnectionInfo.MySQLReplicaURI,
 	}
 
-	return newSecret(a, a.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(a, stringData, true), nil
 }
 
 func (a *mySQLAdapter) getServiceType() string {

--- a/controllers/opensearch_controller.go
+++ b/controllers/opensearch_controller.go
@@ -68,14 +68,20 @@ func (a *opensearchAdapter) getUserConfig() any {
 }
 
 func (a *opensearchAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
+	prefix := getSecretPrefix(a)
 	stringData := map[string]string{
+		prefix + "HOST":     s.URIParams["host"],
+		prefix + "PASSWORD": s.URIParams["password"],
+		prefix + "PORT":     s.URIParams["port"],
+		prefix + "USER":     s.URIParams["user"],
+		// todo: remove in future releases
 		"HOST":     s.URIParams["host"],
 		"PASSWORD": s.URIParams["password"],
 		"PORT":     s.URIParams["port"],
 		"USER":     s.URIParams["user"],
 	}
 
-	return newSecret(a, a.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(a, stringData, false), nil
 }
 
 func (a *opensearchAdapter) getServiceType() string {

--- a/controllers/postgresql_controller.go
+++ b/controllers/postgresql_controller.go
@@ -65,7 +65,16 @@ func (a *postgresSQLAdapter) getUserConfig() any {
 }
 
 func (a *postgresSQLAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
+	prefix := getSecretPrefix(a)
 	stringData := map[string]string{
+		prefix + "HOST":         s.URIParams["host"],
+		prefix + "PORT":         s.URIParams["port"],
+		prefix + "DATABASE":     s.URIParams["dbname"],
+		prefix + "USER":         s.URIParams["user"],
+		prefix + "PASSWORD":     s.URIParams["password"],
+		prefix + "SSLMODE":      s.URIParams["sslmode"],
+		prefix + "DATABASE_URI": s.URI,
+		// todo: remove in future releases
 		"PGHOST":       s.URIParams["host"],
 		"PGPORT":       s.URIParams["port"],
 		"PGDATABASE":   s.URIParams["dbname"],
@@ -75,7 +84,7 @@ func (a *postgresSQLAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error)
 		"DATABASE_URI": s.URI,
 	}
 
-	return newSecret(a, a.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(a, stringData, false), nil
 }
 
 func (a *postgresSQLAdapter) getServiceType() string {

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -167,10 +167,13 @@ func (h ProjectHandler) get(avn *aiven.Client, i client.Object) (*corev1.Secret,
 
 	metav1.SetMetaDataAnnotation(&project.ObjectMeta, instanceIsRunningAnnotation, "true")
 
+	prefix := getSecretPrefix(project)
 	stringData := map[string]string{
+		prefix + "CA_CERT": cert,
+		// todo: remove in future releases
 		"CA_CERT": cert,
 	}
-	return newSecret(project, project.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(project, stringData, false), nil
 }
 
 // exists checks if project already exists on Aiven side

--- a/controllers/redis_controller.go
+++ b/controllers/redis_controller.go
@@ -68,7 +68,14 @@ func (a *redisAdapter) getUserConfig() any {
 }
 
 func (a *redisAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
+	prefix := getSecretPrefix(a)
 	stringData := map[string]string{
+		prefix + "HOST":     s.URIParams["host"],
+		prefix + "PASSWORD": s.URIParams["password"],
+		prefix + "PORT":     s.URIParams["port"],
+		prefix + "SSL":      s.URIParams["ssl"],
+		prefix + "USER":     s.URIParams["user"],
+		// todo: remove in future releases
 		"HOST":     s.URIParams["host"],
 		"PASSWORD": s.URIParams["password"],
 		"PORT":     s.URIParams["port"],
@@ -76,7 +83,7 @@ func (a *redisAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
 		"USER":     s.URIParams["user"],
 	}
 
-	return newSecret(a, a.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(a, stringData, false), nil
 }
 
 func (a *redisAdapter) getServiceType() string {

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -119,7 +119,16 @@ func (h ServiceUserHandler) get(avn *aiven.Client, i client.Object) (*corev1.Sec
 
 	metav1.SetMetaDataAnnotation(&user.ObjectMeta, instanceIsRunningAnnotation, "true")
 
+	prefix := getSecretPrefix(user)
 	stringData := map[string]string{
+		prefix + "HOST":        params["host"],
+		prefix + "PORT":        params["port"],
+		prefix + "USERNAME":    u.Username,
+		prefix + "PASSWORD":    u.Password,
+		prefix + "ACCESS_CERT": u.AccessCert,
+		prefix + "ACCESS_KEY":  u.AccessKey,
+		prefix + "CA_CERT":     caCert,
+		// todo: remove in future releases
 		"HOST":        params["host"],
 		"PORT":        params["port"],
 		"USERNAME":    u.Username,
@@ -129,7 +138,7 @@ func (h ServiceUserHandler) get(avn *aiven.Client, i client.Object) (*corev1.Sec
 		"CA_CERT":     caCert,
 	}
 
-	return newSecret(user, user.Spec.ConnInfoSecretTarget, stringData), nil
+	return newSecret(user, stringData, false), nil
 }
 
 func (h ServiceUserHandler) checkPreconditions(avn *aiven.Client, i client.Object) (bool, error) {

--- a/docs/docs/api-reference/cassandra.md
+++ b/docs/docs/api-reference/cassandra.md
@@ -100,6 +100,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/clickhouse.md
+++ b/docs/docs/api-reference/clickhouse.md
@@ -91,6 +91,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/clickhouseuser.md
+++ b/docs/docs/api-reference/clickhouseuser.md
@@ -70,4 +70,5 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 

--- a/docs/docs/api-reference/connectionpool.md
+++ b/docs/docs/api-reference/connectionpool.md
@@ -78,4 +78,5 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 

--- a/docs/docs/api-reference/grafana.md
+++ b/docs/docs/api-reference/grafana.md
@@ -99,6 +99,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/kafka.md
+++ b/docs/docs/api-reference/kafka.md
@@ -92,6 +92,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/mysql.md
+++ b/docs/docs/api-reference/mysql.md
@@ -99,6 +99,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/opensearch.md
+++ b/docs/docs/api-reference/opensearch.md
@@ -92,6 +92,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/postgresql.md
+++ b/docs/docs/api-reference/postgresql.md
@@ -94,6 +94,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/project.md
+++ b/docs/docs/api-reference/project.md
@@ -80,4 +80,5 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 

--- a/docs/docs/api-reference/redis.md
+++ b/docs/docs/api-reference/redis.md
@@ -94,6 +94,7 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 
 ## projectVPCRef {: #spec.projectVPCRef }
 

--- a/docs/docs/api-reference/serviceuser.md
+++ b/docs/docs/api-reference/serviceuser.md
@@ -71,4 +71,5 @@ Information regarding secret creation.
 
 - [`annotations`](#spec.connInfoSecretTarget.annotations-property){: name='spec.connInfoSecretTarget.annotations-property'} (object, AdditionalProperties: string). Annotations added to the secret.
 - [`labels`](#spec.connInfoSecretTarget.labels-property){: name='spec.connInfoSecretTarget.labels-property'} (object, AdditionalProperties: string). Labels added to the secret.
+- [`prefix`](#spec.connInfoSecretTarget.prefix-property){: name='spec.connInfoSecretTarget.prefix-property'} (string). Prefix for the secret's keys. Added "as is" without any transformations. By default, is equal to the kind name in uppercase + underscore, e.g. `KAFKA_`, `REDIS_`, etc.
 

--- a/tests/clickhouse_test.go
+++ b/tests/clickhouse_test.go
@@ -98,4 +98,10 @@ func TestClickhouse(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["PORT"])
 	assert.NotEmpty(t, secret.Data["USER"])
 	assert.NotEmpty(t, secret.Data["PASSWORD"])
+
+	// New secrets
+	assert.NotEmpty(t, secret.Data["CLICKHOUSE_HOST"])
+	assert.NotEmpty(t, secret.Data["CLICKHOUSE_PORT"])
+	assert.NotEmpty(t, secret.Data["CLICKHOUSE_USER"])
+	assert.NotEmpty(t, secret.Data["CLICKHOUSE_PASSWORD"])
 }

--- a/tests/clickhouseuser_test.go
+++ b/tests/clickhouseuser_test.go
@@ -93,6 +93,10 @@ func TestClickhouseUser(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["PORT"])
 	assert.NotEmpty(t, secret.Data["PASSWORD"])
 	assert.NotEmpty(t, secret.Data["USERNAME"])
+	assert.NotEmpty(t, secret.Data["CLICKHOUSEUSER_HOST"])
+	assert.NotEmpty(t, secret.Data["CLICKHOUSEUSER_PORT"])
+	assert.NotEmpty(t, secret.Data["CLICKHOUSEUSER_PASSWORD"])
+	assert.NotEmpty(t, secret.Data["CLICKHOUSEUSER_USERNAME"])
 	assert.Equal(t, map[string]string{"foo": "bar"}, secret.Annotations)
 	assert.Equal(t, map[string]string{"baz": "egg"}, secret.Labels)
 

--- a/tests/connectionpool_test.go
+++ b/tests/connectionpool_test.go
@@ -154,6 +154,15 @@ func TestConnectionPool(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["PGSSLMODE"])
 	assert.NotEmpty(t, secret.Data["DATABASE_URI"])
 
+	// New secrets
+	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_HOST"])
+	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_PORT"])
+	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_DATABASE"])
+	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_USER"])
+	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_PASSWORD"])
+	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_SSLMODE"])
+	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_DATABASE_URI"])
+
 	// We need to validate deletion,
 	// because we can get false positive here:
 	// if service is deleted, pool is destroyed in Aiven. No service — no pool. No pool — no pool.

--- a/tests/kafka_test.go
+++ b/tests/kafka_test.go
@@ -109,4 +109,12 @@ func TestKafka(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["PASSWORD"])
 	assert.NotEmpty(t, secret.Data["ACCESS_CERT"])
 	assert.NotEmpty(t, secret.Data["ACCESS_KEY"])
+
+	// New secrets
+	assert.NotEmpty(t, secret.Data["KAFKA_HOST"])
+	assert.NotEmpty(t, secret.Data["KAFKA_PORT"])
+	assert.NotEmpty(t, secret.Data["KAFKA_USERNAME"])
+	assert.NotEmpty(t, secret.Data["KAFKA_PASSWORD"])
+	assert.NotEmpty(t, secret.Data["KAFKA_ACCESS_CERT"])
+	assert.NotEmpty(t, secret.Data["KAFKA_ACCESS_KEY"])
 }

--- a/tests/opensearch_test.go
+++ b/tests/opensearch_test.go
@@ -108,6 +108,10 @@ func TestOpenSearch(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["PORT"])
 	assert.NotEmpty(t, secret.Data["USER"])
 	assert.NotEmpty(t, secret.Data["PASSWORD"])
+	assert.NotEmpty(t, secret.Data["OPENSEARCH_HOST"])
+	assert.NotEmpty(t, secret.Data["OPENSEARCH_PORT"])
+	assert.NotEmpty(t, secret.Data["OPENSEARCH_USER"])
+	assert.NotEmpty(t, secret.Data["OPENSEARCH_PASSWORD"])
 	assert.Equal(t, map[string]string{"foo": "bar"}, secret.Annotations)
 	assert.Equal(t, map[string]string{"baz": "egg"}, secret.Labels)
 }

--- a/tests/postgresql_test.go
+++ b/tests/postgresql_test.go
@@ -138,5 +138,14 @@ func TestPgReadReplica(t *testing.T) {
 		assert.NotEmpty(t, secret.Data["PGPASSWORD"])
 		assert.NotEmpty(t, secret.Data["PGSSLMODE"])
 		assert.NotEmpty(t, secret.Data["DATABASE_URI"])
+
+		// New secrets
+		assert.NotEmpty(t, secret.Data["POSTGRESQL_HOST"])
+		assert.NotEmpty(t, secret.Data["POSTGRESQL_PORT"])
+		assert.NotEmpty(t, secret.Data["POSTGRESQL_DATABASE"])
+		assert.NotEmpty(t, secret.Data["POSTGRESQL_USER"])
+		assert.NotEmpty(t, secret.Data["POSTGRESQL_PASSWORD"])
+		assert.NotEmpty(t, secret.Data["POSTGRESQL_SSLMODE"])
+		assert.NotEmpty(t, secret.Data["POSTGRESQL_DATABASE_URI"])
 	}
 }

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -63,4 +63,5 @@ func TestProject(t *testing.T) {
 	secret, err := s.GetSecret(project.GetName())
 	require.NoError(t, err)
 	assert.NotEmpty(t, secret.Data["CA_CERT"])
+	assert.NotEmpty(t, secret.Data["PROJECT_CA_CERT"])
 }

--- a/tests/redis_test.go
+++ b/tests/redis_test.go
@@ -98,4 +98,10 @@ func TestRedis(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["PORT"])
 	assert.NotEmpty(t, secret.Data["USER"])
 	assert.NotEmpty(t, secret.Data["PASSWORD"])
+
+	// New secrets
+	assert.NotEmpty(t, secret.Data["REDIS_HOST"])
+	assert.NotEmpty(t, secret.Data["REDIS_PORT"])
+	assert.NotEmpty(t, secret.Data["REDIS_USER"])
+	assert.NotEmpty(t, secret.Data["REDIS_PASSWORD"])
 }


### PR DESCRIPTION
Use kind name as prefix for secrets to avoid collisions.
Old secrets will be removed in future releases.