### PR TITLE
fix(kafka): remove prometheus port expose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
-- Expose `KAFKA_SCHEMA_REGISTRY_PORT` for `Kafka` kind if `schema_registry` is enabled
-- Expose `KAFKA_CONNECT_PORT` for `Kafka`
-- Expose `KAFKA_REST_PORT` for `Kafka`
-- Expose `KAFKA_PROMETHEUS_PORT` for `Kafka`
+- Expose `KAFKA_SCHEMA_REGISTRY_HOST` and `KAFKA_SCHEMA_REGISTRY_PORT` for `Kafka`
+- Expose `KAFKA_CONNECT_HOST`, `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST` and `KAFKA_REST_PORT` for `Kafka`. Thanks to @Dariusch
 
 ## v0.12.2 - 2023-06-20
 

--- a/api/v1alpha1/kafka_types.go
+++ b/api/v1alpha1/kafka_types.go
@@ -20,7 +20,7 @@ type KafkaSpec struct {
 	AuthSecretRef *AuthSecretReference `json:"authSecretRef,omitempty"`
 
 	// Information regarding secret creation.
-	// Exposed keys: `KAFKA_HOST`, `KAFKA_PORT`, `KAFKA_USERNAME`, `KAFKA_PASSWORD`, `KAFKA_ACCESS_CERT`, `KAFKA_ACCESS_KEY`, `KAFKA_SASL_HOST`, `KAFKA_SASL_PORT`, `KAFKA_SCHEMA_REGISTRY_HOST`, `KAFKA_SCHEMA_REGISTRY_PORT`, `KAFKA_CONNECT_HOST`, `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`, `KAFKA_PROMETHEUS_HOST`, `KAFKA_PROMETHEUS_PORT`
+	// Exposed keys: `KAFKA_HOST`, `KAFKA_PORT`, `KAFKA_USERNAME`, `KAFKA_PASSWORD`, `KAFKA_ACCESS_CERT`, `KAFKA_ACCESS_KEY`, `KAFKA_SASL_HOST`, `KAFKA_SASL_PORT`, `KAFKA_SCHEMA_REGISTRY_HOST`, `KAFKA_SCHEMA_REGISTRY_PORT`, `KAFKA_CONNECT_HOST`, `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`
 
 	// Switch the service to use Karapace for schema registry and REST proxy

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
@@ -70,8 +70,7 @@ spec:
                   `KAFKA_HOST`, `KAFKA_PORT`, `KAFKA_USERNAME`, `KAFKA_PASSWORD`,
                   `KAFKA_ACCESS_CERT`, `KAFKA_ACCESS_KEY`, `KAFKA_SASL_HOST`, `KAFKA_SASL_PORT`,
                   `KAFKA_SCHEMA_REGISTRY_HOST`, `KAFKA_SCHEMA_REGISTRY_PORT`, `KAFKA_CONNECT_HOST`,
-                  `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`, `KAFKA_PROMETHEUS_HOST`,
-                  `KAFKA_PROMETHEUS_PORT`'
+                  `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`'
                 properties:
                   annotations:
                     additionalProperties:

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -70,8 +70,7 @@ spec:
                   `KAFKA_HOST`, `KAFKA_PORT`, `KAFKA_USERNAME`, `KAFKA_PASSWORD`,
                   `KAFKA_ACCESS_CERT`, `KAFKA_ACCESS_KEY`, `KAFKA_SASL_HOST`, `KAFKA_SASL_PORT`,
                   `KAFKA_SCHEMA_REGISTRY_HOST`, `KAFKA_SCHEMA_REGISTRY_PORT`, `KAFKA_CONNECT_HOST`,
-                  `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`, `KAFKA_PROMETHEUS_HOST`,
-                  `KAFKA_PROMETHEUS_PORT`'
+                  `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`'
                 properties:
                   annotations:
                     additionalProperties:

--- a/controllers/kafka_controller.go
+++ b/controllers/kafka_controller.go
@@ -113,9 +113,6 @@ func (a *kafkaAdapter) newSecret(s *aiven.Service) (*corev1.Secret, error) {
 		case "kafka_rest":
 			stringData[prefix+"REST_HOST"] = c.Host
 			stringData[prefix+"REST_PORT"] = strconv.Itoa(c.Port)
-		case "prometheus":
-			stringData[prefix+"PROMETHEUS_HOST"] = c.Host
-			stringData[prefix+"PROMETHEUS_PORT"] = strconv.Itoa(c.Port)
 		}
 	}
 

