### PR TITLE
ci(release): fix incorrect release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: Amraneze/push-to-protected-branch@v1.5.0
         with:
           repository: ${{ github.repository }}
-          branch_name: ${{ github.ref_name }}
+          branch_name: main
           github_token: ${{ secrets.AIVEN_CI_PAT__VALID_WHILE_ALEKS_IS_EMPLOYED }}
           commit_message: "chore(version): bump operator version"
           files_to_commit: main.go


### PR DESCRIPTION
Fixes incorrect release branch in `release.yml`. Because the change is triggered by a tag, `github.ref_name` contains the name of the tag, e.g. `v0.17.0`, `v0.18.0`, etc.
