### PR TITLE
fix(docs): update `jq` repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After created, the Operator will create a Kubernetes Secret containing the Postg
 kubectl describe secret pg-connection
 ```
 
-Use the following [jq](https://github.com/stedolan/jq) command to decode the Secret:
+Use the following [jq](https://github.com/jqlang/jq) command to decode the Secret:
 
 ```bash
 kubectl get secret pg-connection -o json | jq '.data | map_values(@base64d)'

--- a/docs/docs/contributing/developer-guide.md
+++ b/docs/docs/contributing/developer-guide.md
@@ -40,7 +40,7 @@ Please have installed first:
 - docker/podman
 - [helm](https://helm.sh/)
 - [Aiven CLI](https://docs.aiven.io/docs/tools/cli) (make sure you have logged in)
-- [jq](https://stedolan.github.io/jq/)
+- [jq](https://jqlang.github.io/jq/)
 - [kcat](https://github.com/edenhill/kcat)
 - base64, note: MACOS version doesn't support `-w0` flag, some tests may not work properly
 - [kind](https://kind.sigs.k8s.io/), and existing cluster, e.g.

--- a/docs/docs/resources/cassandra.md
+++ b/docs/docs/resources/cassandra.md
@@ -112,7 +112,7 @@ CASSANDRA_USER:      8 bytes
 CASSANDRA_HOST:      60 bytes
 ```
 
-You can use the [jq](https://github.com/stedolan/jq) to quickly decode the Secret:
+You can use the [jq](https://github.com/jqlang/jq) to quickly decode the Secret:
 
 ```shell
 kubectl get secret cassandra-secret -o json | jq '.data | map_values(@base64d)'

--- a/docs/docs/resources/kafka/index.md
+++ b/docs/docs/resources/kafka/index.md
@@ -98,7 +98,7 @@ ACCESS_CERT:  1533 bytes
 ACCESS_KEY:   2484 bytes
 ```
 
-You can use the [jq](https://github.com/stedolan/jq) to quickly decode the Secret:
+You can use the [jq](https://github.com/jqlang/jq) to quickly decode the Secret:
 
 ```shell
 kubectl get secret kafka-auth -o json | jq '.data | map_values(@base64d)'

--- a/docs/docs/resources/mysql.md
+++ b/docs/docs/resources/mysql.md
@@ -106,7 +106,7 @@ MYSQL_HOST:      39 bytes
 MYSQL_PASSWORD:  24 bytes
 ```
 
-You can use [jq](https://github.com/stedolan/jq) to quickly decode the Secret:
+You can use [jq](https://github.com/jqlang/jq) to quickly decode the Secret:
 
 ```shell
 kubectl get secret mysql-secret -o json | jq '.data | map_values(@base64d)'
@@ -157,7 +157,7 @@ kubectl apply -f mysql-service-user.yaml
 
 The `ServiceUser` resource generates a Secret with connection information.
 
-3\. View the details of the Secret using [jq](https://github.com/stedolan/jq):
+3\. View the details of the Secret using [jq](https://github.com/jqlang/jq):
 
 ```shell
 kubectl get secret mysql-service-user-secret -o json | jq '.data | map_values(@base64d)'

--- a/docs/docs/resources/opensearch.md
+++ b/docs/docs/resources/opensearch.md
@@ -105,7 +105,7 @@ PORT:      5 bytes
 USER:      8 bytes
 ```
 
-You can use the [jq](https://github.com/stedolan/jq) to quickly decode the Secret:
+You can use the [jq](https://github.com/jqlang/jq) to quickly decode the Secret:
 
 ```shell
 kubectl get secret os-secret -o json | jq '.data | map_values(@base64d)'

--- a/docs/docs/resources/postgresql.md
+++ b/docs/docs/resources/postgresql.md
@@ -102,7 +102,7 @@ PGSSLMODE:     7 bytes
 PGUSER:        8 bytes
 ```
 
-You can use the [jq](https://github.com/stedolan/jq) to quickly decode the Secret:
+You can use the [jq](https://github.com/jqlang/jq) to quickly decode the Secret:
 
 ```shell
 kubectl get secret pg-connection -o json | jq '.data | map_values(@base64d)'

--- a/docs/docs/resources/redis.md
+++ b/docs/docs/resources/redis.md
@@ -111,7 +111,7 @@ PASSWORD:  24 bytes
 PORT:      5 bytes
 ```
 
-You can use the [jq](https://github.com/stedolan/jq) to quickly decode the Secret:
+You can use the [jq](https://github.com/jqlang/jq) to quickly decode the Secret:
 
 ```shell
 kubectl get secret redis-secret -o json | jq '.data | map_values(@base64d)'


### PR DESCRIPTION
jq repo has moved from `stedolan` to `jqlang` https://github.com/jqlang/jq/issues/2305#issuecomment-1572634869.