### PR TITLE
docs: link to prereqs from installation instructions

### DIFF
--- a/docs/docs/installation/helm.md
+++ b/docs/docs/installation/helm.md
@@ -8,6 +8,8 @@ weight: 10
 
 The Aiven Operator for Kubernetes can be installed via [Helm](https://helm.sh/). 
 
+Before you start, make sure you have the [prerequisites](prerequisites.md).
+
 First add the [Aiven Helm repository](https://github.com/aiven/aiven-charts):
 
 ```shell

--- a/docs/docs/installation/kubectl.md
+++ b/docs/docs/installation/kubectl.md
@@ -6,6 +6,8 @@ weight: 15
 
 ## Installing
 
+Before you start, make sure you have the [prerequisites](prerequisites.md).
+
 All Aiven Operator for Kubernetes components can be installed from one YAML file that is uploaded for every release:
 
 ```shell


### PR DESCRIPTION
Add a link to the prerequisites list to both sets of installation instructions to make sure customers are aware of what they need before installing.