### PR TITLE
feat(makefile): improve tool installation and kubebuilder asset installation process

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
       - uses: karancode/kustomize-github-action@master
         with:
-          kustomize_version: 4.3.0
+          kustomize_version: 4.5.7
           kustomize_build_dir: config/default
           kustomize_output_file: deployment.yaml
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           " > config/manager/kustomization.yaml
       - uses: karancode/kustomize-github-action@master
         with:
-          kustomize_version: 4.3.0
+          kustomize_version: 4.5.7
           kustomize_build_dir: config/default
           kustomize_output_file: deployment.yaml
         env:

--- a/Makefile
+++ b/Makefile
@@ -189,33 +189,37 @@ $(LOCALBIN):
 TOOLS_DIR := hack/tools
 
 ## Tool Binaries
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-ENVTEST ?= $(LOCALBIN)/setup-envtest
-GOLANGCILINT=$(LOCALBIN)/golangci-lint
-GEN_CRD_API_REF_DOCS=$(LOCALBIN)/gen-crd-api-reference-docs
-GOIMPORTS ?= $(LOCALBIN)/goimports
-
+KUBECTL ?= kubectl
+KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
+ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
+GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v4.2.0
+KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.9.2
+ENVTEST_VERSION ?= release-0.16
+GOLANGCI_LINT_VERSION ?= v1.54.2
 
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	test -s $(LOCALBIN)/kustomize || { curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4,$(KUSTOMIZE_VERSION))
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
@@ -342,13 +346,22 @@ endif
 		--set webhooks.enabled=${WEBHOOKS_ENABLED} \
 		aiven-operator charts/aiven-operator
 
-.PHONY: goimports
-goimports: $(GOIMPORTS) ## Download goimports locally if necessary.
-$(GOIMPORTS): $(LOCALBIN)
-	test -s $(LOCALBIN)/goimports || GOBIN=$(LOCALBIN) go install golang.org/x/tools/cmd/goimports@latest
-
 # On MACOS requires gnu-sed. Run `brew info gnu-sed` and follow instructions to replace default sed.
 .PHONY: imports
-imports: goimports
+imports:
 	find . -type f -name '*.go' -exec sed -zi 's/"\n\+\t"/"\n"/g' {} +
-	$(GOIMPORTS) -local "github.com/aiven/aiven-operator" -w .
+	goimports -local "github.com/aiven/aiven-operator" -w .
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary (ideally with version)
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f $(1) ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+GOBIN=$(LOCALBIN) go install $${package} ;\
+mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
+}
+endef


### PR DESCRIPTION
* Align tool installation with kubebuilder v4 template: https://github.com/kubernetes-sigs/kubebuilder/blob/165af70e87848677a039cd0cd87cc67c545d983c/testdata/project-v4/Makefile
  * Remove `goimports` target, it was added in https://github.com/aiven/aiven-operator/commit/5cc56e2bfe0c7155e0cab2c419791e52b46904ce by me. As its not a versioned dependency, and it is very commonly used, we can expect that people familiar with go either a) already have it or b) know how to install it
  * Update kustomize to v4.5.7 to align with their versioning policy: https://github.com/kubernetes-sigs/kustomize?tab=readme-ov-file#kubectl-integration (kubectl v4.5.7 is compatible with k8s v1.26)
* Install kubebuilder asset in `envtest` target. This makes it easier to setup IDE integrations to point to the correct KUBEBUILDER_ASSETS env var. Previously, the assets were installed on demand as part of the `test` target. If one wanted to install kubebuilder assets they would have to either a) manually deduce the correct command and run it themselves (`$PWD/bin/setup-envtest use 1.25.* --bin-dir $PWD/bin -p path`) or b) uncomment the `go test..` command from the `test` target to get the assets installed.