### PR TITLE
feat: implement error-conditions

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -22,6 +22,7 @@ import (
 const (
 	conditionTypeRunning     = "Running"
 	conditionTypeInitialized = "Initialized"
+	conditionTypeError       = "Error"
 
 	secretProtectionFinalizer = "finalizers.aiven.io/needed-to-delete-services"
 	instanceDeletionFinalizer = "finalizers.aiven.io/delete-remote-resource"
@@ -44,6 +45,7 @@ func checkServiceIsRunning(ctx context.Context, c *aiven.Client, project, servic
 	if err != nil {
 		// if service is not found, it is not running
 		if aiven.IsNotFound(err) {
+			// this will swallow an error if the project doesn't exist and object is not project
 			return false, nil
 		}
 		return false, err
@@ -66,6 +68,15 @@ func getRunningCondition(status metav1.ConditionStatus, reason, message string) 
 		Status:  status,
 		Reason:  reason,
 		Message: message,
+	}
+}
+
+func getErrorCondition(reason string, err error) metav1.Condition {
+	return metav1.Condition{
+		Type:    conditionTypeError,
+		Status:  metav1.ConditionUnknown,
+		Reason:  reason,
+		Message: err.Error(),
 	}
 }
 

--- a/controllers/connectionpool_controller.go
+++ b/controllers/connectionpool_controller.go
@@ -48,6 +48,7 @@ func (h ConnectionPoolHandler) createOrUpdate(ctx context.Context, avn *aiven.Cl
 
 	exists, err := h.exists(ctx, avn, cp)
 	if err != nil {
+		meta.SetStatusCondition(&cp.Status.Conditions, getErrorCondition("CheckExists", err))
 		return err
 	}
 	var reason string
@@ -61,6 +62,7 @@ func (h ConnectionPoolHandler) createOrUpdate(ctx context.Context, avn *aiven.Cl
 				Username: optionalStringPointer(cp.Spec.Username),
 			})
 		if err != nil && !aiven.IsAlreadyExists(err) {
+			meta.SetStatusCondition(&cp.Status.Conditions, getErrorCondition("Create", err))
 			return err
 		}
 		reason = "Created"
@@ -73,6 +75,7 @@ func (h ConnectionPoolHandler) createOrUpdate(ctx context.Context, avn *aiven.Cl
 				Username: optionalStringPointer(cp.Spec.Username),
 			})
 		if err != nil {
+			meta.SetStatusCondition(&cp.Status.Conditions, getErrorCondition("Update", err))
 			return err
 		}
 		reason = "Updated"
@@ -100,6 +103,7 @@ func (h ConnectionPoolHandler) delete(ctx context.Context, avn *aiven.Client, ob
 
 	err = avn.ConnectionPools.Delete(ctx, cp.Spec.Project, cp.Spec.ServiceName, cp.Name)
 	if err != nil && !aiven.IsNotFound(err) {
+		meta.SetStatusCondition(&cp.Status.Conditions, getErrorCondition("Delete", err))
 		return false, err
 	}
 
@@ -200,6 +204,7 @@ func (h ConnectionPoolHandler) checkPreconditions(ctx context.Context, avn *aive
 
 	check, err := checkServiceIsRunning(ctx, avn, cp.Spec.Project, cp.Spec.ServiceName)
 	if err != nil {
+		meta.SetStatusCondition(&cp.Status.Conditions, getErrorCondition("Preconditions", err))
 		return false, err
 	}
 

--- a/controllers/kafkaacl_controller.go
+++ b/controllers/kafkaacl_controller.go
@@ -48,6 +48,7 @@ func (h KafkaACLHandler) createOrUpdate(ctx context.Context, avn *aiven.Client, 
 	// Tries to delete it instead
 	_, err = h.delete(ctx, avn, obj)
 	if err != nil {
+		meta.SetStatusCondition(&acl.Status.Conditions, getErrorCondition("Delete", err))
 		return err
 	}
 
@@ -160,7 +161,11 @@ func (h KafkaACLHandler) checkPreconditions(ctx context.Context, avn *aiven.Clie
 	meta.SetStatusCondition(&acl.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsRunning(ctx, avn, acl.Spec.Project, acl.Spec.ServiceName)
+	running, err := checkServiceIsRunning(ctx, avn, acl.Spec.Project, acl.Spec.ServiceName)
+	if err != nil {
+		meta.SetStatusCondition(&acl.Status.Conditions, getErrorCondition("Delete", err))
+	}
+	return running, err
 }
 
 func (h KafkaACLHandler) convert(i client.Object) (*v1alpha1.KafkaACL, error) {

--- a/controllers/kafkaconnector_controller.go
+++ b/controllers/kafkaconnector_controller.go
@@ -52,11 +52,13 @@ func (h KafkaConnectorHandler) createOrUpdate(ctx context.Context, avn *aiven.Cl
 
 	exists, err := h.exists(ctx, avn, conn)
 	if err != nil {
+		meta.SetStatusCondition(&conn.Status.Conditions, getErrorCondition("CheckExists", err))
 		return fmt.Errorf("unable to check if kafka connector exists: %w", err)
 	}
 
 	connCfg, err := h.buildConnectorConfig(conn)
 	if err != nil {
+		meta.SetStatusCondition(&conn.Status.Conditions, getErrorCondition("BuildConfig", err))
 		return fmt.Errorf("unable to build connector config: %w", err)
 	}
 
@@ -64,12 +66,14 @@ func (h KafkaConnectorHandler) createOrUpdate(ctx context.Context, avn *aiven.Cl
 	if !exists {
 		err = avn.KafkaConnectors.Create(ctx, conn.Spec.Project, conn.Spec.ServiceName, connCfg)
 		if err != nil && !aiven.IsAlreadyExists(err) {
+			meta.SetStatusCondition(&conn.Status.Conditions, getErrorCondition("Create", err))
 			return err
 		}
 		reason = "Created"
 	} else {
 		_, err := avn.KafkaConnectors.Update(ctx, conn.Spec.Project, conn.Spec.ServiceName, conn.Name, connCfg)
 		if err != nil {
+			meta.SetStatusCondition(&conn.Status.Conditions, getErrorCondition("Update", err))
 			return err
 		}
 		reason = "Updated"
@@ -141,6 +145,7 @@ func (h KafkaConnectorHandler) delete(ctx context.Context, avn *aiven.Client, ob
 	}
 	err = avn.KafkaConnectors.Delete(ctx, conn.Spec.Project, conn.Spec.ServiceName, conn.Name)
 	if err != nil && !aiven.IsNotFound(err) {
+		meta.SetStatusCondition(&conn.Status.Conditions, getErrorCondition("Delete", err))
 		return false, fmt.Errorf("unable to delete kafka connector: %w", err)
 	}
 	return true, nil
@@ -215,7 +220,11 @@ func (h KafkaConnectorHandler) checkPreconditions(ctx context.Context, avn *aive
 	meta.SetStatusCondition(&conn.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsRunning(ctx, avn, conn.Spec.Project, conn.Spec.ServiceName)
+	running, err := checkServiceIsRunning(ctx, avn, conn.Spec.Project, conn.Spec.ServiceName)
+	if err != nil {
+		meta.SetStatusCondition(&conn.Status.Conditions, getErrorCondition("Preconditions", err))
+	}
+	return running, err
 }
 
 func (h KafkaConnectorHandler) convert(o client.Object) (*v1alpha1.KafkaConnector, error) {

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -77,6 +77,7 @@ func (h ProjectHandler) createOrUpdate(ctx context.Context, avn *aiven.Client, o
 
 	exists, err := h.exists(ctx, avn, project)
 	if err != nil {
+		meta.SetStatusCondition(&project.Status.Conditions, getErrorCondition("CheckExists", err))
 		return fmt.Errorf("project does not exists: %w", err)
 	}
 


### PR DESCRIPTION
We are using aiven-operator in an argocd-setup where we heavily rely on status conditions for synchronization and monitoring purposes. After evaulating the operator we found two major issues:
- In the case of failed preconditions, actual conditions never get written to kube-api
- In the case of error, no condition is ever set on kube-api level to indicate that something failed

Changes this PR introduces:
1. defer function was moved to a higher level in order to consistently trigger status-updates
2. new status conditions in the case of an error during find, create, update, delete were added
3. a new event was introduced sent out when preconditions are not met

This pr builds on top of some of the work done in https://github.com/aiven/aiven-operator/pull/101
I was reading the full discussion there as well as on the issue and i might not that i think it is not a good idea
to remove status conditions in the case the status resolves. I don't find this a standard practice in the whild and there
are good reasons for it. We would only hide that an error happened in the past and for everyone looking at the current
object it would still be clear that the object is healthy because we have a newer status condition then signaling that 
the current state is indeed healthy.

Resolves: https://github.com/aiven/aiven-operator/issues/66