### PR TITLE
feat(connection_pool): expose pool name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+## v0.16.1 - YYYY-MM-DD
+
 - Check VPC for running services before deletion
 - Expose `KAFKA_SCHEMA_REGISTRY_URI` and `KAFKA_REST_URI` to `Kafka` secret
+- Expose `CONNECTIONPOOL_NAME` in `ConnectionPool` secret
+- Fix `CONNECTIONPOOL_PORT` exposes service port instead of pool port 
 
 ## v0.16.0 - 2023-12-07
 

--- a/api/v1alpha1/connectionpool_types.go
+++ b/api/v1alpha1/connectionpool_types.go
@@ -35,7 +35,7 @@ type ConnectionPoolSpec struct {
 	PoolMode string `json:"poolMode,omitempty"`
 
 	// Information regarding secret creation.
-	// Exposed keys: `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`, `CONNECTIONPOOL_DATABASE`, `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`, `CONNECTIONPOOL_SSLMODE`, `CONNECTIONPOOL_DATABASE_URI`
+	// Exposed keys: `CONNECTIONPOOL_NAME`, `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`, `CONNECTIONPOOL_DATABASE`, `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`, `CONNECTIONPOOL_SSLMODE`, `CONNECTIONPOOL_DATABASE_URI`
 	ConnInfoSecretTarget ConnInfoSecretTarget `json:"connInfoSecretTarget,omitempty"`
 
 	// Authentication reference to Aiven token in a secret

--- a/charts/aiven-operator-crds/templates/aiven.io_connectionpools.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_connectionpools.yaml
@@ -69,9 +69,9 @@ spec:
                 type: object
               connInfoSecretTarget:
                 description: 'Information regarding secret creation. Exposed keys:
-                  `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`, `CONNECTIONPOOL_DATABASE`,
-                  `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`, `CONNECTIONPOOL_SSLMODE`,
-                  `CONNECTIONPOOL_DATABASE_URI`'
+                  `CONNECTIONPOOL_NAME`, `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`,
+                  `CONNECTIONPOOL_DATABASE`, `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`,
+                  `CONNECTIONPOOL_SSLMODE`, `CONNECTIONPOOL_DATABASE_URI`'
                 properties:
                   annotations:
                     additionalProperties:

--- a/config/crd/bases/aiven.io_connectionpools.yaml
+++ b/config/crd/bases/aiven.io_connectionpools.yaml
@@ -69,9 +69,9 @@ spec:
                 type: object
               connInfoSecretTarget:
                 description: 'Information regarding secret creation. Exposed keys:
-                  `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`, `CONNECTIONPOOL_DATABASE`,
-                  `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`, `CONNECTIONPOOL_SSLMODE`,
-                  `CONNECTIONPOOL_DATABASE_URI`'
+                  `CONNECTIONPOOL_NAME`, `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`,
+                  `CONNECTIONPOOL_DATABASE`, `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`,
+                  `CONNECTIONPOOL_SSLMODE`, `CONNECTIONPOOL_DATABASE_URI`'
                 properties:
                   annotations:
                     additionalProperties:

--- a/docs/docs/api-reference/connectionpool.md
+++ b/docs/docs/api-reference/connectionpool.md
@@ -57,7 +57,7 @@ ConnectionPoolSpec defines the desired state of ConnectionPool.
 **Optional**
 
 - [`authSecretRef`](#spec.authSecretRef-property){: name='spec.authSecretRef-property'} (object). Authentication reference to Aiven token in a secret. See below for [nested schema](#spec.authSecretRef).
-- [`connInfoSecretTarget`](#spec.connInfoSecretTarget-property){: name='spec.connInfoSecretTarget-property'} (object). Information regarding secret creation. Exposed keys: `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`, `CONNECTIONPOOL_DATABASE`, `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`, `CONNECTIONPOOL_SSLMODE`, `CONNECTIONPOOL_DATABASE_URI`. See below for [nested schema](#spec.connInfoSecretTarget).
+- [`connInfoSecretTarget`](#spec.connInfoSecretTarget-property){: name='spec.connInfoSecretTarget-property'} (object). Information regarding secret creation. Exposed keys: `CONNECTIONPOOL_NAME`, `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`, `CONNECTIONPOOL_DATABASE`, `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`, `CONNECTIONPOOL_SSLMODE`, `CONNECTIONPOOL_DATABASE_URI`. See below for [nested schema](#spec.connInfoSecretTarget).
 - [`poolMode`](#spec.poolMode-property){: name='spec.poolMode-property'} (string, Enum: `session`, `transaction`, `statement`). Mode the pool operates in (session, transaction, statement).
 - [`poolSize`](#spec.poolSize-property){: name='spec.poolSize-property'} (integer). Number of connections the pool may create towards the backend server.
 
@@ -76,7 +76,7 @@ Authentication reference to Aiven token in a secret.
 
 _Appears on [`spec`](#spec)._
 
-Information regarding secret creation. Exposed keys: `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`, `CONNECTIONPOOL_DATABASE`, `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`, `CONNECTIONPOOL_SSLMODE`, `CONNECTIONPOOL_DATABASE_URI`.
+Information regarding secret creation. Exposed keys: `CONNECTIONPOOL_NAME`, `CONNECTIONPOOL_HOST`, `CONNECTIONPOOL_PORT`, `CONNECTIONPOOL_DATABASE`, `CONNECTIONPOOL_USER`, `CONNECTIONPOOL_PASSWORD`, `CONNECTIONPOOL_SSLMODE`, `CONNECTIONPOOL_DATABASE_URI`.
 
 **Required**
 

--- a/tests/connectionpool_test.go
+++ b/tests/connectionpool_test.go
@@ -157,6 +157,7 @@ func TestConnectionPool(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["DATABASE_URI"])
 
 	// New secrets
+	assert.Equal(t, poolName, string(secret.Data["CONNECTIONPOOL_NAME"]))
 	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_HOST"])
 	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_PORT"])
 	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_DATABASE"])
@@ -164,6 +165,11 @@ func TestConnectionPool(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_PASSWORD"])
 	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_SSLMODE"])
 	assert.NotEmpty(t, secret.Data["CONNECTIONPOOL_DATABASE_URI"])
+
+	// URI contains valid values
+	uri := string(secret.Data["CONNECTIONPOOL_DATABASE_URI"])
+	assert.Contains(t, uri, string(secret.Data["CONNECTIONPOOL_HOST"]))
+	assert.Contains(t, uri, string(secret.Data["CONNECTIONPOOL_PORT"]))
 
 	// We need to validate deletion,
 	// because we can get false positive here:


### PR DESCRIPTION
- Exposes `CONNECTIONPOOL_NAME`. Resolves #560 
- Fixes `CONNECTIONPOOL_PORT` has invalid port value (the one from the service)