### PR TITLE
fix(docs): indentation formatting on several admonitions

### DIFF
--- a/docs/docs/installation/helm.md
+++ b/docs/docs/installation/helm.md
@@ -44,7 +44,7 @@ helm install aiven-operator aiven/aiven-operator
 ```
 
 !!! note
-Installation will fail if webhooks are enabled and the CRDs for the cert-manager are not installed.
+    Installation will fail if webhooks are enabled and the CRDs for the cert-manager are not installed.
 
 Verify the installation:
 
@@ -80,7 +80,7 @@ If the person installing the Helm chart does not have the necessary permissions 
 ## Uninstalling
 
 !!! important
-Please see [this page](uninstalling.md) for more information.
+    Please see [this page](uninstalling.md) for more information.
 
 Find out the name of your deployment:
 

--- a/docs/docs/installation/prerequisites.md
+++ b/docs/docs/installation/prerequisites.md
@@ -19,8 +19,10 @@ The Aiven Operator for Kubernetes uses `cert-manager` to configure the [service 
 Please follow the [installation instructions](https://cert-manager.io/docs/installation/helm/) on their website.
 
 !!! note
-This is not required in the Helm installation if you select to [disable webhooks](./helm.md),
-but that is not recommended outside of playground use.
-The Aiven Operator for Kubernetes uses webhooks for setting defaults
-and enforcing invariants that are expected by the aiven API and will lead to errors if ignored.
-In the future webhooks will also be used for conversion and supporting multiple CRD versions.
+    This is not required in the Helm installation if you select to [disable webhooks](./helm.md),
+    but that is not recommended outside of playground use.
+
+    The Aiven Operator for Kubernetes uses webhooks for setting defaults
+    and enforcing invariants that are expected by the aiven API and will lead to errors if ignored.
+
+    In the future webhooks will also be used for conversion and supporting multiple CRD versions.

--- a/docs/docs/resources/cassandra.md
+++ b/docs/docs/resources/cassandra.md
@@ -7,7 +7,7 @@ weight: 55
 Aiven for Apache Cassandra® is a distributed database designed to handle large volumes of writes.
 
 !!! note
-Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)) and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)), and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Creating a Cassandra instance
 

--- a/docs/docs/resources/kafka/index.md
+++ b/docs/docs/resources/kafka/index.md
@@ -8,9 +8,9 @@ Aiven for Apache Kafka is an excellent option if you need to run Apache Kafka at
 you can get up and running with a suitably sized Apache Kafka service in a few minutes.
 
 !!! note
-Before going through this guide, make sure you have a [Kubernetes cluster](../../installation/prerequisites.md) with the
-operator installed (see instructions for [helm](../../installation/helm.md) or [kubectl](../../installation/kubectl.md))
-and a [Kubernetes Secret with an Aiven authentication token](../../authentication.md).
+    Before going through this guide, make sure you have a [Kubernetes cluster](../../installation/prerequisites.md) with the
+    operator installed (see instructions for [helm](../../installation/helm.md) or [kubectl](../../installation/kubectl.md)),
+    and a [Kubernetes Secret with an Aiven authentication token](../../authentication.md).
 
 ## Creating a Kafka instance
 

--- a/docs/docs/resources/opensearch.md
+++ b/docs/docs/resources/opensearch.md
@@ -7,8 +7,8 @@ weight: 45
 OpenSearch® is an open source search and analytics suite including search engine, NoSQL document database, and visualization interface. OpenSearch offers a distributed, full-text search engine based on Apache Lucene® with a RESTful API interface and support for JSON documents.
 
 !!! note
-Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md))
-and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
+    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Creating an OpenSearch instance
 

--- a/docs/docs/resources/postgresql.md
+++ b/docs/docs/resources/postgresql.md
@@ -12,8 +12,8 @@ extender for location queries. Aiven for PostgreSQL is the perfect fit for your 
 With Aiven Kubernetes Operator, you can manage Aiven for PostgreSQL through the well defined Kubernetes API.
 
 !!! note
-Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
-and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
+    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Creating a PostgreSQL instance
 
@@ -361,7 +361,7 @@ spec:
 ```
 
 !!! note
-You can create the replica service in a different region or on a different cloud provider.
+    You can create the replica service in a different region or on a different cloud provider.
 
 2\. Apply the configuration with the following command:
 

--- a/docs/docs/resources/project-vpc.md
+++ b/docs/docs/resources/project-vpc.md
@@ -11,8 +11,8 @@ directly without going through the public internet.
 Within the Aiven Kubernetes Operator, you can create a `ProjectVPC` on Aiven's side to connect to your cloud provider.
 
 !!! note
-Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
-and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
+    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Creating an Aiven VPC
 

--- a/docs/docs/resources/project.md
+++ b/docs/docs/resources/project.md
@@ -5,8 +5,8 @@ weight: 5
 ---
 
 !!! note
-Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md))
-and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)), 
+    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 The `Project` CRD allows you to create Aiven Projects, where your resources can be located.
 

--- a/docs/docs/resources/redis.md
+++ b/docs/docs/resources/redis.md
@@ -7,8 +7,8 @@ weight: 50
 Aiven for Redis®\* is a fully managed in-memory NoSQL database that you can deploy in the cloud of your choice to store and access data quickly and efficiently.
 
 !!! note
-Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md))
-and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)), 
+    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Creating a Redis instance
 

--- a/docs/docs/resources/service-integrations.md
+++ b/docs/docs/resources/service-integrations.md
@@ -11,8 +11,8 @@ our [Getting Started with Service Integrations guide](https://aiven.io/docs/plat
 for more information.
 
 !!! note
-Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
-and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
+    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Send Kafka logs to a Kafka Topic
 


### PR DESCRIPTION
There was missing indentation on several admonitions which resulted in a admonition box (e.g. 'Note') and the text that should be inside the box was just appearing below the box as regular text.

Fix:
After a '!!! note' etc. the admonition content on the next line need to be aligned with the 'note'.