### PR TITLE
refactor: use compatible client error checks

### DIFF
--- a/controllers/basic_controller.go
+++ b/controllers/basic_controller.go
@@ -266,7 +266,7 @@ func (i *instanceReconcilerHelper) reconcileInstance(ctx context.Context, o v1al
 	i.rec.Event(o, corev1.EventTypeNormal, eventWaitingForTheInstanceToBeRunning, "waiting for the instance to be running")
 	err = i.updateInstanceStateAndSecretUntilRunning(ctx, o)
 	if err != nil {
-		if aiven.IsNotFound(err) {
+		if isNotFound(err) {
 			return true, nil
 		}
 
@@ -389,7 +389,7 @@ func (i *instanceReconcilerHelper) finalize(ctx context.Context, o v1alpha1.Aive
 		if i.isInvalidTokenError(err) && !IsAlreadyRunning(o) {
 			i.log.Info("invalid token error on deletion, removing finalizer", "apiError", err)
 			finalised = true
-		} else if aiven.IsNotFound(err) {
+		} else if isNotFound(err) {
 			i.rec.Event(o, corev1.EventTypeWarning, eventUnableToDeleteAtAiven, err.Error())
 			return false, fmt.Errorf("unable to delete instance at aiven: %w", err)
 		} else if isAivenServerError(err) {

--- a/controllers/clickhouseuser_controller.go
+++ b/controllers/clickhouseuser_controller.go
@@ -82,7 +82,7 @@ func (h *clickhouseUserHandler) delete(ctx context.Context, avn *aiven.Client, a
 	}
 
 	err = avn.ClickhouseUser.Delete(ctx, user.Spec.Project, user.Spec.ServiceName, user.Status.UUID)
-	if !aiven.IsNotFound(err) {
+	if !isNotFound(err) {
 		return false, err
 	}
 

--- a/controllers/connectionpool_controller.go
+++ b/controllers/connectionpool_controller.go
@@ -62,7 +62,7 @@ func (h ConnectionPoolHandler) createOrUpdate(ctx context.Context, avn *aiven.Cl
 				PoolSize: cp.Spec.PoolSize,
 				Username: optionalStringPointer(cp.Spec.Username),
 			})
-		if err != nil && !aiven.IsAlreadyExists(err) {
+		if err != nil && !isAlreadyExists(err) {
 			return err
 		}
 		reason = "Created"
@@ -101,7 +101,7 @@ func (h ConnectionPoolHandler) delete(ctx context.Context, avn *aiven.Client, av
 	}
 
 	err = avn.ConnectionPools.Delete(ctx, cp.Spec.Project, cp.Spec.ServiceName, cp.Name)
-	if err != nil && !aiven.IsNotFound(err) {
+	if err != nil && !isNotFound(err) {
 		return false, err
 	}
 
@@ -111,7 +111,7 @@ func (h ConnectionPoolHandler) delete(ctx context.Context, avn *aiven.Client, av
 func (h ConnectionPoolHandler) exists(ctx context.Context, avn *aiven.Client, cp *v1alpha1.ConnectionPool) (bool, error) {
 	conPool, err := avn.ConnectionPools.Get(ctx, cp.Spec.Project, cp.Spec.ServiceName, cp.Name)
 	if err != nil {
-		if aiven.IsNotFound(err) {
+		if isNotFound(err) {
 			return false, nil
 		}
 		return false, err

--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -90,7 +90,7 @@ func (h DatabaseHandler) delete(ctx context.Context, avn *aiven.Client, avnGen a
 		db.Spec.Project,
 		db.Spec.ServiceName,
 		db.Name)
-	if err != nil && !aiven.IsNotFound(err) {
+	if err != nil && !isNotFound(err) {
 		return false, err
 	}
 
@@ -99,7 +99,7 @@ func (h DatabaseHandler) delete(ctx context.Context, avn *aiven.Client, avnGen a
 
 func (h DatabaseHandler) exists(ctx context.Context, avn *aiven.Client, db *v1alpha1.Database) (bool, error) {
 	d, err := avn.Databases.Get(ctx, db.Spec.Project, db.Spec.ServiceName, db.Name)
-	if aiven.IsNotFound(err) {
+	if isNotFound(err) {
 		return false, nil
 	}
 

--- a/controllers/generic_service_handler.go
+++ b/controllers/generic_service_handler.go
@@ -45,7 +45,7 @@ func (h *genericServiceHandler) createOrUpdate(ctx context.Context, avn *aiven.C
 
 	oldService, err := avn.Services.Get(ctx, spec.Project, ometa.Name)
 	exists := err == nil
-	if !exists && !aiven.IsNotFound(err) {
+	if !exists && !isNotFound(err) {
 		return fmt.Errorf("failed to fetch service: %w", err)
 	}
 
@@ -159,7 +159,7 @@ func (h *genericServiceHandler) delete(ctx context.Context, avn *aiven.Client, a
 	}
 
 	err = avn.Services.Delete(ctx, spec.Project, o.getObjectMeta().Name)
-	if err == nil || aiven.IsNotFound(err) {
+	if err == nil || isNotFound(err) {
 		return true, nil
 	}
 

--- a/controllers/kafkaacl_controller.go
+++ b/controllers/kafkaacl_controller.go
@@ -94,7 +94,7 @@ func (h KafkaACLHandler) delete(ctx context.Context, avn *aiven.Client, avnGen a
 		err = avn.KafkaACLs.Delete(ctx, acl.Spec.Project, acl.Spec.ServiceName, id)
 	}
 
-	if err != nil && !aiven.IsNotFound(err) {
+	if err != nil && !isNotFound(err) {
 		return false, fmt.Errorf("aiven client delete Kafka ACL error: %w", err)
 	}
 
@@ -123,7 +123,7 @@ func (h KafkaACLHandler) getID(ctx context.Context, avn *aiven.Client, acl *v1al
 		}
 	}
 
-	// Error should mimic client error to play well with aiven.IsNotFound(err)
+	// Error should mimic client error to play well with isNotFound(err)
 	return "", aiven.Error{Status: http.StatusNotFound, Message: fmt.Sprintf("Kafka ACL %q not found", acl.Name)}
 }
 

--- a/controllers/kafkaconnector_controller.go
+++ b/controllers/kafkaconnector_controller.go
@@ -64,7 +64,7 @@ func (h KafkaConnectorHandler) createOrUpdate(ctx context.Context, avn *aiven.Cl
 	var reason string
 	if !exists {
 		err = avn.KafkaConnectors.Create(ctx, conn.Spec.Project, conn.Spec.ServiceName, connCfg)
-		if err != nil && !aiven.IsAlreadyExists(err) {
+		if err != nil && !isAlreadyExists(err) {
 			return err
 		}
 		reason = "Created"
@@ -141,7 +141,7 @@ func (h KafkaConnectorHandler) delete(ctx context.Context, avn *aiven.Client, av
 		return false, err
 	}
 	err = avn.KafkaConnectors.Delete(ctx, conn.Spec.Project, conn.Spec.ServiceName, conn.Name)
-	if err != nil && !aiven.IsNotFound(err) {
+	if err != nil && !isNotFound(err) {
 		return false, fmt.Errorf("unable to delete kafka connector: %w", err)
 	}
 	return true, nil
@@ -149,7 +149,7 @@ func (h KafkaConnectorHandler) delete(ctx context.Context, avn *aiven.Client, av
 
 func (h KafkaConnectorHandler) exists(ctx context.Context, avn *aiven.Client, conn *v1alpha1.KafkaConnector) (bool, error) {
 	connector, err := avn.KafkaConnectors.Status(ctx, conn.Spec.Project, conn.Spec.ServiceName, conn.Name)
-	if err != nil && !aiven.IsNotFound(err) {
+	if err != nil && !isNotFound(err) {
 		return false, err
 	}
 	return connector != nil, nil

--- a/controllers/kafkaschema_controller.go
+++ b/controllers/kafkaschema_controller.go
@@ -101,7 +101,7 @@ func (h KafkaSchemaHandler) delete(ctx context.Context, avn *aiven.Client, avnGe
 	}
 
 	err = avn.KafkaSubjectSchemas.Delete(ctx, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName)
-	if err != nil && !aiven.IsNotFound(err) {
+	if err != nil && !isNotFound(err) {
 		return false, fmt.Errorf("aiven client delete Kafka Schema error: %w", err)
 	}
 

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -66,7 +66,7 @@ func (h KafkaTopicHandler) createOrUpdate(ctx context.Context, avn *aiven.Client
 			Tags:        tags,
 			Config:      convertKafkaTopicConfig(topic),
 		})
-		if err != nil && !aiven.IsAlreadyExists(err) {
+		if err != nil && !isAlreadyExists(err) {
 			return err
 		}
 
@@ -112,7 +112,7 @@ func (h KafkaTopicHandler) delete(ctx context.Context, avn *aiven.Client, avnGen
 
 	// Delete project on Aiven side
 	err = avn.KafkaTopics.Delete(ctx, topic.Spec.Project, topic.Spec.ServiceName, topic.GetTopicName())
-	if err != nil && !aiven.IsNotFound(err) {
+	if err != nil && !isNotFound(err) {
 		return false, err
 	}
 
@@ -121,7 +121,7 @@ func (h KafkaTopicHandler) delete(ctx context.Context, avn *aiven.Client, avnGen
 
 func (h KafkaTopicHandler) exists(ctx context.Context, avn *aiven.Client, topic *v1alpha1.KafkaTopic) (bool, error) {
 	t, err := avn.KafkaTopics.Get(ctx, topic.Spec.Project, topic.Spec.ServiceName, topic.GetTopicName())
-	if err != nil && !aiven.IsNotFound(err) {
+	if err != nil && !isNotFound(err) {
 		if aivenError, ok := err.(aiven.Error); ok {
 			// Getting topic info can sometimes temporarily fail with 501 and 502. Don't
 			// treat that as fatal error but keep on retrying instead.

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -180,7 +180,7 @@ func (h ProjectHandler) get(ctx context.Context, avn *aiven.Client, avnGen avnge
 // exists checks if project already exists on Aiven side
 func (h ProjectHandler) exists(ctx context.Context, avn *aiven.Client, project *v1alpha1.Project) (bool, error) {
 	pr, err := avn.Projects.Get(ctx, project.Name)
-	if aiven.IsNotFound(err) {
+	if isNotFound(err) {
 		return false, nil
 	}
 
@@ -199,7 +199,7 @@ func (h ProjectHandler) delete(ctx context.Context, avn *aiven.Client, avnGen av
 		var skip bool
 
 		// If project not found then there is nothing to delete
-		if aiven.IsNotFound(err) {
+		if isNotFound(err) {
 			skip = true
 		}
 

--- a/controllers/projectvpc_controller.go
+++ b/controllers/projectvpc_controller.go
@@ -83,7 +83,7 @@ func (h *ProjectVPCHandler) delete(ctx context.Context, avn *aiven.Client, avnGe
 	}
 
 	vpc, err := avn.VPCs.Get(ctx, projectVPC.Spec.Project, projectVPC.Status.ID)
-	if aiven.IsNotFound(err) {
+	if isNotFound(err) {
 		return true, nil
 	}
 

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -55,7 +55,7 @@ func (h ServiceUserHandler) createOrUpdate(ctx context.Context, avn *aiven.Clien
 				RedisACLKeys:       []string{},
 			},
 		})
-	if err != nil && !aiven.IsAlreadyExists(err) {
+	if err != nil && !isAlreadyExists(err) {
 		return fmt.Errorf("cannot createOrUpdate service user on aiven side: %w", err)
 	}
 
@@ -84,7 +84,7 @@ func (h ServiceUserHandler) delete(ctx context.Context, avn *aiven.Client, avnGe
 	}
 
 	err = avn.ServiceUsers.Delete(ctx, user.Spec.Project, user.Spec.ServiceName, user.Name)
-	if !aiven.IsNotFound(err) {
+	if !isNotFound(err) {
 		return false, err
 	}
 


### PR DESCRIPTION
Now we are mixing the old and the new client. Error checks must support both types of errors: the old and the new one.