### PR TITLE
fix(ci): add `token` to kustomize-github-action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,5 +57,7 @@ jobs:
           kustomize_version: 4.5.7
           kustomize_build_dir: config/default
           kustomize_output_file: deployment.yaml
+          # TODO: remove token once https://github.com/karancode/kustomize-github-action/issues/46 is resolved
+          token: ${{ github.token }}
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
           kustomize_version: 4.5.7
           kustomize_build_dir: config/default
           kustomize_output_file: deployment.yaml
+          # TODO: remove token once https://github.com/karancode/kustomize-github-action/issues/46 is resolved
+          token: ${{ github.token }}
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
       - uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Lint action was failing consistently with:

```bash
curl: option : blank argument where content is expected
curl: try 'curl --help' or 'curl --manual' for more information
```

See: 
- https://github.com/aiven/aiven-operator/actions/runs/9386573825/job/25847480037?pr=745.
- https://github.com/karancode/kustomize-github-action/issues/46#issuecomment-2136079824