### PR TITLE
ci(dependabot): run on weekly basis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
       main:
         applies-to: version-updates
         patterns:
-          - '*'
+          - "*"
       sec:
         applies-to: security-updates
         patterns:
-          - '*'
+          - "*"
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -38,8 +38,8 @@ updates:
       main:
         applies-to: version-updates
         patterns:
-          - '*'
+          - "*"
       sec:
         applies-to: security-updates
         patterns:
-          - '*'
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,20 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      main:
+        applies-to: version-updates
+        patterns:
+          - '*'
+      sec:
+        applies-to: security-updates
+        patterns:
+          - '*'
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     ignore:
       - dependency-name: k8s.io/api
         update-types:
@@ -25,3 +34,12 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+    groups:
+      main:
+        applies-to: version-updates
+        patterns:
+          - '*'
+      sec:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
- Sets `dependabot` to run on a weekly basis instead of its default daily basis
- Groups dependencies together to create one PR instead of multiple ones

<!-- Provide the issue number below if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- To save the amount of time that it takes to review PRs
- To reduce the notification noise that it creates
