### PR TITLE
fix(serviceintegration): skip delete if has no id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Add kind: `ServiceIntegrationEndpoint`
+- Fix `ServiceIntegration` deletion when instance has no id set
 - Change `Kafka` field `userConfig.kafka_version`: enum ~~`[3.4, 3.5, 3.6]`~~ → `[3.4, 3.5, 3.6, 3.7]`
 - Add `ServiceIntegration` `flink_external_postgresql` type
 

--- a/controllers/serviceintegration_controller.go
+++ b/controllers/serviceintegration_controller.go
@@ -132,11 +132,11 @@ func (h ServiceIntegrationHandler) delete(ctx context.Context, avn *aiven.Client
 	}
 
 	if si.Status.ID == "" {
-		return false, nil
+		return true, nil
 	}
 
 	err = avnGen.ServiceIntegrationDelete(ctx, si.Spec.Project, si.Status.ID)
-	if err != nil && avngen.IsNotFound(err) {
+	if avngen.OmitNotFound(err) != nil {
 		return false, fmt.Errorf("aiven client delete service integration error: %w", err)
 	}
 

--- a/controllers/serviceintegrationendpoint_controller.go
+++ b/controllers/serviceintegrationendpoint_controller.go
@@ -130,11 +130,11 @@ func (h ServiceIntegrationEndpointHandler) delete(ctx context.Context, avn *aive
 	}
 
 	if si.Status.ID == "" {
-		return false, nil
+		return true, nil
 	}
 
 	err = avnGen.ServiceIntegrationEndpointDelete(ctx, si.Spec.Project, si.Status.ID)
-	if err != nil && avngen.IsNotFound(err) {
+	if avngen.OmitNotFound(err) != nil {
 		return false, fmt.Errorf("aiven client delete service integration endpoint error: %w", err)
 	}
 


### PR DESCRIPTION
`ServiceIntegration` instance without id is looped in deletion.
The bug appeared in [017d5c5:133](https://github.com/aiven/aiven-operator/commit/017d5c54d8023a9feff324fd970815e97440f56f#diff-964ab155d891c32d1b45aff877417feae4cdc021214efe999f94e0e409c750a1R133) and [017d5c5:137](https://github.com/aiven/aiven-operator/commit/017d5c54d8023a9feff324fd970815e97440f56f#diff-964ab155d891c32d1b45aff877417feae4cdc021214efe999f94e0e409c750a1R137) after refactoring and copy-pasted to the service integration endpoint controller later. Before that, deletion was requested with empty id which produced false positive 404, yet it worked.
While `ServiceIntegrationEndpoint` is not released yet, not mentioning it in the changelog.