### PR TITLE
fix(tests): move defaultNamespace const to fix undefined variable issue

### DIFF
--- a/tests/session.go
+++ b/tests/session.go
@@ -31,6 +31,7 @@ const (
 	createTimeout      = time.Second * 15
 	waitRunningTimeout = time.Minute * 10
 	yamlBufferSize     = 100
+	defaultNamespace   = "default"
 )
 
 type Session interface {

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -33,9 +33,8 @@ var (
 )
 
 const (
-	secretRefName    = "aiven-token"
-	secretRefKey     = "token"
-	defaultNamespace = "default"
+	secretRefName = "aiven-token"
+	secretRefKey  = "token"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
This addresses an issue that has been failing any commit that occurred after #632 