### PR TITLE
feat: allow optional installation of cluster role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add `annotations` and `labels` fields to `connInfoSecretTarget`
 - Allow to disable capabilities check to install webhooks. Thanks to @amstee
 - Set `OpenSearch.spec.userConfig.opensearch.search_max_buckets` maximum to `65536`
+- Add `clusterRole.create` option to Helm chart
 
 ## v0.10.0 - 2023-04-17
 

--- a/charts/aiven-operator/templates/cluster_role.yaml
+++ b/charts/aiven-operator/templates/cluster_role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clusterRole.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -602,3 +603,4 @@ rules:
       - get
       - list
       - update
+{{- end }}

--- a/charts/aiven-operator/templates/cluster_role_binding.yaml
+++ b/charts/aiven-operator/templates/cluster_role_binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clusterRole.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "aiven-operator.serviceAccountName" . }}
   namespace: {{ include "aiven-operator.namespace" . }}
+{{- end }}

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -77,3 +77,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+clusterRole:
+  create: true

--- a/docs/docs/installation/helm.md
+++ b/docs/docs/installation/helm.md
@@ -67,6 +67,9 @@ helm install aiven-operator aiven/aiven-operator --set webhooks.enabled=false
 
 Please refer to the [values.yaml](https://github.com/aiven/aiven-charts/blob/main/charts/aiven-operator/values.yaml) of the chart.
 
+#### Installing without full cluster administrator access
+There can be some scenarios where the individual installing the Helm chart does not have the ability to provision cluster-wide resources (e.g. ClusterRoles/ClusterRoleBindings). In this scenario, you can have a cluster administrator manually install the [ClusterRole](../../../charts/aiven-operator/templates/cluster_role.yaml) and [ClusterRoleBinding](../../../charts/aiven-operator/templates/cluster_role_binding.yaml) the operator requires prior to installing the Helm chart specifying `false` for the `clusterRole.create` attribute. 
+
 ## Uninstalling 
 
 !!! important


### PR DESCRIPTION
This change allows the Helm chart be installed without including the creation of cluster-wide resources (ClusterRoles/ClusterRoleBindings). Specifically, this change supports the use case where the engineer installing the chart has limited (i.e. namespace only) access and cannot install cluster-wide resources. This change allows the cluster-wide resources to be installed separately by cluster administrators while still allowing the engineers to manage the operator itself without having full cluster-wide access.

It is understood that if `clusterRole.create=false` is set without the cluster role/cluster role binding being installed beforehand the operator will not function as expected but this gives the option to have the namespaced resources installed/managed by individuals with namepace-only access without giving access to create cluster-wide resources.