### PR TITLE
ci(tests): fix tests panic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
 
   sweep:
     if: always()
-    needs: [test, setup_aiven_project_suffix]
+    needs: [setup_aiven_project_suffix, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,26 @@ jobs:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
           AIVEN_PROJECT_NAME_PREFIX: ${{ secrets.AIVEN_PROJECT_NAME_PREFIX }}
 
-  test:
-    needs: setup_aiven_project_suffix
+  find_tests:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find_tests.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - id: find_tests
+        run: |
+          echo "matrix=$(LIST_ONLY=1 go test ./tests/... -list=. | grep Test | jq -cnR '[inputs | select(length>0)]')" >> $GITHUB_OUTPUT
+
+  test:
+    needs: [setup_aiven_project_suffix, find_tests]
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        name: ${{ fromJson(needs.find_tests.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,7 +48,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - run: make test
+      - run: make run="^${{ matrix.name }}$" test
         env:
           AIVEN_TOKEN: ${{ secrets.AIVEN_TOKEN }}
           AIVEN_PROJECT_NAME: >-

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test-e2e-preinstalled: check-env-vars check-avn-client ## Run end-to-end tests u
 
 test: envtest ## Run tests. To target a specific test, use 'run=TestName make test'.
 	export KUBEBUILDER_ASSETS=$(shell eval ${KUBEBUILDER_ASSETS_CMD}); \
-	go test ./tests/... -race -run=$(run) -v $(if $(run), -timeout 20m, -timeout 60m) -parallel 10 -cover -coverpkg=./controllers -covermode=atomic -coverprofile=coverage.out
+	go test ./tests/... -race -run=$(run) -v $(if $(run), -timeout 30m, -timeout 60m) -parallel 10 -cover -coverpkg=./controllers -covermode=atomic -coverprofile=coverage.out
 
 ##@ Build
 

--- a/tests/cassandra_test.go
+++ b/tests/cassandra_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -49,10 +48,12 @@ func TestCassandra(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("cassandra")
 	yml := getCassandraYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
 	// Cleans test afterward
 	defer s.Destroy()

--- a/tests/clickhouse_test.go
+++ b/tests/clickhouse_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -45,12 +44,14 @@ func TestClickhouse(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("clickhouse")
 	yml := getClickhouseYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/clickhouseuser_test.go
+++ b/tests/clickhouseuser_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -55,13 +54,15 @@ func TestClickhouseUser(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	chName := randName("clickhouse-user")
 	userName := randName("clickhouse-user")
 	yml := getClickhouseUserYaml(cfg.Project, chName, userName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/connectionpool_test.go
+++ b/tests/connectionpool_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -79,15 +78,17 @@ func TestConnectionPool(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	pgName := randName("connection-pool")
 	dbName := randName("connection-pool")
 	userName := randName("connection-pool")
 	poolName := randName("connection-pool")
 	yml := getConnectionPoolYaml(cfg.Project, pgName, dbName, userName, poolName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -51,13 +50,15 @@ func TestDatabase(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	pgName := randName("database")
 	dbName := randName("database")
 	yml := getDatabaseYaml(cfg.Project, pgName, dbName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/generic_service_handler_test.go
+++ b/tests/generic_service_handler_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -58,12 +57,14 @@ func TestCreateUpdateService(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	pgName := randName("generic-handler")
 	ymlCreate := getCreateServiceYaml(cfg.Project, pgName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN
@@ -116,12 +117,14 @@ func TestErrorCondition(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	pgName := randName("generic-handler")
 	yml := getErrorConditionYaml(cfg.Project, pgName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/grafana_test.go
+++ b/tests/grafana_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -48,12 +47,14 @@ func TestGrafana(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("grafana")
 	yml := getGrafanaYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/kafka_test.go
+++ b/tests/kafka_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -50,12 +49,14 @@ func TestKafka(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("kafka")
 	yml := getKafkaYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/kafka_with_projectvpc_ref_test.go
+++ b/tests/kafka_with_projectvpc_ref_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -52,13 +51,15 @@ func TestKafkaWithProjectVPCRef(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	vpcName := randName("kafka-vpc")
 	kafkaName := randName("kafka-vpc")
 	yml := getKafkaWithProjectVPCRefYaml(cfg.Project, vpcName, kafkaName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/kafkaacl_test.go
+++ b/tests/kafkaacl_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -68,14 +67,16 @@ func TestKafkaACL(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	kafkaName := randName("kafka-acl")
 	topicName := randName("kafka-acl")
 	aclName := randName("kafka-acl")
 	yml := getKafkaACLYaml(cfg.Project, kafkaName, topicName, aclName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/kafkaconnect_test.go
+++ b/tests/kafkaconnect_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -48,12 +47,14 @@ func TestKafkaConnect(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("kafka-connect")
 	yml := getKafkaConnectYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/kafkaschema_test.go
+++ b/tests/kafkaschema_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -67,14 +66,16 @@ func TestKafkaSchema(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	kafkaName := randName("kafka-schema")
 	schemaName := randName("kafka-schema")
 	subjectName := randName("kafka-schema")
 	yml := getKafkaSchemaYaml(cfg.Project, kafkaName, schemaName, subjectName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/kafkatopic_test.go
+++ b/tests/kafkatopic_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -74,12 +73,14 @@ func TestKafkaTopic(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	ksName := randName("kafka-topic")
 	yml := getKafkaTopicNameYaml(cfg.Project, ksName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -48,12 +47,14 @@ func TestMySQL(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("mysql")
 	yml := getMySQLYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/opensearch_test.go
+++ b/tests/opensearch_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -53,12 +52,14 @@ func TestOpenSearch(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("opensearch")
 	yml := getOpenSearchYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/postgresql_test.go
+++ b/tests/postgresql_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -69,13 +68,15 @@ func TestPgReadReplica(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	masterName := randName("pg-master")
 	replicaName := randName("pg-replica")
 	yml := getPgReadReplicaYaml(cfg.Project, masterName, replicaName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN
@@ -186,12 +187,14 @@ func TestPgCustomPrefix(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	pgName := randName("secret-prefix")
 	yml := getPgCustomPrefixYaml(cfg.Project, pgName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN
@@ -277,10 +280,12 @@ func TestPgUpgradeVersion(t *testing.T) {
 	startingVersion := pgVersions[len(pgVersions)-2]
 	targetVersion := pgVersions[len(pgVersions)-1]
 
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	pgName := randName("upgrade-test")
 	yaml := getPgUpgradeVersionYaml(cfg.Project, pgName, cfg.PrimaryCloudName, startingVersion)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
 	defer s.Destroy()
 

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -36,12 +35,14 @@ func TestProject(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("project")
 	yml := getProjectYaml(name)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/redis_test.go
+++ b/tests/redis_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -45,12 +44,14 @@ func TestRedis(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("redis")
 	yml := getRedisYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/service_opts_test.go
+++ b/tests/service_opts_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -42,12 +41,14 @@ func TestServiceTechnicalEmails(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	name := randName("grafana")
 	yml := getTechnicalEmailsYaml(cfg.Project, name, cfg.PrimaryCloudName, true)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN
@@ -114,9 +115,12 @@ func runTest(t *testing.T, scenario TestScenario) {
 	createYaml := getYamlWithDisabledOption(baseYaml, scenario.connInfoSecretTargetDisabledChange[0])
 	updateYaml := getYamlWithDisabledOption(baseYaml, scenario.connInfoSecretTargetDisabledChange[1])
 
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	ctx, cancel := testCtx()
+	defer cancel()
 
-	// Cleans test afterwards
+	s := NewSession(ctx, k8sClient, cfg.Project)
+
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/serviceintegration_test.go
+++ b/tests/serviceintegration_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -78,15 +77,17 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	chName := randName("clickhouse-postgresql")
 	pgName := randName("clickhouse-postgresql")
 	siName := randName("clickhouse-postgresql")
 
 	yml := getClickhousePostgreSQLYaml(cfg.Project, chName, pgName, siName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN
@@ -193,15 +194,17 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	ksName := randName("kafka-logs")
 	ktName := randName("kafka-logs")
 	siName := randName("kafka-logs")
 
 	yml := getKafkaLogsYaml(cfg.Project, ksName, ktName, siName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN
@@ -313,15 +316,17 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	ksName := randName("kafka-connect")
 	kcName := randName("kafka-connect")
 	siName := randName("kafka-connect")
 
 	yml := getSIKafkaConnectYaml(cfg.Project, ksName, kcName, siName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN
@@ -422,14 +427,16 @@ func TestServiceIntegrationDatadog(t *testing.T) {
 	}
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+
+	defer cancel()
 	pgName := randName("datadog")
 	siName := randName("datadog")
 
 	yml := getDatadogYaml(cfg.Project, pgName, siName, endpointID, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN
@@ -498,12 +505,15 @@ func TestWebhookMultipleUserConfigsDenied(t *testing.T) {
 	t.Parallel()
 	defer recoverPanic(t)
 
+	ctx, cancel := testCtx()
+	defer cancel()
+
 	// GIVEN
 	siName := randName("datadog")
 	yml := getWebhookMultipleUserConfigsDeniedYaml(cfg.Project, siName)
 
 	// WHEN
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
 	// THEN
 	err := s.Apply(yml)

--- a/tests/serviceuser_test.go
+++ b/tests/serviceuser_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -60,11 +59,12 @@ func TestServiceUserKafka(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
 	kafkaName := randName("service-user")
 	userName := randName("service-user")
 	yml := getServiceUserKafkaYaml(cfg.Project, kafkaName, userName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
 	// Cleans test afterward
 	defer s.Destroy()
@@ -181,13 +181,14 @@ func TestServiceUserPg(t *testing.T) {
 	defer recoverPanic(t)
 
 	// GIVEN
-	ctx := context.Background()
+	ctx, cancel := testCtx()
+	defer cancel()
 	pgName := randName("connection-pool")
 	userName := randName("connection-pool")
 	yml := getServiceUserPgYaml(cfg.Project, pgName, userName, cfg.PrimaryCloudName)
-	s := NewSession(k8sClient, avnClient, cfg.Project)
+	s := NewSession(ctx, k8sClient, cfg.Project)
 
-	// Cleans test afterwards
+	// Cleans test afterward
 	defer s.Destroy()
 
 	// WHEN

--- a/tests/session.go
+++ b/tests/session.go
@@ -27,7 +27,6 @@ import (
 )
 
 const (
-	suiteTimeout       = time.Minute * 20
 	retryInterval      = time.Second * 10
 	createTimeout      = time.Second * 15
 	waitRunningTimeout = time.Minute * 20
@@ -46,23 +45,20 @@ type Session interface {
 var _ Session = &session{}
 
 type session struct {
-	k8s       client.Client
-	avn       *aiven.Client
-	ctx       context.Context
-	cancelCtx func()
-	objs      map[string]client.Object
-	project   string
+	k8s     client.Client
+	avn     *aiven.Client
+	ctx     context.Context
+	objs    map[string]client.Object
+	project string
 }
 
 func NewSession(k8s client.Client, avn *aiven.Client, project string) Session {
-	ctx, cancel := context.WithTimeout(context.Background(), suiteTimeout)
 	s := &session{
-		k8s:       k8s,
-		avn:       avn,
-		ctx:       ctx,
-		cancelCtx: cancel,
-		objs:      make(map[string]client.Object),
-		project:   project,
+		k8s:     k8s,
+		avn:     avn,
+		ctx:     context.Background(),
+		objs:    make(map[string]client.Object),
+		project: project,
 	}
 	return s
 }
@@ -146,8 +142,6 @@ func (s *session) GetSecret(keys ...string) (*corev1.Secret, error) {
 // Tolerant to "not found" error,
 // because resource may have been deleted manually
 func (s *session) Destroy() {
-	defer s.cancelCtx()
-
 	if err := recover(); err != nil {
 		log.Printf("panicked, deleting resources: %s", err)
 	}

--- a/tests/session.go
+++ b/tests/session.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	suiteTimeout       = time.Minute * 20
 	retryInterval      = time.Second * 10
 	createTimeout      = time.Second * 15
 	waitRunningTimeout = time.Minute * 20
@@ -45,20 +46,23 @@ type Session interface {
 var _ Session = &session{}
 
 type session struct {
-	k8s     client.Client
-	avn     *aiven.Client
-	ctx     context.Context
-	objs    map[string]client.Object
-	project string
+	k8s       client.Client
+	avn       *aiven.Client
+	ctx       context.Context
+	cancelCtx func()
+	objs      map[string]client.Object
+	project   string
 }
 
 func NewSession(k8s client.Client, avn *aiven.Client, project string) Session {
+	ctx, cancel := context.WithTimeout(context.Background(), suiteTimeout)
 	s := &session{
-		k8s:     k8s,
-		avn:     avn,
-		ctx:     context.Background(),
-		objs:    make(map[string]client.Object),
-		project: project,
+		k8s:       k8s,
+		avn:       avn,
+		ctx:       ctx,
+		cancelCtx: cancel,
+		objs:      make(map[string]client.Object),
+		project:   project,
 	}
 	return s
 }
@@ -142,6 +146,12 @@ func (s *session) GetSecret(keys ...string) (*corev1.Secret, error) {
 // Tolerant to "not found" error,
 // because resource may have been deleted manually
 func (s *session) Destroy() {
+	defer s.cancelCtx()
+
+	if err := recover(); err != nil {
+		log.Printf("panicked, deleting resources: %s", err)
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(len(s.objs))
 	for n := range s.objs {
@@ -183,15 +193,18 @@ func (s *session) delete(o client.Object) error {
 		return fmt.Errorf("resource %q not applied", o.GetName())
 	}
 
-	err := s.k8s.Delete(s.ctx, o)
+	// Delete operation doesn't share the context,
+	// because it shouldn't leave artifacts
+	ctx := context.Background()
+	err := s.k8s.Delete(ctx, o)
 	if err != nil {
 		return fmt.Errorf("kubernetes error: %w", err)
 	}
 
 	// Waits being deleted from kube
 	key := types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}
-	return retryForever(s.ctx, fmt.Sprintf("delete %s", o.GetName()), func() (bool, error) {
-		err := s.k8s.Get(s.ctx, key, o)
+	return retryForever(ctx, fmt.Sprintf("delete %s", o.GetName()), func() (bool, error) {
+		err := s.k8s.Get(ctx, key, o)
 		return !isNotFound(err), nil
 	})
 }

--- a/tests/session.go
+++ b/tests/session.go
@@ -46,17 +46,15 @@ var _ Session = &session{}
 
 type session struct {
 	k8s     client.Client
-	avn     *aiven.Client
 	ctx     context.Context
 	objs    map[string]client.Object
 	project string
 }
 
-func NewSession(k8s client.Client, avn *aiven.Client, project string) Session {
+func NewSession(ctx context.Context, k8s client.Client, project string) Session {
 	s := &session{
 		k8s:     k8s,
-		avn:     avn,
-		ctx:     context.Background(),
+		ctx:     ctx,
 		objs:    make(map[string]client.Object),
 		project: project,
 	}

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -43,6 +43,13 @@ type testConfig struct {
 }
 
 func TestMain(m *testing.M) {
+	if os.Getenv("LIST_ONLY") != "" {
+		// For go test ./... -list=.
+		// Lists test names without running them.
+		m.Run()
+		return
+	}
+
 	env, err := setupSuite()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
- Tries to destroy resources even when panics
- Splits tests into separate jobs, as individual timeouts are not supported in go [yet](https://github.com/golang/go/issues/48157)
- Adds per-test context timeout to end test gracefully
- Increases the test runner timeout to 30 minutes to let timeouting test finish