### PR TITLE
refactor(tests): use envconfig for configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.1
 	github.com/google/go-cmp v0.6.0
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/liip/sheriff v0.11.1
 	github.com/otiai10/copy v1.14.0
 	github.com/stoewer/go-strcase v1.3.0
@@ -52,7 +53,6 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/tests/cassandra_test.go
+++ b/tests/cassandra_test.go
@@ -51,10 +51,10 @@ func TestCassandra(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	name := randName("cassandra")
-	yml := getCassandraYaml(testProject, name, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getCassandraYaml(cfg.Project, name, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN
@@ -66,7 +66,7 @@ func TestCassandra(t *testing.T) {
 	require.NoError(t, s.GetRunning(cs, name))
 
 	// THEN
-	csAvn, err := avnClient.Services.Get(ctx, testProject, name)
+	csAvn, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, csAvn.Name, cs.GetName())
 	assert.Equal(t, "RUNNING", cs.Status.State)
@@ -76,7 +76,7 @@ func TestCassandra(t *testing.T) {
 	assert.Equal(t, "450Gib", cs.Spec.DiskSpace)
 	assert.Equal(t, 460800, csAvn.DiskSpaceMB)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, cs.Spec.Tags)
-	csResp, err := avnClient.ServiceTags.Get(ctx, testProject, name)
+	csResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, csResp.Tags, cs.Spec.Tags)
 

--- a/tests/clickhouse_test.go
+++ b/tests/clickhouse_test.go
@@ -47,8 +47,8 @@ func TestClickhouse(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	name := randName("clickhouse")
-	yml := getClickhouseYaml(testProject, name, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getClickhouseYaml(cfg.Project, name, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -62,7 +62,7 @@ func TestClickhouse(t *testing.T) {
 	require.NoError(t, s.GetRunning(ch, name))
 
 	// THEN
-	chAvn, err := avnClient.Services.Get(ctx, testProject, name)
+	chAvn, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, chAvn.Name, ch.GetName())
 	assert.Equal(t, "RUNNING", ch.Status.State)
@@ -70,7 +70,7 @@ func TestClickhouse(t *testing.T) {
 	assert.Equal(t, chAvn.Plan, ch.Spec.Plan)
 	assert.Equal(t, chAvn.CloudName, ch.Spec.CloudName)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, ch.Spec.Tags)
-	chResp, err := avnClient.ServiceTags.Get(ctx, testProject, name)
+	chResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, chResp.Tags, ch.Spec.Tags)
 

--- a/tests/clickhouseuser_test.go
+++ b/tests/clickhouseuser_test.go
@@ -58,8 +58,8 @@ func TestClickhouseUser(t *testing.T) {
 	ctx := context.Background()
 	chName := randName("clickhouse-user")
 	userName := randName("clickhouse-user")
-	yml := getClickhouseUserYaml(testProject, chName, userName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getClickhouseUserYaml(cfg.Project, chName, userName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -73,7 +73,7 @@ func TestClickhouseUser(t *testing.T) {
 	require.NoError(t, s.GetRunning(ch, chName))
 
 	// THEN
-	chAvn, err := avnClient.Services.Get(ctx, testProject, chName)
+	chAvn, err := avnClient.Services.Get(ctx, cfg.Project, chName)
 	require.NoError(t, err)
 	assert.Equal(t, chAvn.Name, ch.GetName())
 	assert.Equal(t, "RUNNING", ch.Status.State)
@@ -84,7 +84,7 @@ func TestClickhouseUser(t *testing.T) {
 	user := new(v1alpha1.ClickhouseUser)
 	require.NoError(t, s.GetRunning(user, userName))
 
-	userAvn, err := avnClient.ClickhouseUser.Get(ctx, testProject, chName, user.Status.UUID)
+	userAvn, err := avnClient.ClickhouseUser.Get(ctx, cfg.Project, chName, user.Status.UUID)
 	require.NoError(t, err)
 	assert.Equal(t, userName, user.GetName())
 	assert.Equal(t, userAvn.Name, user.GetName())
@@ -107,7 +107,7 @@ func TestClickhouseUser(t *testing.T) {
 	// if service is deleted, user is destroyed in Aiven. No service — no user. No user — no user.
 	// And we make sure that controller can delete user itself
 	assert.NoError(t, s.Delete(user, func() error {
-		_, err = avnClient.ClickhouseUser.Get(ctx, testProject, chName, user.Status.UUID)
+		_, err = avnClient.ClickhouseUser.Get(ctx, cfg.Project, chName, user.Status.UUID)
 		return err
 	}))
 }

--- a/tests/connectionpool_test.go
+++ b/tests/connectionpool_test.go
@@ -84,8 +84,8 @@ func TestConnectionPool(t *testing.T) {
 	dbName := randName("connection-pool")
 	userName := randName("connection-pool")
 	poolName := randName("connection-pool")
-	yml := getConnectionPoolYaml(testProject, pgName, dbName, userName, poolName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getConnectionPoolYaml(cfg.Project, pgName, dbName, userName, poolName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -109,7 +109,7 @@ func TestConnectionPool(t *testing.T) {
 
 	// THEN
 	// Validates PostgreSQL
-	pgAvn, err := avnClient.Services.Get(ctx, testProject, pgName)
+	pgAvn, err := avnClient.Services.Get(ctx, cfg.Project, pgName)
 	require.NoError(t, err)
 	assert.Equal(t, pgAvn.Name, pg.GetName())
 	assert.Equal(t, "RUNNING", pg.Status.State)
@@ -118,20 +118,20 @@ func TestConnectionPool(t *testing.T) {
 	assert.Equal(t, pgAvn.CloudName, pg.Spec.CloudName)
 
 	// Validates Database
-	dbAvn, err := avnClient.Databases.Get(ctx, testProject, pgName, dbName)
+	dbAvn, err := avnClient.Databases.Get(ctx, cfg.Project, pgName, dbName)
 	require.NoError(t, err)
 	assert.Equal(t, dbName, db.GetName())
 	assert.Equal(t, dbAvn.DatabaseName, db.GetName())
 
 	// Validates ServiceUser
-	userAvn, err := avnClient.ServiceUsers.Get(ctx, testProject, pgName, userName)
+	userAvn, err := avnClient.ServiceUsers.Get(ctx, cfg.Project, pgName, userName)
 	require.NoError(t, err)
 	assert.Equal(t, userName, user.GetName())
 	assert.Equal(t, userName, userAvn.Username)
 	assert.Equal(t, pgName, user.Spec.ServiceName)
 
 	// Validates ConnectionPool
-	poolAvn, err := avnClient.ConnectionPools.Get(ctx, testProject, pgName, poolName)
+	poolAvn, err := avnClient.ConnectionPools.Get(ctx, cfg.Project, pgName, poolName)
 	require.NoError(t, err)
 	assert.Equal(t, pgName, pool.Spec.ServiceName)
 	assert.Equal(t, poolName, pool.GetName())
@@ -177,7 +177,7 @@ func TestConnectionPool(t *testing.T) {
 	// if service is deleted, pool is destroyed in Aiven. No service — no pool. No pool — no pool.
 	// And we make sure that controller can delete db itself
 	assert.NoError(t, s.Delete(pool, func() error {
-		_, err = avnClient.ConnectionPools.Get(ctx, testProject, pgName, poolName)
+		_, err = avnClient.ConnectionPools.Get(ctx, cfg.Project, pgName, poolName)
 		return err
 	}))
 }

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -54,8 +54,8 @@ func TestDatabase(t *testing.T) {
 	ctx := context.Background()
 	pgName := randName("database")
 	dbName := randName("database")
-	yml := getDatabaseYaml(testProject, pgName, dbName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getDatabaseYaml(cfg.Project, pgName, dbName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -73,7 +73,7 @@ func TestDatabase(t *testing.T) {
 
 	// THEN
 	// Validates PostgreSQL
-	pgAvn, err := avnClient.Services.Get(ctx, testProject, pgName)
+	pgAvn, err := avnClient.Services.Get(ctx, cfg.Project, pgName)
 	require.NoError(t, err)
 	assert.Equal(t, pgAvn.Name, pg.GetName())
 	assert.Equal(t, "RUNNING", pg.Status.State)
@@ -82,7 +82,7 @@ func TestDatabase(t *testing.T) {
 	assert.Equal(t, pgAvn.CloudName, pg.Spec.CloudName)
 
 	// Validates Database
-	dbAvn, err := avnClient.Databases.Get(ctx, testProject, pgName, dbName)
+	dbAvn, err := avnClient.Databases.Get(ctx, cfg.Project, pgName, dbName)
 	require.NoError(t, err)
 	assert.Equal(t, dbName, db.GetName())
 	assert.Equal(t, dbAvn.DatabaseName, db.GetName())
@@ -96,7 +96,7 @@ func TestDatabase(t *testing.T) {
 	// if service is deleted, db is destroyed in Aiven. No service — no db. No db — no db.
 	// And we make sure that controller can delete db itself
 	assert.NoError(t, s.Delete(db, func() error {
-		_, err = avnClient.Databases.Get(ctx, testProject, pgName, dbName)
+		_, err = avnClient.Databases.Get(ctx, cfg.Project, pgName, dbName)
 		return err
 	}))
 }

--- a/tests/generic_service_handler_test.go
+++ b/tests/generic_service_handler_test.go
@@ -60,8 +60,8 @@ func TestCreateUpdateService(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	pgName := randName("generic-handler")
-	ymlCreate := getCreateServiceYaml(testProject, pgName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	ymlCreate := getCreateServiceYaml(cfg.Project, pgName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -76,20 +76,20 @@ func TestCreateUpdateService(t *testing.T) {
 
 	// THEN
 	// Validates tags
-	tagsCreatedAvn, err := avnClient.ServiceTags.Get(ctx, testProject, pgName)
+	tagsCreatedAvn, err := avnClient.ServiceTags.Get(ctx, cfg.Project, pgName)
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]string{"env": "prod", "instance": "master"}, pg.Spec.Tags)
 	assert.Equal(t, tagsCreatedAvn.Tags, pg.Spec.Tags)
 
 	// Updates tags
-	ymlUpdate := getUpdateServiceYaml(testProject, pgName)
+	ymlUpdate := getUpdateServiceYaml(cfg.Project, pgName)
 	require.NoError(t, err)
 	require.NoError(t, s.Apply(ymlUpdate))
 
 	pgUpdated := new(v1alpha1.PostgreSQL)
 	require.NoError(t, s.GetRunning(pgUpdated, pgName))
-	tagsUpdatedAvn, err := avnClient.ServiceTags.Get(ctx, testProject, pgName)
+	tagsUpdatedAvn, err := avnClient.ServiceTags.Get(ctx, cfg.Project, pgName)
 	require.NoError(t, err)
 	assert.Empty(t, tagsUpdatedAvn.Tags) // cleared tags
 }
@@ -118,8 +118,8 @@ func TestErrorCondition(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	pgName := randName("generic-handler")
-	yml := getErrorConditionYaml(testProject, pgName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getErrorConditionYaml(cfg.Project, pgName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()

--- a/tests/grafana_test.go
+++ b/tests/grafana_test.go
@@ -50,8 +50,8 @@ func TestGrafana(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	name := randName("grafana")
-	yml := getGrafanaYaml(testProject, name, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getGrafanaYaml(cfg.Project, name, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -65,7 +65,7 @@ func TestGrafana(t *testing.T) {
 	require.NoError(t, s.GetRunning(grafana, name))
 
 	// THEN
-	grafanaAvn, err := avnClient.Services.Get(ctx, testProject, name)
+	grafanaAvn, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, grafanaAvn.Name, grafana.GetName())
 	assert.Equal(t, "RUNNING", grafana.Status.State)
@@ -73,7 +73,7 @@ func TestGrafana(t *testing.T) {
 	assert.Equal(t, grafanaAvn.Plan, grafana.Spec.Plan)
 	assert.Equal(t, grafanaAvn.CloudName, grafana.Spec.CloudName)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, grafana.Spec.Tags)
-	grafanaResp, err := avnClient.ServiceTags.Get(ctx, testProject, name)
+	grafanaResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, grafanaResp.Tags, grafana.Spec.Tags)
 

--- a/tests/kafka_test.go
+++ b/tests/kafka_test.go
@@ -52,8 +52,8 @@ func TestKafka(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	name := randName("kafka")
-	yml := getKafkaYaml(testProject, name, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getKafkaYaml(cfg.Project, name, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -67,7 +67,7 @@ func TestKafka(t *testing.T) {
 	require.NoError(t, s.GetRunning(ks, name))
 
 	// THEN
-	ksAvn, err := avnClient.Services.Get(ctx, testProject, name)
+	ksAvn, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, ksAvn.Name, ks.GetName())
 	assert.Equal(t, "RUNNING", ks.Status.State)
@@ -77,7 +77,7 @@ func TestKafka(t *testing.T) {
 	assert.Equal(t, "600Gib", ks.Spec.DiskSpace)
 	assert.Equal(t, 614400, ksAvn.DiskSpaceMB)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, ks.Spec.Tags)
-	ksResp, err := avnClient.ServiceTags.Get(ctx, testProject, name)
+	ksResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, ksResp.Tags, ks.Spec.Tags)
 

--- a/tests/kafka_with_projectvpc_ref_test.go
+++ b/tests/kafka_with_projectvpc_ref_test.go
@@ -55,8 +55,8 @@ func TestKafkaWithProjectVPCRef(t *testing.T) {
 	ctx := context.Background()
 	vpcName := randName("kafka-vpc")
 	kafkaName := randName("kafka-vpc")
-	yml := getKafkaWithProjectVPCRefYaml(testProject, vpcName, kafkaName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getKafkaWithProjectVPCRefYaml(cfg.Project, vpcName, kafkaName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -73,7 +73,7 @@ func TestKafkaWithProjectVPCRef(t *testing.T) {
 	require.NoError(t, s.GetRunning(vpc, vpcName))
 
 	// THEN
-	kafkaAvn, err := avnClient.Services.Get(ctx, testProject, kafkaName)
+	kafkaAvn, err := avnClient.Services.Get(ctx, cfg.Project, kafkaName)
 	require.NoError(t, err)
 	assert.Equal(t, kafkaAvn.Name, kafka.GetName())
 	assert.Equal(t, "RUNNING", kafka.Status.State)
@@ -86,7 +86,7 @@ func TestKafkaWithProjectVPCRef(t *testing.T) {
 	assert.Equal(t, vpcName, kafka.Spec.ProjectVPCRef.Name)
 	assert.Equal(t, anyPointer(vpc.Status.ID), kafkaAvn.ProjectVPCID)
 
-	vpcAvn, err := avnClient.VPCs.Get(ctx, testProject, vpc.Status.ID)
+	vpcAvn, err := avnClient.VPCs.Get(ctx, cfg.Project, vpc.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "ACTIVE", vpcAvn.State)
 	assert.Equal(t, vpcAvn.State, vpc.Status.State)

--- a/tests/kafkaacl_test.go
+++ b/tests/kafkaacl_test.go
@@ -72,8 +72,8 @@ func TestKafkaACL(t *testing.T) {
 	kafkaName := randName("kafka-acl")
 	topicName := randName("kafka-acl")
 	aclName := randName("kafka-acl")
-	yml := getKafkaACLYaml(testProject, kafkaName, topicName, aclName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getKafkaACLYaml(cfg.Project, kafkaName, topicName, aclName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -94,7 +94,7 @@ func TestKafkaACL(t *testing.T) {
 
 	// THEN
 	// Kafka
-	kafkaAvn, err := avnClient.Services.Get(ctx, testProject, kafkaName)
+	kafkaAvn, err := avnClient.Services.Get(ctx, cfg.Project, kafkaName)
 	require.NoError(t, err)
 	assert.Equal(t, kafkaAvn.Name, kafka.GetName())
 	assert.Equal(t, "RUNNING", kafka.Status.State)
@@ -103,7 +103,7 @@ func TestKafkaACL(t *testing.T) {
 	assert.Equal(t, kafkaAvn.CloudName, kafka.Spec.CloudName)
 
 	// KafkaTopic
-	topicAvn, err := avnClient.KafkaTopics.Get(ctx, testProject, kafkaName, topic.GetTopicName())
+	topicAvn, err := avnClient.KafkaTopics.Get(ctx, cfg.Project, kafkaName, topic.GetTopicName())
 	require.NoError(t, err)
 	assert.Equal(t, topicName, topic.GetName())
 	assert.Equal(t, topicName, topic.GetTopicName())
@@ -113,7 +113,7 @@ func TestKafkaACL(t *testing.T) {
 	assert.Len(t, topicAvn.Partitions, topic.Spec.Partitions)
 
 	// KafkaACL
-	aclAvn, err := avnClient.KafkaACLs.Get(ctx, testProject, kafkaName, acl.Status.ID)
+	aclAvn, err := avnClient.KafkaACLs.Get(ctx, cfg.Project, kafkaName, acl.Status.ID)
 	require.NoError(t, err)
 	assert.True(t, meta.IsStatusConditionTrue(acl.Status.Conditions, "Running"))
 	assert.Equal(t, "admin", acl.Spec.Permission)
@@ -136,14 +136,14 @@ func TestKafkaACL(t *testing.T) {
 	assert.NotEqual(t, aclWrite.Status.ID, acl.Status.ID)
 
 	// Permission has changed on Aiven side too
-	aclWriteAvn, err := avnClient.KafkaACLs.Get(ctx, testProject, kafkaName, aclWrite.Status.ID)
+	aclWriteAvn, err := avnClient.KafkaACLs.Get(ctx, cfg.Project, kafkaName, aclWrite.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "write", aclWrite.Spec.Permission)
 	assert.Equal(t, aclWriteAvn.Permission, aclWrite.Spec.Permission)
 
 	// Validate delete by new ID
 	assert.NoError(t, s.Delete(aclWrite, func() error {
-		_, err = avnClient.KafkaACLs.Get(ctx, testProject, kafkaName, aclWrite.Status.ID)
+		_, err = avnClient.KafkaACLs.Get(ctx, cfg.Project, kafkaName, aclWrite.Status.ID)
 		return err
 	}))
 }

--- a/tests/kafkaconnect_test.go
+++ b/tests/kafkaconnect_test.go
@@ -50,8 +50,8 @@ func TestKafkaConnect(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	name := randName("kafka-connect")
-	yml := getKafkaConnectYaml(testProject, name, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getKafkaConnectYaml(cfg.Project, name, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -65,7 +65,7 @@ func TestKafkaConnect(t *testing.T) {
 	require.NoError(t, s.GetRunning(kc, name))
 
 	// THEN
-	kcAvn, err := avnClient.Services.Get(ctx, testProject, name)
+	kcAvn, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, kcAvn.Name, kc.GetName())
 	assert.Equal(t, "RUNNING", kc.Status.State)

--- a/tests/kafkaschema_test.go
+++ b/tests/kafkaschema_test.go
@@ -71,8 +71,8 @@ func TestKafkaSchema(t *testing.T) {
 	kafkaName := randName("kafka-schema")
 	schemaName := randName("kafka-schema")
 	subjectName := randName("kafka-schema")
-	yml := getKafkaSchemaYaml(testProject, kafkaName, schemaName, subjectName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getKafkaSchemaYaml(cfg.Project, kafkaName, schemaName, subjectName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -87,7 +87,7 @@ func TestKafkaSchema(t *testing.T) {
 
 	// THEN
 	// Kafka test
-	kafkaAvn, err := avnClient.Services.Get(ctx, testProject, kafkaName)
+	kafkaAvn, err := avnClient.Services.Get(ctx, cfg.Project, kafkaName)
 	require.NoError(t, err)
 	assert.Equal(t, kafkaAvn.Name, kafka.GetName())
 	assert.Equal(t, "RUNNING", kafka.Status.State)
@@ -137,7 +137,7 @@ func TestKafkaSchema(t *testing.T) {
 
 	// Validates deleting, because deleted kafka drops schemas, and we want be sure deletion works
 	assert.NoError(t, s.Delete(schema, func() error {
-		_, err := avnClient.KafkaSubjectSchemas.Get(ctx, testProject, kafkaName, subjectName, 1)
+		_, err := avnClient.KafkaSubjectSchemas.Get(ctx, cfg.Project, kafkaName, subjectName, 1)
 		return err
 	}))
 }

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -50,8 +50,8 @@ func TestMySQL(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	name := randName("mysql")
-	yml := getMySQLYaml(testProject, name, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getMySQLYaml(cfg.Project, name, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -65,7 +65,7 @@ func TestMySQL(t *testing.T) {
 	require.NoError(t, s.GetRunning(ms, name))
 
 	// THEN
-	msAvn, err := avnClient.Services.Get(ctx, testProject, name)
+	msAvn, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, msAvn.Name, ms.GetName())
 	assert.Equal(t, "RUNNING", ms.Status.State)
@@ -75,7 +75,7 @@ func TestMySQL(t *testing.T) {
 	assert.Equal(t, "100Gib", ms.Spec.DiskSpace)
 	assert.Equal(t, 102400, msAvn.DiskSpaceMB)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, ms.Spec.Tags)
-	msResp, err := avnClient.ServiceTags.Get(ctx, testProject, name)
+	msResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, msResp.Tags, ms.Spec.Tags)
 

--- a/tests/opensearch_test.go
+++ b/tests/opensearch_test.go
@@ -55,8 +55,8 @@ func TestOpenSearch(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	name := randName("opensearch")
-	yml := getOpenSearchYaml(testProject, name, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getOpenSearchYaml(cfg.Project, name, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -70,7 +70,7 @@ func TestOpenSearch(t *testing.T) {
 	require.NoError(t, s.GetRunning(os, name))
 
 	// THEN
-	osAvn, err := avnClient.Services.Get(ctx, testProject, name)
+	osAvn, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, osAvn.Name, os.GetName())
 	assert.Equal(t, "RUNNING", os.Status.State)
@@ -80,7 +80,7 @@ func TestOpenSearch(t *testing.T) {
 	assert.Equal(t, "240Gib", os.Spec.DiskSpace)
 	assert.Equal(t, 245760, osAvn.DiskSpaceMB)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, os.Spec.Tags)
-	osResp, err := avnClient.ServiceTags.Get(ctx, testProject, name)
+	osResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, osResp.Tags, os.Spec.Tags)
 

--- a/tests/postgresql_test.go
+++ b/tests/postgresql_test.go
@@ -69,8 +69,8 @@ func TestPgReadReplica(t *testing.T) {
 	ctx := context.Background()
 	masterName := randName("pg-master")
 	replicaName := randName("pg-replica")
-	yml := getPgReadReplicaYaml(testProject, masterName, replicaName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getPgReadReplicaYaml(cfg.Project, masterName, replicaName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -88,7 +88,7 @@ func TestPgReadReplica(t *testing.T) {
 
 	// THEN
 	// Validates instances
-	masterAvn, err := avnClient.Services.Get(ctx, testProject, masterName)
+	masterAvn, err := avnClient.Services.Get(ctx, cfg.Project, masterName)
 	require.NoError(t, err)
 	assert.Equal(t, masterAvn.Name, master.GetName())
 	assert.Equal(t, "RUNNING", master.Status.State)
@@ -98,11 +98,11 @@ func TestPgReadReplica(t *testing.T) {
 	assert.NotNil(t, masterAvn.UserConfig) // "Aiven instance has defaults set"
 	assert.Nil(t, master.Spec.UserConfig)
 	assert.Equal(t, map[string]string{"env": "prod", "instance": "master"}, master.Spec.Tags)
-	masterResp, err := avnClient.ServiceTags.Get(ctx, testProject, masterName)
+	masterResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, masterName)
 	require.NoError(t, err)
 	assert.Equal(t, masterResp.Tags, master.Spec.Tags)
 
-	replicaAvn, err := avnClient.Services.Get(ctx, testProject, replicaName)
+	replicaAvn, err := avnClient.Services.Get(ctx, cfg.Project, replicaName)
 	require.NoError(t, err)
 	assert.Equal(t, replicaAvn.Name, replica.GetName())
 	assert.Equal(t, "RUNNING", replica.Status.State)
@@ -110,7 +110,7 @@ func TestPgReadReplica(t *testing.T) {
 	assert.Equal(t, replicaAvn.Plan, replica.Spec.Plan)
 	assert.Equal(t, replicaAvn.CloudName, replica.Spec.CloudName)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "replica"}, replica.Spec.Tags)
-	replicaResp, err := avnClient.ServiceTags.Get(ctx, testProject, replicaName)
+	replicaResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, replicaName)
 	require.NoError(t, err)
 	assert.Equal(t, replicaResp.Tags, replica.Spec.Tags)
 
@@ -185,8 +185,8 @@ func TestPgCustomPrefix(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	pgName := randName("secret-prefix")
-	yml := getPgCustomPrefixYaml(testProject, pgName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getPgCustomPrefixYaml(cfg.Project, pgName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -201,7 +201,7 @@ func TestPgCustomPrefix(t *testing.T) {
 
 	// THEN
 	// Validates instance
-	pgAvn, err := avnClient.Services.Get(ctx, testProject, pgName)
+	pgAvn, err := avnClient.Services.Get(ctx, cfg.Project, pgName)
 	require.NoError(t, err)
 	assert.Equal(t, pgAvn.Name, pg.GetName())
 	assert.Equal(t, "RUNNING", pg.Status.State)
@@ -209,7 +209,7 @@ func TestPgCustomPrefix(t *testing.T) {
 	assert.Equal(t, pgAvn.Plan, pg.Spec.Plan)
 	assert.Equal(t, pgAvn.CloudName, pg.Spec.CloudName)
 	assert.Equal(t, map[string]string{"env": "prod", "instance": "pg"}, pg.Spec.Tags)
-	masterResp, err := avnClient.ServiceTags.Get(ctx, testProject, pgName)
+	masterResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, pgName)
 	require.NoError(t, err)
 	assert.Equal(t, masterResp.Tags, pg.Spec.Tags)
 

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -39,7 +39,7 @@ func TestProject(t *testing.T) {
 	ctx := context.Background()
 	name := randName("project")
 	yml := getProjectYaml(name)
-	s := NewSession(k8sClient, avnClient, testProject)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()

--- a/tests/redis_test.go
+++ b/tests/redis_test.go
@@ -47,8 +47,8 @@ func TestRedis(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	name := randName("redis")
-	yml := getRedisYaml(testProject, name, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getRedisYaml(cfg.Project, name, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -62,7 +62,7 @@ func TestRedis(t *testing.T) {
 	require.NoError(t, s.GetRunning(rs, name))
 
 	// THEN
-	rsAvn, err := avnClient.Services.Get(ctx, testProject, name)
+	rsAvn, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, rsAvn.Name, rs.GetName())
 	assert.Equal(t, "RUNNING", rs.Status.State)
@@ -70,7 +70,7 @@ func TestRedis(t *testing.T) {
 	assert.Equal(t, rsAvn.Plan, rs.Spec.Plan)
 	assert.Equal(t, rsAvn.CloudName, rs.Spec.CloudName)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, rs.Spec.Tags)
-	rsResp, err := avnClient.ServiceTags.Get(ctx, testProject, name)
+	rsResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Equal(t, rsResp.Tags, rs.Spec.Tags)
 

--- a/tests/service_opts_test.go
+++ b/tests/service_opts_test.go
@@ -44,8 +44,8 @@ func TestServiceTechnicalEmails(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
 	name := randName("grafana")
-	yml := getTechnicalEmailsYaml(testProject, name, testPrimaryCloudName, true)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getTechnicalEmailsYaml(cfg.Project, name, cfg.PrimaryCloudName, true)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -60,14 +60,14 @@ func TestServiceTechnicalEmails(t *testing.T) {
 
 	// THEN
 	// Technical emails are set
-	grafanaAvn, err := avnClient.Services.Get(ctx, testProject, name)
+	grafanaAvn, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Len(t, grafana.Spec.TechnicalEmails, 1)
 	assert.Equal(t, "test@example.com", grafanaAvn.TechnicalEmails[0].Email)
 
 	// WHEN
 	// Technical emails are removed from manifest
-	updatedYml := getTechnicalEmailsYaml(testProject, name, testPrimaryCloudName, false)
+	updatedYml := getTechnicalEmailsYaml(cfg.Project, name, cfg.PrimaryCloudName, false)
 
 	// Applies updated manifest
 	require.NoError(t, s.Apply(updatedYml))
@@ -77,7 +77,7 @@ func TestServiceTechnicalEmails(t *testing.T) {
 
 	// THEN
 	// Technical emails are removed from service
-	grafanaAvnUpdated, err := avnClient.Services.Get(ctx, testProject, name)
+	grafanaAvnUpdated, err := avnClient.Services.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)
 	assert.Empty(t, grafanaAvnUpdated.TechnicalEmails)
 }
@@ -110,11 +110,11 @@ func runTest(t *testing.T, scenario TestScenario) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	baseYaml := getConnInfoBaseYaml(testProject, scenario.serviceName, testPrimaryCloudName)
+	baseYaml := getConnInfoBaseYaml(cfg.Project, scenario.serviceName, cfg.PrimaryCloudName)
 	createYaml := getYamlWithDisabledOption(baseYaml, scenario.connInfoSecretTargetDisabledChange[0])
 	updateYaml := getYamlWithDisabledOption(baseYaml, scenario.connInfoSecretTargetDisabledChange[1])
 
-	s := NewSession(k8sClient, avnClient, testProject)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()

--- a/tests/serviceintegration_test.go
+++ b/tests/serviceintegration_test.go
@@ -83,8 +83,8 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 	pgName := randName("clickhouse-postgresql")
 	siName := randName("clickhouse-postgresql")
 
-	yml := getClickhousePostgreSQLYaml(testProject, chName, pgName, siName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getClickhousePostgreSQLYaml(cfg.Project, chName, pgName, siName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -105,7 +105,7 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 
 	// THEN
 	// Validates Clickhouse
-	chAvn, err := avnClient.Services.Get(ctx, testProject, chName)
+	chAvn, err := avnClient.Services.Get(ctx, cfg.Project, chName)
 	require.NoError(t, err)
 	assert.Equal(t, chAvn.Name, ch.GetName())
 	assert.Equal(t, chAvn.State, ch.Status.State)
@@ -115,7 +115,7 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 	assert.Equal(t, chAvn.MaintenanceWindow.TimeOfDay, ch.Spec.MaintenanceWindowTime)
 
 	// Validates PostgreSQL
-	pgAvn, err := avnClient.Services.Get(ctx, testProject, pgName)
+	pgAvn, err := avnClient.Services.Get(ctx, cfg.Project, pgName)
 	require.NoError(t, err)
 	assert.Equal(t, pgAvn.Name, pg.GetName())
 	assert.Equal(t, pgAvn.State, pg.Status.State)
@@ -126,7 +126,7 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 	assert.Equal(t, pgAvn.UserConfig["pg_version"].(string), *pg.Spec.UserConfig.PgVersion)
 
 	// Validates ServiceIntegration
-	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, testProject, si.Status.ID)
+	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "clickhouse_postgresql", siAvn.IntegrationType)
 	assert.Equal(t, siAvn.IntegrationType, si.Spec.IntegrationType)
@@ -198,8 +198,8 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 	ktName := randName("kafka-logs")
 	siName := randName("kafka-logs")
 
-	yml := getKafkaLogsYaml(testProject, ksName, ktName, siName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getKafkaLogsYaml(cfg.Project, ksName, ktName, siName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -220,7 +220,7 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 
 	// THEN
 	// Validates Kafka
-	ksAvn, err := avnClient.Services.Get(ctx, testProject, ksName)
+	ksAvn, err := avnClient.Services.Get(ctx, cfg.Project, ksName)
 	require.NoError(t, err)
 	assert.Equal(t, ksAvn.Name, ks.GetName())
 	assert.Equal(t, ksAvn.State, ks.Status.State)
@@ -228,7 +228,7 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 	assert.Equal(t, ksAvn.CloudName, ks.Spec.CloudName)
 
 	// Validates KafkaTopic
-	ktAvn, err := avnClient.KafkaTopics.Get(ctx, testProject, ksName, ktName)
+	ktAvn, err := avnClient.KafkaTopics.Get(ctx, cfg.Project, ksName, ktName)
 	require.NoError(t, err)
 	assert.Equal(t, ktAvn.TopicName, kt.GetName())
 	assert.Equal(t, ktAvn.State, kt.Status.State)
@@ -236,7 +236,7 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 	assert.Len(t, ktAvn.Partitions, kt.Spec.Partitions)
 
 	// Validates ServiceIntegration
-	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, testProject, si.Status.ID)
+	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "kafka_logs", siAvn.IntegrationType)
 	assert.Equal(t, siAvn.IntegrationType, si.Spec.IntegrationType)
@@ -318,8 +318,8 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 	kcName := randName("kafka-connect")
 	siName := randName("kafka-connect")
 
-	yml := getSIKafkaConnectYaml(testProject, ksName, kcName, siName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getSIKafkaConnectYaml(cfg.Project, ksName, kcName, siName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -340,7 +340,7 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 
 	// THEN
 	// Validates Kafka
-	ksAvn, err := avnClient.Services.Get(ctx, testProject, ksName)
+	ksAvn, err := avnClient.Services.Get(ctx, cfg.Project, ksName)
 	require.NoError(t, err)
 	assert.Equal(t, ksAvn.Name, ks.GetName())
 	assert.Equal(t, ksAvn.State, ks.Status.State)
@@ -348,7 +348,7 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 	assert.Equal(t, ksAvn.CloudName, ks.Spec.CloudName)
 
 	// Validates KafkaConnect
-	kcAvn, err := avnClient.Services.Get(ctx, testProject, kcName)
+	kcAvn, err := avnClient.Services.Get(ctx, cfg.Project, kcName)
 	require.NoError(t, err)
 	assert.Equal(t, kcAvn.Name, kc.GetName())
 	assert.Equal(t, kcAvn.State, kc.Status.State)
@@ -358,7 +358,7 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 	assert.True(t, *kc.Spec.UserConfig.PublicAccess.KafkaConnect)
 
 	// Validates ServiceIntegration
-	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, testProject, si.Status.ID)
+	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "kafka_connect", siAvn.IntegrationType)
 	assert.Equal(t, siAvn.IntegrationType, si.Spec.IntegrationType)
@@ -426,8 +426,8 @@ func TestServiceIntegrationDatadog(t *testing.T) {
 	pgName := randName("datadog")
 	siName := randName("datadog")
 
-	yml := getDatadogYaml(testProject, pgName, siName, endpointID, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getDatadogYaml(cfg.Project, pgName, siName, endpointID, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -445,14 +445,14 @@ func TestServiceIntegrationDatadog(t *testing.T) {
 
 	// THEN
 	// Validates PostgreSQL
-	pgAvn, err := avnClient.Services.Get(ctx, testProject, pgName)
+	pgAvn, err := avnClient.Services.Get(ctx, cfg.Project, pgName)
 	require.NoError(t, err)
 	assert.Equal(t, pgAvn.Name, pg.GetName())
 	assert.Equal(t, pgAvn.State, pg.Status.State)
 	assert.Equal(t, pgAvn.Plan, pg.Spec.Plan)
 
 	// Validates Datadog
-	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, testProject, si.Status.ID)
+	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "datadog", siAvn.IntegrationType)
 	assert.Equal(t, siAvn.IntegrationType, si.Spec.IntegrationType)
@@ -500,10 +500,10 @@ func TestWebhookMultipleUserConfigsDenied(t *testing.T) {
 
 	// GIVEN
 	siName := randName("datadog")
-	yml := getWebhookMultipleUserConfigsDeniedYaml(testProject, siName)
+	yml := getWebhookMultipleUserConfigsDeniedYaml(cfg.Project, siName)
 
 	// WHEN
-	s := NewSession(k8sClient, avnClient, testProject)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// THEN
 	err := s.Apply(yml)

--- a/tests/serviceuser_test.go
+++ b/tests/serviceuser_test.go
@@ -63,8 +63,8 @@ func TestServiceUserKafka(t *testing.T) {
 	ctx := context.Background()
 	kafkaName := randName("service-user")
 	userName := randName("service-user")
-	yml := getServiceUserKafkaYaml(testProject, kafkaName, userName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getServiceUserKafkaYaml(cfg.Project, kafkaName, userName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterward
 	defer s.Destroy()
@@ -82,7 +82,7 @@ func TestServiceUserKafka(t *testing.T) {
 
 	// THEN
 	// Validates Kafka
-	kafkaAvn, err := avnClient.Services.Get(ctx, testProject, kafkaName)
+	kafkaAvn, err := avnClient.Services.Get(ctx, cfg.Project, kafkaName)
 	require.NoError(t, err)
 	assert.Equal(t, kafkaAvn.Name, kafka.GetName())
 	assert.Equal(t, "RUNNING", kafka.Status.State)
@@ -91,7 +91,7 @@ func TestServiceUserKafka(t *testing.T) {
 	assert.Equal(t, kafkaAvn.CloudName, kafka.Spec.CloudName)
 
 	// Validates ServiceUser
-	userAvn, err := avnClient.ServiceUsers.Get(ctx, testProject, kafkaName, userName)
+	userAvn, err := avnClient.ServiceUsers.Get(ctx, cfg.Project, kafkaName, userName)
 	require.NoError(t, err)
 	assert.Equal(t, userName, user.GetName())
 	assert.Equal(t, userName, userAvn.Username)
@@ -132,7 +132,7 @@ func TestServiceUserKafka(t *testing.T) {
 	// if service is deleted, pool is destroyed in Aiven. No service — no pool. No pool — no pool.
 	// And we make sure that the controller can delete db itself
 	assert.NoError(t, s.Delete(user, func() error {
-		_, err = avnClient.ServiceUsers.Get(ctx, testProject, kafkaName, userName)
+		_, err = avnClient.ServiceUsers.Get(ctx, cfg.Project, kafkaName, userName)
 		return err
 	}))
 }
@@ -184,8 +184,8 @@ func TestServiceUserPg(t *testing.T) {
 	ctx := context.Background()
 	pgName := randName("connection-pool")
 	userName := randName("connection-pool")
-	yml := getServiceUserPgYaml(testProject, pgName, userName, testPrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, testProject)
+	yml := getServiceUserPgYaml(cfg.Project, pgName, userName, cfg.PrimaryCloudName)
+	s := NewSession(k8sClient, avnClient, cfg.Project)
 
 	// Cleans test afterwards
 	defer s.Destroy()
@@ -203,7 +203,7 @@ func TestServiceUserPg(t *testing.T) {
 
 	// THEN
 	// Validates PostgreSQL
-	pgAvn, err := avnClient.Services.Get(ctx, testProject, pgName)
+	pgAvn, err := avnClient.Services.Get(ctx, cfg.Project, pgName)
 	require.NoError(t, err)
 	assert.Equal(t, pgAvn.Name, pg.GetName())
 	assert.Equal(t, "RUNNING", pg.Status.State)
@@ -212,7 +212,7 @@ func TestServiceUserPg(t *testing.T) {
 	assert.Equal(t, pgAvn.CloudName, pg.Spec.CloudName)
 
 	// Validates ServiceUser
-	userAvn, err := avnClient.ServiceUsers.Get(ctx, testProject, pgName, userName)
+	userAvn, err := avnClient.ServiceUsers.Get(ctx, cfg.Project, pgName, userName)
 	require.NoError(t, err)
 	assert.Equal(t, userName, user.GetName())
 	assert.Equal(t, userName, userAvn.Username)
@@ -247,7 +247,7 @@ func TestServiceUserPg(t *testing.T) {
 	// if service is deleted, pool is destroyed in Aiven. No service — no pool. No pool — no pool.
 	// And we make sure that the controller can delete db itself
 	assert.NoError(t, s.Delete(user, func() error {
-		_, err = avnClient.ServiceUsers.Get(ctx, testProject, pgName, userName)
+		_, err = avnClient.ServiceUsers.Get(ctx, cfg.Project, pgName, userName)
 		return err
 	}))
 }


### PR DESCRIPTION
1. Unifies tests configuration by using envconfig, replaces individual per-var validations
2. Removes testEnv global variable
3. Fixes kafka topic test