### PR TITLE
fix(makefile): install `goimports` to $(LOCALBIN)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCILINT=$(LOCALBIN)/golangci-lint
 GEN_CRD_API_REF_DOCS=$(LOCALBIN)/gen-crd-api-reference-docs
+GOIMPORTS ?= $(LOCALBIN)/goimports
 
 
 ## Tool Versions
@@ -340,8 +341,13 @@ endif
 		--set webhooks.enabled=${WEBHOOKS_ENABLED} \
 		aiven-operator charts/aiven-operator
 
+.PHONY: goimports
+goimports: $(GOIMPORTS) ## Download goimports locally if necessary.
+$(GOIMPORTS): $(LOCALBIN)
+	test -s $(LOCALBIN)/goimports || GOBIN=$(LOCALBIN) go install golang.org/x/tools/cmd/goimports@latest
+
 # On MACOS requires gnu-sed. Run `brew info gnu-sed` and follow instructions to replace default sed.
 .PHONY: imports
-imports:
+imports: goimports
 	find . -type f -name '*.go' -exec sed -zi 's/"\n\+\t"/"\n"/g' {} +
-	goimports -local "github.com/aiven/aiven-operator" -w .
+	$(GOIMPORTS) -local "github.com/aiven/aiven-operator" -w .


### PR DESCRIPTION
If `goimports` wasn't installed, `make build` would fail with:

    ❯ make build
    go generate ./...
    2023/12/18 11:45:04 can't compile field "topic_name" regex `^(?!\.$|\.\.$)[-_.A-Za-z0-9]+$`: error parsing regexp: invalid or unsupported Perl syntax: `(?!`
    2023/12/18 11:45:04 can't compile field "name" regex `^(?!\.$|\.\.$)[-_.A-Za-z0-9]+$`: error parsing regexp: invalid or unsupported Perl syntax: `(?!`
    2023/12/18 11:45:04 can't compile field "tag" regex `^(?!aiven-)[^\W\d_](?:[:\w./-]*[\w./-])?$`: error parsing regexp: invalid or unsupported Perl syntax: `(?!`
    2023/12/18 11:45:04 can't compile field "kafka_topic" regex `^(?!\.$|\.\.$)[-_.A-Za-z0-9]+$`: error parsing regexp: invalid or unsupported Perl syntax: `(?!`
    test -s /Users/riski/code/work/aiven-operator/bin/controller-gen || GOBIN=/Users/riski/code/work/aiven-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2
    /Users/riski/code/work/aiven-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
    find . -type f -name '*.go' -exec sed -zi 's/"\n\+\t"/"\n"/g' {} +
    goimports -local "github.com/aiven/aiven-operator" -w .
    bash: line 1: goimports: command not found
    make: *** [Makefile:352: imports] Error 127

This commit adds a new target to the makefile which downloads `goimports` to `$(LOCALBIN)` if necessary.