### PR TITLE
ci: add options to pass commitlint to trunk-upgrade action

### DIFF
--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -22,3 +22,6 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: trunk-io/trunk-action/upgrade@v1
+        with:
+          prefix: "ci(deps): "
+          lowercase-title: true


### PR DESCRIPTION
https://github.com/aiven/aiven-operator/pull/595 failed in CI and upstream changes were required and done in https://github.com/trunk-io/trunk-action/pull/218.