--- a/docs/docs/api-reference/kafka.md
+++ b/docs/docs/api-reference/kafka.md
@@ -56,7 +56,7 @@ KafkaSpec defines the desired state of Kafka.
 
 - [`authSecretRef`](#spec.authSecretRef-property){: name='spec.authSecretRef-property'} (object). Authentication reference to Aiven token in a secret. See below for [nested schema](#spec.authSecretRef).
 - [`cloudName`](#spec.cloudName-property){: name='spec.cloudName-property'} (string, MaxLength: 256). Cloud the service runs in.
-- [`connInfoSecretTarget`](#spec.connInfoSecretTarget-property){: name='spec.connInfoSecretTarget-property'} (object). Information regarding secret creation. Exposed keys: `KAFKA_HOST`, `KAFKA_PORT`, `KAFKA_USERNAME`, `KAFKA_PASSWORD`, `KAFKA_ACCESS_CERT`, `KAFKA_ACCESS_KEY`, `KAFKA_SASL_HOST`, `KAFKA_SASL_PORT`, `KAFKA_SCHEMA_REGISTRY_HOST`, `KAFKA_SCHEMA_REGISTRY_PORT`, `KAFKA_CONNECT_HOST`, `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`, `KAFKA_PROMETHEUS_HOST`, `KAFKA_PROMETHEUS_PORT`. See below for [nested schema](#spec.connInfoSecretTarget).
+- [`connInfoSecretTarget`](#spec.connInfoSecretTarget-property){: name='spec.connInfoSecretTarget-property'} (object). Information regarding secret creation. Exposed keys: `KAFKA_HOST`, `KAFKA_PORT`, `KAFKA_USERNAME`, `KAFKA_PASSWORD`, `KAFKA_ACCESS_CERT`, `KAFKA_ACCESS_KEY`, `KAFKA_SASL_HOST`, `KAFKA_SASL_PORT`, `KAFKA_SCHEMA_REGISTRY_HOST`, `KAFKA_SCHEMA_REGISTRY_PORT`, `KAFKA_CONNECT_HOST`, `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`. See below for [nested schema](#spec.connInfoSecretTarget).
 - [`disk_space`](#spec.disk_space-property){: name='spec.disk_space-property'} (string). The disk space of the service, possible values depend on the service type, the cloud provider and the project. Reducing will result in the service re-balancing.
 - [`karapace`](#spec.karapace-property){: name='spec.karapace-property'} (boolean). Switch the service to use Karapace for schema registry and REST proxy.
 - [`maintenanceWindowDow`](#spec.maintenanceWindowDow-property){: name='spec.maintenanceWindowDow-property'} (string, Enum: `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`). Day of week when maintenance operations should be performed. One monday, tuesday, wednesday, etc.
@@ -83,7 +83,7 @@ Authentication reference to Aiven token in a secret.
 
 _Appears on [`spec`](#spec)._
 
-Information regarding secret creation. Exposed keys: `KAFKA_HOST`, `KAFKA_PORT`, `KAFKA_USERNAME`, `KAFKA_PASSWORD`, `KAFKA_ACCESS_CERT`, `KAFKA_ACCESS_KEY`, `KAFKA_SASL_HOST`, `KAFKA_SASL_PORT`, `KAFKA_SCHEMA_REGISTRY_HOST`, `KAFKA_SCHEMA_REGISTRY_PORT`, `KAFKA_CONNECT_HOST`, `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`, `KAFKA_PROMETHEUS_HOST`, `KAFKA_PROMETHEUS_PORT`.
+Information regarding secret creation. Exposed keys: `KAFKA_HOST`, `KAFKA_PORT`, `KAFKA_USERNAME`, `KAFKA_PASSWORD`, `KAFKA_ACCESS_CERT`, `KAFKA_ACCESS_KEY`, `KAFKA_SASL_HOST`, `KAFKA_SASL_PORT`, `KAFKA_SCHEMA_REGISTRY_HOST`, `KAFKA_SCHEMA_REGISTRY_PORT`, `KAFKA_CONNECT_HOST`, `KAFKA_CONNECT_PORT`, `KAFKA_REST_HOST`, `KAFKA_REST_PORT`.
 
 **Required**
 

--- a/tests/kafka_test.go
+++ b/tests/kafka_test.go
@@ -133,22 +133,16 @@ func TestKafka(t *testing.T) {
 	assert.NotEqual(t, secret.Data["KAFKA_SCHEMA_REGISTRY_PORT"], secret.Data["KAFKA_SASL_PORT"])
 
 	// Kafka Connect test
-	assert.Equal(t, anyPointer(true), ks.Spec.UserConfig.KafkaConnectConfig)
+	assert.Equal(t, anyPointer(true), ks.Spec.UserConfig.KafkaConnect)
 	assert.NotEmpty(t, secret.Data["KAFKA_CONNECT_HOST"])
 	assert.NotEmpty(t, secret.Data["KAFKA_CONNECT_PORT"])
 	assert.NotEqual(t, secret.Data["KAFKA_CONNECT_PORT"], secret.Data["KAFKA_PORT"])
 	assert.NotEqual(t, secret.Data["KAFKA_CONNECT_PORT"], secret.Data["KAFKA_SASL_PORT"])
 
 	// Kafka REST test
-	assert.Equal(t, anyPointer(true), ks.Spec.UserConfig.KafkaRestConfig)
+	assert.Equal(t, anyPointer(true), ks.Spec.UserConfig.KafkaRest)
 	assert.NotEmpty(t, secret.Data["KAFKA_REST_HOST"])
 	assert.NotEmpty(t, secret.Data["KAFKA_REST_PORT"])
 	assert.NotEqual(t, secret.Data["KAFKA_REST_PORT"], secret.Data["KAFKA_PORT"])
 	assert.NotEqual(t, secret.Data["KAFKA_REST_PORT"], secret.Data["KAFKA_SASL_PORT"])
-
-	// Prometheus test
-	assert.NotEmpty(t, secret.Data["KAFKA_PROMETHEUS_HOST"])
-	assert.NotEmpty(t, secret.Data["KAFKA_PROMETHEUS_PORT"])
-	assert.NotEqual(t, secret.Data["KAFKA_PROMETHEUS_PORT"], secret.Data["KAFKA_PORT"])
-	assert.NotEqual(t, secret.Data["KAFKA_PROMETHEUS_PORT"], secret.Data["KAFKA_SASL_PORT"])
 }


### PR DESCRIPTION
Requires integration endpoint support. Related to #439 