### PR TITLE
chore(ci): update commitlint config to v19 format and update commitlint-github-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      # Remove this when Trunk uses v19 for Commitlint
-      - dependency-name: wagoid/commitlint-github-action
-        update-types:
-          - version-update:semver-major
   - package-ecosystem: gomod
     directory: /
     schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5
+      - uses: wagoid/commitlint-github-action@v6
   trunk:
     runs-on: ubuntu-latest
     permissions:

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   extends: ["@commitlint/config-conventional"],
   ignores: [(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
 };


### PR DESCRIPTION
We run commitlint locally via trunk, but trunk-action doesn't run commitlint in CI so we still need `wagoid/commitlint-github-action`.