### PR TITLE
refactor(models): rename receivers to in

### DIFF
--- a/api/v1alpha1/clickhouse_webhook.go
+++ b/api/v1alpha1/clickhouse_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var clickhouselog = logf.Log.WithName("clickhouse-resource")
 
-func (r *Clickhouse) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *Clickhouse) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,8 +25,8 @@ func (r *Clickhouse) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &Clickhouse{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *Clickhouse) Default() {
-	clickhouselog.Info("default", "name", r.Name)
+func (in *Clickhouse) Default() {
+	clickhouselog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-aiven-io-v1alpha1-clickhouse,mutating=false,failurePolicy=fail,groups=aiven.io,resources=clickhouses,versions=v1alpha1,name=vclickhouse.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -34,36 +34,36 @@ func (r *Clickhouse) Default() {
 var _ webhook.Validator = &Clickhouse{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *Clickhouse) ValidateCreate() error {
-	clickhouselog.Info("validate create", "name", r.Name)
+func (in *Clickhouse) ValidateCreate() error {
+	clickhouselog.Info("validate create", "name", in.Name)
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Clickhouse) ValidateUpdate(old runtime.Object) error {
-	clickhouselog.Info("validate update", "name", r.Name)
+func (in *Clickhouse) ValidateUpdate(old runtime.Object) error {
+	clickhouselog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*Clickhouse).Spec.Project {
+	if in.Spec.Project != old.(*Clickhouse).Spec.Project {
 		return errors.New("cannot update a Clickhouse service, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ConnInfoSecretTarget.Name != old.(*Clickhouse).Spec.ConnInfoSecretTarget.Name {
+	if in.Spec.ConnInfoSecretTarget.Name != old.(*Clickhouse).Spec.ConnInfoSecretTarget.Name {
 		return errors.New("cannot update a Clickhouse service, connInfoSecretTarget.name field is immutable and cannot be updated")
 	}
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *Clickhouse) ValidateDelete() error {
-	clickhouselog.Info("validate delete", "name", r.Name)
+func (in *Clickhouse) ValidateDelete() error {
+	clickhouselog.Info("validate delete", "name", in.Name)
 
-	if r.Spec.TerminationProtection != nil && *r.Spec.TerminationProtection {
+	if in.Spec.TerminationProtection != nil && *in.Spec.TerminationProtection {
 		return errors.New("cannot delete Clickhouse service, termination protection is on")
 	}
 
-	if r.Spec.ProjectVPCID != "" && r.Spec.ProjectVPCRef != nil {
+	if in.Spec.ProjectVPCID != "" && in.Spec.ProjectVPCRef != nil {
 		return errors.New("cannot use both projectVpcId and projectVPCRef")
 	}
 

--- a/api/v1alpha1/clickhouseuser_types.go
+++ b/api/v1alpha1/clickhouseuser_types.go
@@ -52,8 +52,8 @@ type ClickhouseUser struct {
 	Status ClickhouseUserStatus `json:"status,omitempty"`
 }
 
-func (u ClickhouseUser) AuthSecretRef() *AuthSecretReference {
-	return u.Spec.AuthSecretRef
+func (in *ClickhouseUser) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 func (in *ClickhouseUser) GetConnInfoSecretTarget() ConnInfoSecretTarget {

--- a/api/v1alpha1/clickhouseuser_webhook.go
+++ b/api/v1alpha1/clickhouseuser_webhook.go
@@ -12,9 +12,9 @@ import (
 // log is for logging in this package.
 var clickhouseuserlog = logf.Log.WithName("clickhouseuser-resource")
 
-func (r *ClickhouseUser) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *ClickhouseUser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -23,8 +23,8 @@ func (r *ClickhouseUser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &ClickhouseUser{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *ClickhouseUser) Default() {
-	clickhouseuserlog.Info("default", "name", r.Name)
+func (in *ClickhouseUser) Default() {
+	clickhouseuserlog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:path=/validate-aiven-io-v1alpha1-clickhouseuser,mutating=false,failurePolicy=fail,sideEffects=None,groups=aiven.io,resources=clickhouseusers,verbs=create;update,versions=v1alpha1,name=vclickhouseuser.kb.io,admissionReviewVersions=v1
@@ -32,21 +32,21 @@ func (r *ClickhouseUser) Default() {
 var _ webhook.Validator = &ClickhouseUser{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *ClickhouseUser) ValidateCreate() error {
-	clickhouseuserlog.Info("validate create", "name", r.Name)
+func (in *ClickhouseUser) ValidateCreate() error {
+	clickhouseuserlog.Info("validate create", "name", in.Name)
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *ClickhouseUser) ValidateUpdate(old runtime.Object) error {
-	clickhouseuserlog.Info("validate update", "name", r.Name)
+func (in *ClickhouseUser) ValidateUpdate(old runtime.Object) error {
+	clickhouseuserlog.Info("validate update", "name", in.Name)
 
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *ClickhouseUser) ValidateDelete() error {
-	clickhouseuserlog.Info("validate delete", "name", r.Name)
+func (in *ClickhouseUser) ValidateDelete() error {
+	clickhouseuserlog.Info("validate delete", "name", in.Name)
 
 	return nil
 }

--- a/api/v1alpha1/connectionpool_types.go
+++ b/api/v1alpha1/connectionpool_types.go
@@ -66,8 +66,8 @@ type ConnectionPool struct {
 	Status ConnectionPoolStatus `json:"status,omitempty"`
 }
 
-func (cp ConnectionPool) AuthSecretRef() *AuthSecretReference {
-	return cp.Spec.AuthSecretRef
+func (in *ConnectionPool) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 func (in *ConnectionPool) GetConnInfoSecretTarget() ConnInfoSecretTarget {

--- a/api/v1alpha1/connectionpool_webhook.go
+++ b/api/v1alpha1/connectionpool_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var connectionpoollog = logf.Log.WithName("connectionpool-resource")
 
-func (r *ConnectionPool) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *ConnectionPool) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,11 +25,11 @@ func (r *ConnectionPool) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &ConnectionPool{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *ConnectionPool) Default() {
-	connectionpoollog.Info("default", "name", r.Name)
+func (in *ConnectionPool) Default() {
+	connectionpoollog.Info("default", "name", in.Name)
 
-	if r.Spec.PoolSize == 0 {
-		r.Spec.PoolSize = 10
+	if in.Spec.PoolSize == 0 {
+		in.Spec.PoolSize = 10
 	}
 }
 
@@ -38,25 +38,25 @@ func (r *ConnectionPool) Default() {
 var _ webhook.Validator = &ConnectionPool{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *ConnectionPool) ValidateCreate() error {
-	connectionpoollog.Info("validate create", "name", r.Name)
+func (in *ConnectionPool) ValidateCreate() error {
+	connectionpoollog.Info("validate create", "name", in.Name)
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *ConnectionPool) ValidateUpdate(old runtime.Object) error {
-	connectionpoollog.Info("validate update", "name", r.Name)
+func (in *ConnectionPool) ValidateUpdate(old runtime.Object) error {
+	connectionpoollog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*ConnectionPool).Spec.Project {
+	if in.Spec.Project != old.(*ConnectionPool).Spec.Project {
 		return errors.New("cannot update a ConnectionPool, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ServiceName != old.(*ConnectionPool).Spec.ServiceName {
+	if in.Spec.ServiceName != old.(*ConnectionPool).Spec.ServiceName {
 		return errors.New("cannot update a ConnectionPool, serviceName field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ConnInfoSecretTarget.Name != old.(*ConnectionPool).Spec.ConnInfoSecretTarget.Name {
+	if in.Spec.ConnInfoSecretTarget.Name != old.(*ConnectionPool).Spec.ConnInfoSecretTarget.Name {
 		return errors.New("cannot update a ConnectionPool, connInfoSecretTarget.name field is immutable and cannot be updated")
 	}
 
@@ -64,8 +64,8 @@ func (r *ConnectionPool) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *ConnectionPool) ValidateDelete() error {
-	connectionpoollog.Info("validate delete", "name", r.Name)
+func (in *ConnectionPool) ValidateDelete() error {
+	connectionpoollog.Info("validate delete", "name", in.Name)
 
 	return nil
 }

--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -54,8 +54,8 @@ type Database struct {
 	Status DatabaseStatus `json:"status,omitempty"`
 }
 
-func (db Database) AuthSecretRef() *AuthSecretReference {
-	return db.Spec.AuthSecretRef
+func (in *Database) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/database_webhook.go
+++ b/api/v1alpha1/database_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var databaselog = logf.Log.WithName("database-resource")
 
-func (r *Database) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *Database) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,17 +25,17 @@ func (r *Database) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &Database{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *Database) Default() {
-	databaselog.Info("default", "name", r.Name)
+func (in *Database) Default() {
+	databaselog.Info("default", "name", in.Name)
 
 	const defaultLC = "en_US.UTF-8"
 
-	if r.Spec.LcCtype == "" {
-		r.Spec.LcCtype = defaultLC
+	if in.Spec.LcCtype == "" {
+		in.Spec.LcCtype = defaultLC
 	}
 
-	if r.Spec.LcCollate == "" {
-		r.Spec.LcCollate = defaultLC
+	if in.Spec.LcCollate == "" {
+		in.Spec.LcCollate = defaultLC
 	}
 }
 
@@ -44,29 +44,29 @@ func (r *Database) Default() {
 var _ webhook.Validator = &Database{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *Database) ValidateCreate() error {
-	databaselog.Info("validate create", "name", r.Name)
+func (in *Database) ValidateCreate() error {
+	databaselog.Info("validate create", "name", in.Name)
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Database) ValidateUpdate(old runtime.Object) error {
-	databaselog.Info("validate update", "name", r.Name)
+func (in *Database) ValidateUpdate(old runtime.Object) error {
+	databaselog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*Database).Spec.Project {
+	if in.Spec.Project != old.(*Database).Spec.Project {
 		return errors.New("cannot update a Database, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ServiceName != old.(*Database).Spec.ServiceName {
+	if in.Spec.ServiceName != old.(*Database).Spec.ServiceName {
 		return errors.New("cannot update a Database, service_name field is immutable and cannot be updated")
 	}
 
-	if r.Spec.LcCollate != old.(*Database).Spec.LcCollate {
+	if in.Spec.LcCollate != old.(*Database).Spec.LcCollate {
 		return errors.New("cannot update a Database, lc_collate field is immutable and cannot be updated")
 	}
 
-	if r.Spec.LcCtype != old.(*Database).Spec.LcCtype {
+	if in.Spec.LcCtype != old.(*Database).Spec.LcCtype {
 		return errors.New("cannot update a Database, lc_ctype field is immutable and cannot be updated")
 	}
 
@@ -74,10 +74,10 @@ func (r *Database) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *Database) ValidateDelete() error {
-	databaselog.Info("validate delete", "name", r.Name)
+func (in *Database) ValidateDelete() error {
+	databaselog.Info("validate delete", "name", in.Name)
 
-	if r.Spec.TerminationProtection != nil && *r.Spec.TerminationProtection {
+	if in.Spec.TerminationProtection != nil && *in.Spec.TerminationProtection {
 		return errors.New("cannot delete Database, termination protection is on")
 	}
 	return nil

--- a/api/v1alpha1/kafka_webhook.go
+++ b/api/v1alpha1/kafka_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var kafkalog = logf.Log.WithName("kafka-resource")
 
-func (r *Kafka) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *Kafka) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,8 +25,8 @@ func (r *Kafka) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &Kafka{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *Kafka) Default() {
-	kafkalog.Info("default", "name", r.Name)
+func (in *Kafka) Default() {
+	kafkalog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-aiven-io-v1alpha1-kafka,mutating=false,failurePolicy=fail,groups=aiven.io,resources=kafkas,versions=v1alpha1,name=vkafka.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -34,36 +34,36 @@ func (r *Kafka) Default() {
 var _ webhook.Validator = &Kafka{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *Kafka) ValidateCreate() error {
-	kafkalog.Info("validate create", "name", r.Name)
+func (in *Kafka) ValidateCreate() error {
+	kafkalog.Info("validate create", "name", in.Name)
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Kafka) ValidateUpdate(old runtime.Object) error {
-	kafkalog.Info("validate update", "name", r.Name)
+func (in *Kafka) ValidateUpdate(old runtime.Object) error {
+	kafkalog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*Kafka).Spec.Project {
+	if in.Spec.Project != old.(*Kafka).Spec.Project {
 		return errors.New("cannot update a Kafka service, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ConnInfoSecretTarget.Name != old.(*Kafka).Spec.ConnInfoSecretTarget.Name {
+	if in.Spec.ConnInfoSecretTarget.Name != old.(*Kafka).Spec.ConnInfoSecretTarget.Name {
 		return errors.New("cannot update a Kafka service, connInfoSecretTarget.name field is immutable and cannot be updated")
 	}
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *Kafka) ValidateDelete() error {
-	kafkalog.Info("validate delete", "name", r.Name)
+func (in *Kafka) ValidateDelete() error {
+	kafkalog.Info("validate delete", "name", in.Name)
 
-	if r.Spec.TerminationProtection != nil && *r.Spec.TerminationProtection {
+	if in.Spec.TerminationProtection != nil && *in.Spec.TerminationProtection {
 		return errors.New("cannot delete Kafka service, termination protection is on")
 	}
 
-	if r.Spec.ProjectVPCID != "" && r.Spec.ProjectVPCRef != nil {
+	if in.Spec.ProjectVPCID != "" && in.Spec.ProjectVPCRef != nil {
 		return errors.New("cannot use both projectVpcId and projectVPCRef")
 	}
 

--- a/api/v1alpha1/kafkaacl_types.go
+++ b/api/v1alpha1/kafkaacl_types.go
@@ -57,8 +57,8 @@ type KafkaACL struct {
 	Status KafkaACLStatus `json:"status,omitempty"`
 }
 
-func (acl KafkaACL) AuthSecretRef() *AuthSecretReference {
-	return acl.Spec.AuthSecretRef
+func (in *KafkaACL) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/kafkaacl_webhook.go
+++ b/api/v1alpha1/kafkaacl_webhook.go
@@ -12,9 +12,9 @@ import (
 // log is for logging in this package.
 var kafkaacllog = logf.Log.WithName("kafkaacl-resource")
 
-func (r *KafkaACL) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *KafkaACL) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -23,8 +23,8 @@ func (r *KafkaACL) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &KafkaACL{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *KafkaACL) Default() {
-	kafkaacllog.Info("default", "name", r.Name)
+func (in *KafkaACL) Default() {
+	kafkaacllog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update,path=/validate-aiven-io-v1alpha1-kafkaacl,mutating=false,failurePolicy=fail,groups=aiven.io,resources=kafkaacls,versions=v1alpha1,name=vkafkaacl.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -32,15 +32,15 @@ func (r *KafkaACL) Default() {
 var _ webhook.Validator = &KafkaACL{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaACL) ValidateCreate() error {
-	kafkaacllog.Info("validate create", "name", r.Name)
+func (in *KafkaACL) ValidateCreate() error {
+	kafkaacllog.Info("validate create", "name", in.Name)
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaACL) ValidateUpdate(old runtime.Object) error {
-	kafkaacllog.Info("validate update", "name", r.Name)
+func (in *KafkaACL) ValidateUpdate(old runtime.Object) error {
+	kafkaacllog.Info("validate update", "name", in.Name)
 
 	// TODO: validate that the spec does not get updated; this will fail on the aiven api
 
@@ -48,8 +48,8 @@ func (r *KafkaACL) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaACL) ValidateDelete() error {
-	kafkaacllog.Info("validate delete", "name", r.Name)
+func (in *KafkaACL) ValidateDelete() error {
+	kafkaacllog.Info("validate delete", "name", in.Name)
 
 	return nil
 }

--- a/api/v1alpha1/kafkaconnect_webhook.go
+++ b/api/v1alpha1/kafkaconnect_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var kafkaconnectlog = logf.Log.WithName("kafkaconnect-resource")
 
-func (r *KafkaConnect) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *KafkaConnect) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,8 +25,8 @@ func (r *KafkaConnect) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &KafkaConnect{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *KafkaConnect) Default() {
-	kafkaconnectlog.Info("default", "name", r.Name)
+func (in *KafkaConnect) Default() {
+	kafkaconnectlog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-aiven-io-v1alpha1-kafkaconnect,mutating=false,failurePolicy=fail,groups=aiven.io,resources=kafkaconnects,versions=v1alpha1,name=vkafkaconnect.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -34,32 +34,32 @@ func (r *KafkaConnect) Default() {
 var _ webhook.Validator = &KafkaConnect{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaConnect) ValidateCreate() error {
-	kafkaconnectlog.Info("validate create", "name", r.Name)
+func (in *KafkaConnect) ValidateCreate() error {
+	kafkaconnectlog.Info("validate create", "name", in.Name)
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaConnect) ValidateUpdate(old runtime.Object) error {
-	kafkaconnectlog.Info("validate update", "name", r.Name)
+func (in *KafkaConnect) ValidateUpdate(old runtime.Object) error {
+	kafkaconnectlog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*KafkaConnect).Spec.Project {
+	if in.Spec.Project != old.(*KafkaConnect).Spec.Project {
 		return errors.New("cannot update a KafkaConnect service, project field is immutable and cannot be updated")
 	}
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaConnect) ValidateDelete() error {
-	kafkaconnectlog.Info("validate delete", "name", r.Name)
+func (in *KafkaConnect) ValidateDelete() error {
+	kafkaconnectlog.Info("validate delete", "name", in.Name)
 
-	if r.Spec.TerminationProtection != nil && *r.Spec.TerminationProtection {
+	if in.Spec.TerminationProtection != nil && *in.Spec.TerminationProtection {
 		return errors.New("cannot delete KafkaConnect service, termination protection is on")
 	}
 
-	if r.Spec.ProjectVPCID != "" && r.Spec.ProjectVPCRef != nil {
+	if in.Spec.ProjectVPCID != "" && in.Spec.ProjectVPCRef != nil {
 		return errors.New("cannot use both projectVpcId and projectVPCRef")
 	}
 

--- a/api/v1alpha1/kafkaconnector_types.go
+++ b/api/v1alpha1/kafkaconnector_types.go
@@ -84,8 +84,8 @@ type KafkaConnector struct {
 	Status KafkaConnectorStatus `json:"status,omitempty"`
 }
 
-func (kfk KafkaConnector) AuthSecretRef() *AuthSecretReference {
-	return kfk.Spec.AuthSecretRef
+func (in *KafkaConnector) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/kafkaconnector_webhook.go
+++ b/api/v1alpha1/kafkaconnector_webhook.go
@@ -12,9 +12,9 @@ import (
 // log is for logging in this package.
 var kafkaconnectorlog = logf.Log.WithName("kafkaconnector-resource")
 
-func (r *KafkaConnector) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *KafkaConnector) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -23,8 +23,8 @@ func (r *KafkaConnector) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &KafkaConnector{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *KafkaConnector) Default() {
-	kafkaconnectorlog.Info("default", "name", r.Name)
+func (in *KafkaConnector) Default() {
+	kafkaconnectorlog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-aiven-io-v1alpha1-kafkaconnector,mutating=false,failurePolicy=fail,groups=aiven.io,resources=kafkaconnectors,versions=v1alpha1,name=vkafkaconnector.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -32,22 +32,22 @@ func (r *KafkaConnector) Default() {
 var _ webhook.Validator = &KafkaConnector{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaConnector) ValidateCreate() error {
-	kafkaconnectorlog.Info("validate create", "name", r.Name)
+func (in *KafkaConnector) ValidateCreate() error {
+	kafkaconnectorlog.Info("validate create", "name", in.Name)
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaConnector) ValidateUpdate(old runtime.Object) error {
-	kafkaconnectorlog.Info("validate update", "name", r.Name)
+func (in *KafkaConnector) ValidateUpdate(old runtime.Object) error {
+	kafkaconnectorlog.Info("validate update", "name", in.Name)
 
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaConnector) ValidateDelete() error {
-	kafkaconnectorlog.Info("validate delete", "name", r.Name)
+func (in *KafkaConnector) ValidateDelete() error {
+	kafkaconnectorlog.Info("validate delete", "name", in.Name)
 
 	return nil
 }

--- a/api/v1alpha1/kafkaschema_types.go
+++ b/api/v1alpha1/kafkaschema_types.go
@@ -58,8 +58,8 @@ type KafkaSchema struct {
 	Status KafkaSchemaStatus `json:"status,omitempty"`
 }
 
-func (kfks KafkaSchema) AuthSecretRef() *AuthSecretReference {
-	return kfks.Spec.AuthSecretRef
+func (in *KafkaSchema) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/kafkaschema_webhook.go
+++ b/api/v1alpha1/kafkaschema_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var kafkaschemalog = logf.Log.WithName("kafkaschema-resource")
 
-func (r *KafkaSchema) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *KafkaSchema) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,8 +25,8 @@ func (r *KafkaSchema) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &KafkaSchema{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *KafkaSchema) Default() {
-	kafkaschemalog.Info("default", "name", r.Name)
+func (in *KafkaSchema) Default() {
+	kafkaschemalog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update,path=/validate-aiven-io-v1alpha1-kafkaschema,mutating=false,failurePolicy=fail,groups=aiven.io,resources=kafkaschemas,versions=v1alpha1,name=vkafkaschema.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -34,25 +34,25 @@ func (r *KafkaSchema) Default() {
 var _ webhook.Validator = &KafkaSchema{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaSchema) ValidateCreate() error {
-	kafkaschemalog.Info("validate create", "name", r.Name)
+func (in *KafkaSchema) ValidateCreate() error {
+	kafkaschemalog.Info("validate create", "name", in.Name)
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaSchema) ValidateUpdate(old runtime.Object) error {
-	kafkaschemalog.Info("validate update", "name", r.Name)
+func (in *KafkaSchema) ValidateUpdate(old runtime.Object) error {
+	kafkaschemalog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*KafkaSchema).Spec.Project {
+	if in.Spec.Project != old.(*KafkaSchema).Spec.Project {
 		return errors.New("cannot update a KafkaSchema, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ServiceName != old.(*KafkaSchema).Spec.ServiceName {
+	if in.Spec.ServiceName != old.(*KafkaSchema).Spec.ServiceName {
 		return errors.New("cannot update a KafkaSchema, serviceName field is immutable and cannot be updated")
 	}
 
-	if r.Spec.SubjectName != old.(*KafkaSchema).Spec.SubjectName {
+	if in.Spec.SubjectName != old.(*KafkaSchema).Spec.SubjectName {
 		return errors.New("cannot update a KafkaSchema, subjectName field is immutable and cannot be updated")
 	}
 
@@ -60,8 +60,8 @@ func (r *KafkaSchema) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaSchema) ValidateDelete() error {
-	kafkaschemalog.Info("validate delete", "name", r.Name)
+func (in *KafkaSchema) ValidateDelete() error {
+	kafkaschemalog.Info("validate delete", "name", in.Name)
 
 	return nil
 }

--- a/api/v1alpha1/kafkatopic_types.go
+++ b/api/v1alpha1/kafkatopic_types.go
@@ -51,11 +51,11 @@ type KafkaTopicSpec struct {
 
 // GetTopicName returns topic name with a backward compatibility.
 // metadata.Name is deprecated
-func (t *KafkaTopic) GetTopicName() string {
-	if t.Spec.TopicName != "" {
-		return t.Spec.TopicName
+func (in *KafkaTopic) GetTopicName() string {
+	if in.Spec.TopicName != "" {
+		return in.Spec.TopicName
 	}
-	return t.Name
+	return in.Name
 }
 
 type KafkaTopicTag struct {
@@ -165,8 +165,8 @@ type KafkaTopic struct {
 	Status KafkaTopicStatus `json:"status,omitempty"`
 }
 
-func (t *KafkaTopic) AuthSecretRef() *AuthSecretReference {
-	return t.Spec.AuthSecretRef
+func (in *KafkaTopic) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/kafkatopic_webhook.go
+++ b/api/v1alpha1/kafkatopic_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var kafkatopiclog = logf.Log.WithName("kafkatopic-resource")
 
-func (r *KafkaTopic) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *KafkaTopic) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,8 +25,8 @@ func (r *KafkaTopic) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &KafkaTopic{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *KafkaTopic) Default() {
-	kafkatopiclog.Info("default", "name", r.Name)
+func (in *KafkaTopic) Default() {
+	kafkatopiclog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-aiven-io-v1alpha1-kafkatopic,mutating=false,failurePolicy=fail,groups=aiven.io,resources=kafkatopics,versions=v1alpha1,name=vkafkatopic.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -34,21 +34,21 @@ func (r *KafkaTopic) Default() {
 var _ webhook.Validator = &KafkaTopic{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaTopic) ValidateCreate() error {
-	kafkatopiclog.Info("validate create", "name", r.Name)
+func (in *KafkaTopic) ValidateCreate() error {
+	kafkatopiclog.Info("validate create", "name", in.Name)
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaTopic) ValidateUpdate(old runtime.Object) error {
-	kafkatopiclog.Info("validate update", "name", r.Name)
+func (in *KafkaTopic) ValidateUpdate(old runtime.Object) error {
+	kafkatopiclog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*KafkaTopic).Spec.Project {
+	if in.Spec.Project != old.(*KafkaTopic).Spec.Project {
 		return errors.New("cannot update a KafkaTopic, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ServiceName != old.(*KafkaTopic).Spec.ServiceName {
+	if in.Spec.ServiceName != old.(*KafkaTopic).Spec.ServiceName {
 		return errors.New("cannot update a KafkaTopic, serviceName field is immutable and cannot be updated")
 	}
 
@@ -56,10 +56,10 @@ func (r *KafkaTopic) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *KafkaTopic) ValidateDelete() error {
-	kafkatopiclog.Info("validate delete", "name", r.Name)
+func (in *KafkaTopic) ValidateDelete() error {
+	kafkatopiclog.Info("validate delete", "name", in.Name)
 
-	if r.Spec.TerminationProtection != nil && *r.Spec.TerminationProtection {
+	if in.Spec.TerminationProtection != nil && *in.Spec.TerminationProtection {
 		return errors.New("cannot delete KafkaTopic, termination protection is on")
 	}
 

--- a/api/v1alpha1/opensearch_webhook.go
+++ b/api/v1alpha1/opensearch_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var opensearchlog = logf.Log.WithName("opensearch-resource")
 
-func (r *OpenSearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *OpenSearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,8 +25,8 @@ func (r *OpenSearch) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &OpenSearch{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *OpenSearch) Default() {
-	opensearchlog.Info("default", "name", r.Name)
+func (in *OpenSearch) Default() {
+	opensearchlog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-aiven-io-v1alpha1-opensearch,mutating=false,failurePolicy=fail,groups=aiven.io,resources=opensearches,versions=v1alpha1,name=vopensearch.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -34,36 +34,36 @@ func (r *OpenSearch) Default() {
 var _ webhook.Validator = &OpenSearch{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *OpenSearch) ValidateCreate() error {
-	opensearchlog.Info("validate create", "name", r.Name)
+func (in *OpenSearch) ValidateCreate() error {
+	opensearchlog.Info("validate create", "name", in.Name)
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *OpenSearch) ValidateUpdate(old runtime.Object) error {
-	opensearchlog.Info("validate update", "name", r.Name)
+func (in *OpenSearch) ValidateUpdate(old runtime.Object) error {
+	opensearchlog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*OpenSearch).Spec.Project {
+	if in.Spec.Project != old.(*OpenSearch).Spec.Project {
 		return errors.New("cannot update a OpenSearch service, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ConnInfoSecretTarget.Name != old.(*OpenSearch).Spec.ConnInfoSecretTarget.Name {
+	if in.Spec.ConnInfoSecretTarget.Name != old.(*OpenSearch).Spec.ConnInfoSecretTarget.Name {
 		return errors.New("cannot update a OpenSearch service, connInfoSecretTarget.name field is immutable and cannot be updated")
 	}
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *OpenSearch) ValidateDelete() error {
-	opensearchlog.Info("validate delete", "name", r.Name)
+func (in *OpenSearch) ValidateDelete() error {
+	opensearchlog.Info("validate delete", "name", in.Name)
 
-	if r.Spec.TerminationProtection != nil && *r.Spec.TerminationProtection {
+	if in.Spec.TerminationProtection != nil && *in.Spec.TerminationProtection {
 		return errors.New("cannot delete OpenSearch service, termination protection is on")
 	}
 
-	if r.Spec.ProjectVPCID != "" && r.Spec.ProjectVPCRef != nil {
+	if in.Spec.ProjectVPCID != "" && in.Spec.ProjectVPCRef != nil {
 		return errors.New("cannot use both projectVpcId and projectVPCRef")
 	}
 

--- a/api/v1alpha1/postgresql_webhook.go
+++ b/api/v1alpha1/postgresql_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var pglog = logf.Log.WithName("postgresql-resource")
 
-func (r *PostgreSQL) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *PostgreSQL) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,8 +25,8 @@ func (r *PostgreSQL) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &PostgreSQL{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *PostgreSQL) Default() {
-	pglog.Info("default", "name", r.Name)
+func (in *PostgreSQL) Default() {
+	pglog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-aiven-io-v1alpha1-postgresql,mutating=false,failurePolicy=fail,groups=aiven.io,resources=postgresqls,versions=v1alpha1,name=vpg.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -34,36 +34,36 @@ func (r *PostgreSQL) Default() {
 var _ webhook.Validator = &PostgreSQL{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *PostgreSQL) ValidateCreate() error {
-	pglog.Info("validate create", "name", r.Name)
+func (in *PostgreSQL) ValidateCreate() error {
+	pglog.Info("validate create", "name", in.Name)
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *PostgreSQL) ValidateUpdate(old runtime.Object) error {
-	pglog.Info("validate update", "name", r.Name)
+func (in *PostgreSQL) ValidateUpdate(old runtime.Object) error {
+	pglog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*PostgreSQL).Spec.Project {
+	if in.Spec.Project != old.(*PostgreSQL).Spec.Project {
 		return errors.New("cannot update a PostgreSQL service, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ConnInfoSecretTarget.Name != old.(*PostgreSQL).Spec.ConnInfoSecretTarget.Name {
+	if in.Spec.ConnInfoSecretTarget.Name != old.(*PostgreSQL).Spec.ConnInfoSecretTarget.Name {
 		return errors.New("cannot update a PostgreSQL service, connInfoSecretTarget.name field is immutable and cannot be updated")
 	}
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *PostgreSQL) ValidateDelete() error {
-	pglog.Info("validate delete", "name", r.Name)
+func (in *PostgreSQL) ValidateDelete() error {
+	pglog.Info("validate delete", "name", in.Name)
 
-	if r.Spec.TerminationProtection != nil && *r.Spec.TerminationProtection {
+	if in.Spec.TerminationProtection != nil && *in.Spec.TerminationProtection {
 		return errors.New("cannot delete PostgreSQL service, termination protection is on")
 	}
 
-	if r.Spec.ProjectVPCID != "" && r.Spec.ProjectVPCRef != nil {
+	if in.Spec.ProjectVPCID != "" && in.Spec.ProjectVPCRef != nil {
 		return errors.New("cannot use both projectVpcId and projectVPCRef")
 	}
 

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -99,8 +99,8 @@ type Project struct {
 	Status ProjectStatus `json:"status,omitempty"`
 }
 
-func (proj Project) AuthSecretRef() *AuthSecretReference {
-	return proj.Spec.AuthSecretRef
+func (in *Project) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 func (in *Project) GetConnInfoSecretTarget() ConnInfoSecretTarget {

--- a/api/v1alpha1/project_webhook.go
+++ b/api/v1alpha1/project_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var projectlog = logf.Log.WithName("project-resource")
 
-func (r *Project) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *Project) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -27,8 +27,8 @@ func (r *Project) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &Project{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *Project) Default() {
-	projectlog.Info("default", "name", r.Name)
+func (in *Project) Default() {
+	projectlog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-aiven-io-v1alpha1-project,mutating=false,failurePolicy=fail,groups=aiven.io,resources=projects,versions=v1alpha1,name=vproject.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -36,25 +36,25 @@ func (r *Project) Default() {
 var _ webhook.Validator = &Project{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *Project) ValidateCreate() error {
-	projectlog.Info("validate create", "name", r.Name)
+func (in *Project) ValidateCreate() error {
+	projectlog.Info("validate create", "name", in.Name)
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Project) ValidateUpdate(old runtime.Object) error {
-	projectlog.Info("validate update", "name", r.Name)
+func (in *Project) ValidateUpdate(old runtime.Object) error {
+	projectlog.Info("validate update", "name", in.Name)
 
-	if r.Spec.CopyFromProject != old.(*Project).Spec.CopyFromProject {
+	if in.Spec.CopyFromProject != old.(*Project).Spec.CopyFromProject {
 		return errors.New("'copyFromProject' can only be set during creation of a project")
 	}
 
-	if r.Spec.ConnInfoSecretTarget.Name != old.(*Project).Spec.ConnInfoSecretTarget.Name {
+	if in.Spec.ConnInfoSecretTarget.Name != old.(*Project).Spec.ConnInfoSecretTarget.Name {
 		return errors.New("cannot update a Project, connInfoSecretTarget.name field is immutable and cannot be updated")
 	}
 
-	if r.Spec.BillingGroupID != old.(*Project).Spec.BillingGroupID {
+	if in.Spec.BillingGroupID != old.(*Project).Spec.BillingGroupID {
 		return errors.New("'billingGroupId' can only be set during creation of a project")
 	}
 
@@ -62,10 +62,10 @@ func (r *Project) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *Project) ValidateDelete() error {
-	projectlog.Info("validate delete", "name", r.Name)
+func (in *Project) ValidateDelete() error {
+	projectlog.Info("validate delete", "name", in.Name)
 
-	if r.Spec.AccountID == "" && r.Status.EstimatedBalance != "0.00" {
+	if in.Spec.AccountID == "" && in.Status.EstimatedBalance != "0.00" {
 		return errors.New("project with an open balance cannot be deleted")
 	}
 

--- a/api/v1alpha1/projectvpc_types.go
+++ b/api/v1alpha1/projectvpc_types.go
@@ -56,8 +56,8 @@ type ProjectVPC struct {
 	Status ProjectVPCStatus `json:"status,omitempty"`
 }
 
-func (pvpc ProjectVPC) AuthSecretRef() *AuthSecretReference {
-	return pvpc.Spec.AuthSecretRef
+func (in *ProjectVPC) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/redis_webhook.go
+++ b/api/v1alpha1/redis_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var redislog = logf.Log.WithName("redis-resource")
 
-func (r *Redis) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *Redis) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,8 +25,8 @@ func (r *Redis) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &Redis{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *Redis) Default() {
-	redislog.Info("default", "name", r.Name)
+func (in *Redis) Default() {
+	redislog.Info("default", "name", in.Name)
 }
 
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-aiven-io-v1alpha1-redis,mutating=false,failurePolicy=fail,groups=aiven.io,resources=redis,versions=v1alpha1,name=vredis.kb.io,sideEffects=none,admissionReviewVersions=v1
@@ -34,36 +34,36 @@ func (r *Redis) Default() {
 var _ webhook.Validator = &Redis{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *Redis) ValidateCreate() error {
-	redislog.Info("validate create", "name", r.Name)
+func (in *Redis) ValidateCreate() error {
+	redislog.Info("validate create", "name", in.Name)
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Redis) ValidateUpdate(old runtime.Object) error {
-	redislog.Info("validate update", "name", r.Name)
+func (in *Redis) ValidateUpdate(old runtime.Object) error {
+	redislog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*Redis).Spec.Project {
+	if in.Spec.Project != old.(*Redis).Spec.Project {
 		return errors.New("cannot update a Redis service, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ConnInfoSecretTarget.Name != old.(*Redis).Spec.ConnInfoSecretTarget.Name {
+	if in.Spec.ConnInfoSecretTarget.Name != old.(*Redis).Spec.ConnInfoSecretTarget.Name {
 		return errors.New("cannot update a Redis service, connInfoSecretTarget.name field is immutable and cannot be updated")
 	}
 
-	return r.Spec.Validate()
+	return in.Spec.Validate()
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *Redis) ValidateDelete() error {
-	redislog.Info("validate delete", "name", r.Name)
+func (in *Redis) ValidateDelete() error {
+	redislog.Info("validate delete", "name", in.Name)
 
-	if r.Spec.TerminationProtection != nil && *r.Spec.TerminationProtection {
+	if in.Spec.TerminationProtection != nil && *in.Spec.TerminationProtection {
 		return errors.New("cannot delete Redis service, termination protection is on")
 	}
 
-	if r.Spec.ProjectVPCID != "" && r.Spec.ProjectVPCRef != nil {
+	if in.Spec.ProjectVPCID != "" && in.Spec.ProjectVPCRef != nil {
 		return errors.New("cannot use both projectVpcId and projectVPCRef")
 	}
 

--- a/api/v1alpha1/serviceuser_types.go
+++ b/api/v1alpha1/serviceuser_types.go
@@ -53,8 +53,8 @@ type ServiceUser struct {
 	Status ServiceUserStatus `json:"status,omitempty"`
 }
 
-func (svcusr ServiceUser) AuthSecretRef() *AuthSecretReference {
-	return svcusr.Spec.AuthSecretRef
+func (in *ServiceUser) AuthSecretRef() *AuthSecretReference {
+	return in.Spec.AuthSecretRef
 }
 
 func (in *ServiceUser) GetConnInfoSecretTarget() ConnInfoSecretTarget {

--- a/api/v1alpha1/serviceuser_webhook.go
+++ b/api/v1alpha1/serviceuser_webhook.go
@@ -14,9 +14,9 @@ import (
 // log is for logging in this package.
 var serviceuserlog = logf.Log.WithName("serviceuser-resource")
 
-func (r *ServiceUser) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (in *ServiceUser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(in).
 		Complete()
 }
 
@@ -25,8 +25,8 @@ func (r *ServiceUser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &ServiceUser{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
-func (r *ServiceUser) Default() {
-	serviceuserlog.Info("default", "name", r.Name)
+func (in *ServiceUser) Default() {
+	serviceuserlog.Info("default", "name", in.Name)
 
 }
 
@@ -35,25 +35,25 @@ func (r *ServiceUser) Default() {
 var _ webhook.Validator = &ServiceUser{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *ServiceUser) ValidateCreate() error {
-	serviceuserlog.Info("validate create", "name", r.Name)
+func (in *ServiceUser) ValidateCreate() error {
+	serviceuserlog.Info("validate create", "name", in.Name)
 
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *ServiceUser) ValidateUpdate(old runtime.Object) error {
-	serviceuserlog.Info("validate update", "name", r.Name)
+func (in *ServiceUser) ValidateUpdate(old runtime.Object) error {
+	serviceuserlog.Info("validate update", "name", in.Name)
 
-	if r.Spec.Project != old.(*ServiceUser).Spec.Project {
+	if in.Spec.Project != old.(*ServiceUser).Spec.Project {
 		return errors.New("cannot update a Service User, project field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ServiceName != old.(*ServiceUser).Spec.ServiceName {
+	if in.Spec.ServiceName != old.(*ServiceUser).Spec.ServiceName {
 		return errors.New("cannot update a Service User, serviceName field is immutable and cannot be updated")
 	}
 
-	if r.Spec.ConnInfoSecretTarget.Name != old.(*ServiceUser).Spec.ConnInfoSecretTarget.Name {
+	if in.Spec.ConnInfoSecretTarget.Name != old.(*ServiceUser).Spec.ConnInfoSecretTarget.Name {
 		return errors.New("cannot update a ServiceUser, connInfoSecretTarget.name field is immutable and cannot be updated")
 	}
 
@@ -61,8 +61,8 @@ func (r *ServiceUser) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *ServiceUser) ValidateDelete() error {
-	serviceuserlog.Info("validate delete", "name", r.Name)
+func (in *ServiceUser) ValidateDelete() error {
+	serviceuserlog.Info("validate delete", "name", in.Name)
 
 	return nil
 }


### PR DESCRIPTION
SDK generator generates `in` receiver name. While our code is inconsistent it is hard to apply changes to models using simple "find and replace" command. The PR renames receivers to `in`.