### PR TITLE
feat(tests): log operation status when calling `retryForever`

### DIFF
--- a/tests/projectvpc_test.go
+++ b/tests/projectvpc_test.go
@@ -147,7 +147,7 @@ func TestProjectVPCID(t *testing.T) {
 
 	// Gets Aiven object
 	var kafkaAvnUpd *aiven.Service
-	require.NoError(t, retryForever(ctx, func() (bool, error) {
+	require.NoError(t, retryForever(ctx, fmt.Sprintf("migrate %s to VPC with ID %s", kafkaName, vpc2.Status.ID), func() (bool, error) {
 		kafkaAvnUpd, err = avnClient.Services.Get(ctx, testProject, kafkaName)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
To better understand what exactly failed, `retryForever` now requires that a string that contains a description of the operation be passed.