### PR TITLE
fix: make conditions and state optional attributes of service status

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -41,10 +41,10 @@ type ConnInfoSecretTarget struct {
 // ServiceStatus defines the observed state of service
 type ServiceStatus struct {
 	// Conditions represent the latest available observations of a service state
-	Conditions []metav1.Condition `json:"conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Service state
-	State string `json:"state"`
+	State string `json:"state,omitempty"`
 }
 
 type ServiceCommonSpec struct {

--- a/charts/aiven-operator-crds/templates/aiven.io_cassandras.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_cassandras.yaml
@@ -375,9 +375,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
@@ -298,9 +298,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
@@ -791,9 +791,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkaconnects.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkaconnects.yaml
@@ -425,9 +425,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
@@ -887,9 +887,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/charts/aiven-operator-crds/templates/aiven.io_mysqls.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_mysqls.yaml
@@ -666,9 +666,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
@@ -735,9 +735,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/charts/aiven-operator-crds/templates/aiven.io_postgresqls.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_postgresqls.yaml
@@ -934,9 +934,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/charts/aiven-operator-crds/templates/aiven.io_redis.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_redis.yaml
@@ -471,9 +471,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/config/crd/bases/aiven.io_cassandras.yaml
+++ b/config/crd/bases/aiven.io_cassandras.yaml
@@ -375,9 +375,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/config/crd/bases/aiven.io_clickhouses.yaml
+++ b/config/crd/bases/aiven.io_clickhouses.yaml
@@ -298,9 +298,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/config/crd/bases/aiven.io_grafanas.yaml
+++ b/config/crd/bases/aiven.io_grafanas.yaml
@@ -791,9 +791,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/config/crd/bases/aiven.io_kafkaconnects.yaml
+++ b/config/crd/bases/aiven.io_kafkaconnects.yaml
@@ -425,9 +425,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -887,9 +887,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/config/crd/bases/aiven.io_mysqls.yaml
+++ b/config/crd/bases/aiven.io_mysqls.yaml
@@ -666,9 +666,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/config/crd/bases/aiven.io_opensearches.yaml
+++ b/config/crd/bases/aiven.io_opensearches.yaml
@@ -735,9 +735,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/config/crd/bases/aiven.io_postgresqls.yaml
+++ b/config/crd/bases/aiven.io_postgresqls.yaml
@@ -934,9 +934,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true

--- a/config/crd/bases/aiven.io_redis.yaml
+++ b/config/crd/bases/aiven.io_redis.yaml
@@ -471,9 +471,6 @@ spec:
               state:
                 description: Service state
                 type: string
-            required:
-            - conditions
-            - state
             type: object
         type: object
     served: true


### PR DESCRIPTION
In some cases, the someone might attempt to pass an object with a `status` attribute, but with no `conditions` or `state`.
When attempting to read such objects you may encounter errors about the missing attributes.
When marking them with `omitempty`, the generated schema will no longer consider these attributes required, which probably is more correct, and allows parsers to correctly parse these objects.

