### PR TITLE
ci(commitlint): ignore dependabot's commit messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    extends: ["@commitlint/config-conventional"],
+    ignores: [(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
+};


### PR DESCRIPTION
makes `commitlint` ignore depenadbot's commit messages

should be removed when https://github.com/dependabot/dependabot-core/issues/2445 is resolved
