### PR TITLE
fix: remove redundant CA_CERT secret key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix `ServiceIntegration` deletion when instance has no id set
 - Change `Kafka` field `userConfig.kafka_version`: enum ~~`[3.4, 3.5, 3.6]`~~ → `[3.4, 3.5, 3.6, 3.7]`
 - Add `ServiceIntegration` `flink_external_postgresql` type
-- Remove `REDIS_CA_CERT` secret key. Can't be used with the service type
+- Remove `CA_CERT` secret key for `Grafana`, `OpenSearch`, `Redis`, and `Clickhouse`. Can't be used with these service types
 
 ## v0.19.0 - 2024-04-18
 

--- a/api/v1alpha1/clickhouse_types.go
+++ b/api/v1alpha1/clickhouse_types.go
@@ -20,7 +20,7 @@ type ClickhouseSpec struct {
 //+kubebuilder:subresource:status
 
 // Clickhouse is the Schema for the clickhouses API.
-// Info "Exposes secret keys": `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_CA_CERT`
+// Info "Exposes secret keys": `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`
 type Clickhouse struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/grafana_types.go
+++ b/api/v1alpha1/grafana_types.go
@@ -19,7 +19,7 @@ type GrafanaSpec struct {
 }
 
 // Grafana is the Schema for the grafanas API.
-// Info "Exposes secret keys": `GRAFANA_HOST`, `GRAFANA_PORT`, `GRAFANA_USER`, `GRAFANA_PASSWORD`, `GRAFANA_URI`, `GRAFANA_HOSTS`, `GRAFANA_CA_CERT`
+// Info "Exposes secret keys": `GRAFANA_HOST`, `GRAFANA_PORT`, `GRAFANA_USER`, `GRAFANA_PASSWORD`, `GRAFANA_URI`, `GRAFANA_HOSTS`
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Project",type="string",JSONPath=".spec.project"

--- a/api/v1alpha1/opensearch_types.go
+++ b/api/v1alpha1/opensearch_types.go
@@ -20,7 +20,7 @@ type OpenSearchSpec struct {
 //+kubebuilder:subresource:status
 
 // OpenSearch is the Schema for the opensearches API.
-// Info "Exposes secret keys": `OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`, `OPENSEARCH_CA_CERT`
+// Info "Exposes secret keys": `OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`
 type OpenSearch struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
@@ -20,8 +20,7 @@ spec:
         openAPIV3Schema:
           description:
             'Clickhouse is the Schema for the clickhouses API. Info "Exposes
-            secret keys": `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`,
-            `CLICKHOUSE_CA_CERT`'
+            secret keys": `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`'
           properties:
             apiVersion:
               description:

--- a/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
@@ -34,7 +34,7 @@ spec:
           description:
             'Grafana is the Schema for the grafanas API. Info "Exposes secret
             keys": `GRAFANA_HOST`, `GRAFANA_PORT`, `GRAFANA_USER`, `GRAFANA_PASSWORD`,
-            `GRAFANA_URI`, `GRAFANA_HOSTS`, `GRAFANA_CA_CERT`'
+            `GRAFANA_URI`, `GRAFANA_HOSTS`'
           properties:
             apiVersion:
               description:

--- a/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
@@ -20,8 +20,7 @@ spec:
         openAPIV3Schema:
           description:
             'OpenSearch is the Schema for the opensearches API. Info "Exposes
-            secret keys": `OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`,
-            `OPENSEARCH_CA_CERT`'
+            secret keys": `OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`'
           properties:
             apiVersion:
               description:

--- a/config/crd/bases/aiven.io_clickhouses.yaml
+++ b/config/crd/bases/aiven.io_clickhouses.yaml
@@ -20,8 +20,7 @@ spec:
         openAPIV3Schema:
           description:
             'Clickhouse is the Schema for the clickhouses API. Info "Exposes
-            secret keys": `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`,
-            `CLICKHOUSE_CA_CERT`'
+            secret keys": `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`'
           properties:
             apiVersion:
               description:

--- a/config/crd/bases/aiven.io_grafanas.yaml
+++ b/config/crd/bases/aiven.io_grafanas.yaml
@@ -34,7 +34,7 @@ spec:
           description:
             'Grafana is the Schema for the grafanas API. Info "Exposes secret
             keys": `GRAFANA_HOST`, `GRAFANA_PORT`, `GRAFANA_USER`, `GRAFANA_PASSWORD`,
-            `GRAFANA_URI`, `GRAFANA_HOSTS`, `GRAFANA_CA_CERT`'
+            `GRAFANA_URI`, `GRAFANA_HOSTS`'
           properties:
             apiVersion:
               description:

--- a/config/crd/bases/aiven.io_opensearches.yaml
+++ b/config/crd/bases/aiven.io_opensearches.yaml
@@ -20,8 +20,7 @@ spec:
         openAPIV3Schema:
           description:
             'OpenSearch is the Schema for the opensearches API. Info "Exposes
-            secret keys": `OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`,
-            `OPENSEARCH_CA_CERT`'
+            secret keys": `OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`'
           properties:
             apiVersion:
               description:

--- a/controllers/generic_service_handler.go
+++ b/controllers/generic_service_handler.go
@@ -193,9 +193,10 @@ func (h *genericServiceHandler) get(ctx context.Context, avn *aiven.Client, avnG
 			return secret, err
 		}
 
-		// Redis shouldn't expose CA_CERT
-		// It can't be used to connect to redis
-		if o.getServiceType() == "redis" {
+		switch o.getServiceType() {
+		case "kafka", "pg", "mysql", "cassandra":
+			// CA_CERT can be used with these service types only
+		default:
 			return secret, nil
 		}
 

--- a/docs/docs/api-reference/clickhouse.md
+++ b/docs/docs/api-reference/clickhouse.md
@@ -37,7 +37,7 @@ Clickhouse is the Schema for the clickhouses API.
 
 !!! Info "Exposes secret keys"
 
-    `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_CA_CERT`.
+    `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`.
 
 **Required**
 

--- a/docs/docs/api-reference/grafana.md
+++ b/docs/docs/api-reference/grafana.md
@@ -45,7 +45,7 @@ Grafana is the Schema for the grafanas API.
 
 !!! Info "Exposes secret keys"
 
-    `GRAFANA_HOST`, `GRAFANA_PORT`, `GRAFANA_USER`, `GRAFANA_PASSWORD`, `GRAFANA_URI`, `GRAFANA_HOSTS`, `GRAFANA_CA_CERT`.
+    `GRAFANA_HOST`, `GRAFANA_PORT`, `GRAFANA_USER`, `GRAFANA_PASSWORD`, `GRAFANA_URI`, `GRAFANA_HOSTS`.
 
 **Required**
 

--- a/docs/docs/api-reference/opensearch.md
+++ b/docs/docs/api-reference/opensearch.md
@@ -38,7 +38,7 @@ OpenSearch is the Schema for the opensearches API.
 
 !!! Info "Exposes secret keys"
 
-    `OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`, `OPENSEARCH_CA_CERT`.
+    `OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`.
 
 **Required**
 

--- a/tests/clickhouse_test.go
+++ b/tests/clickhouse_test.go
@@ -169,7 +169,6 @@ func TestClickhouse(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["CLICKHOUSE_PORT"])
 	assert.NotEmpty(t, secret.Data["CLICKHOUSE_USER"])
 	assert.NotEmpty(t, secret.Data["CLICKHOUSE_PASSWORD"])
-	assert.NotEmpty(t, secret.Data["CLICKHOUSE_CA_CERT"])
 
 	// Validates ClickhouseDatabase
 	db1 := new(v1alpha1.ClickhouseDatabase)

--- a/tests/grafana_test.go
+++ b/tests/grafana_test.go
@@ -111,5 +111,4 @@ func TestGrafana(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["GRAFANA_PASSWORD"])
 	assert.NotEmpty(t, secret.Data["GRAFANA_URI"])
 	assert.NotEmpty(t, secret.Data["GRAFANA_HOSTS"])
-	assert.NotEmpty(t, secret.Data["GRAFANA_CA_CERT"])
 }

--- a/tests/opensearch_test.go
+++ b/tests/opensearch_test.go
@@ -115,7 +115,6 @@ func TestOpenSearch(t *testing.T) {
 	assert.NotEmpty(t, secret.Data["OPENSEARCH_PORT"])
 	assert.NotEmpty(t, secret.Data["OPENSEARCH_USER"])
 	assert.NotEmpty(t, secret.Data["OPENSEARCH_PASSWORD"])
-	assert.NotEmpty(t, secret.Data["OPENSEARCH_CA_CERT"])
 	assert.Equal(t, map[string]string{"foo": "bar"}, secret.Annotations)
 	assert.Equal(t, map[string]string{"baz": "egg"}, secret.Labels)
 }


### PR DESCRIPTION
Removes redundant CA_CERT secret key for `Grafana`, `OpenSearch`, and `Clickhouse`. Can't be used with these service types