### PR TITLE
docs(changelog): add missing user-agent entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `KafkaSchemaRegistryACL` kind
 - Add `ClickhouseDatabase` kind
 - Fix secret creation for kinds with no secrets
+- Include the Kubernetes version in the Go client's user agent
 - Replace `Database` kind validations and default values with CRD validation rules
 - Perform upgrade tasks to check if PG service can be upgraded before updating the service
 - Expose project CA certificate to service secrets: `REDIS_CA_CERT`, `MYSQL_CA_CERT`, etc.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,6 +6,7 @@
 - Add `KafkaSchemaRegistryACL` kind
 - Add `ClickhouseDatabase` kind
 - Fix secret creation for kinds with no secrets
+- Include the Kubernetes version in the Go client's user agent
 - Replace `Database` kind validations and default values with CRD validation rules
 - Perform upgrade tasks to check if PG service can be upgraded before updating the service
 - Expose project CA certificate to service secrets: `REDIS_CA_CERT`, `MYSQL_CA_CERT`, etc.


### PR DESCRIPTION
Must include the kube version gathering change.