### PR TITLE
test: uniform user-agent

### DIFF
--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -142,12 +142,12 @@ func setupSuite() (*envtest.Environment, error) {
 		return nil, fmt.Errorf("unable to get k8s version: %w", err)
 	}
 
-	avnClient, err = controllers.NewAivenClient(cfg.Token, kubeVersion.String()+"-test", operatorVersion+"-test")
+	avnClient, err = controllers.NewAivenClient(cfg.Token, kubeVersion.String(), operatorVersion)
 	if err != nil {
 		return nil, err
 	}
 
-	avnGen, err = controllers.NewAivenGeneratedClient(cfg.Token, kubeVersion.String()+"-test", operatorVersion+"-test")
+	avnGen, err = controllers.NewAivenGeneratedClient(cfg.Token, kubeVersion.String(), operatorVersion)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
current user-agent during tests is:

`k8s-operator/x.y.z-test/test-test`

where `x.y.z` is the k8s version

this PR uniforms it with what we use in Terraform: `terraform-provider-aiven/x.y.z/test`, i.e. it'll be `k8s-operator/x.y.z/test`
