### PR TITLE
ci(trunk-upgrade): run on weekly basis

### DIFF
--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -3,7 +3,7 @@ name: trunk upgrade
 
 on:
   schedule:
-    - cron: 0 8 * * 1-5
+    - cron: 0 8 * * 1
   workflow_dispatch: {}
 
 permissions: read-all


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->

## About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
- Sets `trunk-upgrade` to run on a weekly basis instead of its default daily basis

<!-- Provide the issue number below if it exists. -->

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- To save the amount of time that it takes to review PRs
- To reduce the notification noise that it creates
