### PR TITLE
Revert "build(deps): bump wagoid/commitlint-github-action from 5 to 6"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+    ignore:
+      # Remove this when Trunk uses v19 for Commitlint
+      - dependency-name: wagoid/commitlint-github-action
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: gomod
     directory: /
     schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@v5
   trunk:
     runs-on: ubuntu-latest
     permissions:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   extends: ["@commitlint/config-conventional"],
   ignores: [(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
 };


### PR DESCRIPTION
Reverts aiven/aiven-operator#690

This breaks the ability to run `commitlint` locally when committing. 