### PR TITLE
feat(clickhouseuser,clickhousedatabase): support UTF-8 names for user and database names

### DIFF
--- a/api/v1alpha1/clickhouserole_types.go
+++ b/api/v1alpha1/clickhouserole_types.go
@@ -11,7 +11,6 @@ type ClickhouseRoleSpec struct {
 	ServiceDependant `json:",inline"`
 
 	// +kubebuilder:validation:MaxLength=255
-	// +kubebuilder:validation:Pattern="^[a-zA-Z_][0-9a-zA-Z_]*$"
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// The role that is to be created
 	Role string `json:"role"`

--- a/api/v1alpha1/clickhouseuser_types.go
+++ b/api/v1alpha1/clickhouseuser_types.go
@@ -6,10 +6,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// TODO: Enable `username` validation rule (add a '+' to the XValidation:rule line below).
+//
+// Currently controller-gen has a bug that prevents the line below from working correctly.
+// We use XValidation on connInfoSecretTargetDisabled which is on the same level in the generated CRD yaml as
+// username. Kubebuilder has CRD flattening which merges the validation rules into a single allOf array
+// which generates invalid CRD yaml that results in a "spec.validation.openAPIV3Schema.properties[spec].allOf[0].x-kubernetes-validations:
+// Forbidden: must be empty to be structural" error when trying to install the CRDs.
+
+// kubebuilder:validation:XValidation:rule="!has(oldSelf.username) || has(self.username)",message="Username is required once set"
+
 // ClickhouseUserSpec defines the desired state of ClickhouseUser
 type ClickhouseUserSpec struct {
 	ServiceDependant `json:",inline"`
 	SecretFields     `json:",inline"`
+
+	// Name of the Clickhouse user. Defaults to `metadata.name` if omitted.
+	// Note: `metadata.name` is ASCII-only. For UTF-8 names, use `spec.username`, but ASCII is advised for compatibility.
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	Username string `json:"username,omitempty"`
 }
 
 // ClickhouseUserStatus defines the observed state of ClickhouseUser
@@ -27,6 +43,7 @@ type ClickhouseUserStatus struct {
 
 // ClickhouseUser is the Schema for the clickhouseusers API.
 // Info "Exposes secret keys": `CLICKHOUSEUSER_HOST`, `CLICKHOUSEUSER_PORT`, `CLICKHOUSEUSER_USER`, `CLICKHOUSEUSER_PASSWORD`
+// +kubebuilder:printcolumn:name="Username",type="string",JSONPath=".spec.username"
 // +kubebuilder:printcolumn:name="Service Name",type="string",JSONPath=".spec.serviceName"
 // +kubebuilder:printcolumn:name="Project",type="string",JSONPath=".spec.project"
 // +kubebuilder:printcolumn:name="Connection Information Secret",type="string",JSONPath=".spec.connInfoSecretTarget.name"
@@ -39,6 +56,16 @@ type ClickhouseUser struct {
 }
 
 var _ AivenManagedObject = &ClickhouseUser{}
+
+func (in *ClickhouseUser) GetUsername() string {
+	// Default to Spec.Username and use ObjectMeta.Name if empty.
+	// ObjectMeta.Name doesn't support UTF-8 characters, Spec.Username does.
+	name := in.Spec.Username
+	if name == "" {
+		name = in.ObjectMeta.Name
+	}
+	return name
+}
 
 func (in *ClickhouseUser) NoSecret() bool {
 	return in.Spec.ConnInfoSecretTargetDisabled != nil && *in.Spec.ConnInfoSecretTargetDisabled

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhousedatabases.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhousedatabases.yaml
@@ -15,6 +15,9 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
+        - jsonPath: .spec.databaseName
+          name: Database name
+          type: string
         - jsonPath: .spec.serviceName
           name: Service Name
           type: string
@@ -59,6 +62,15 @@ spec:
                     - key
                     - name
                   type: object
+                databaseName:
+                  description: |-
+                    Specifies the Clickhouse database name. Defaults to `metadata.name` if omitted.
+                    Note: `metadata.name` is ASCII-only. For UTF-8 names, use `spec.databaseName`, but ASCII is advised for compatibility.
+                  maxLength: 63
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
                 project:
                   description: Identifies the project this resource belongs to
                   maxLength: 63
@@ -81,6 +93,9 @@ spec:
                 - project
                 - serviceName
               type: object
+              x-kubernetes-validations:
+                - message: databaseName is required once set
+                  rule: "!has(oldSelf.databaseName) || has(self.databaseName)"
             status:
               description: ClickhouseDatabaseStatus defines the observed state of ClickhouseDatabase
               properties:

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhouseroles.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhouseroles.yaml
@@ -73,7 +73,6 @@ spec:
                 role:
                   description: The role that is to be created
                   maxLength: 255
-                  pattern: ^[a-zA-Z_][0-9a-zA-Z_]*$
                   type: string
                   x-kubernetes-validations:
                     - message: Value is immutable

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhouseusers.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhouseusers.yaml
@@ -15,6 +15,9 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
+        - jsonPath: .spec.username
+          name: Username
+          type: string
         - jsonPath: .spec.serviceName
           name: Service Name
           type: string
@@ -119,6 +122,15 @@ spec:
                     belongs to
                   maxLength: 63
                   pattern: ^[a-z][-a-z0-9]+$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                username:
+                  description: |-
+                    Name of the Clickhouse user. Defaults to `metadata.name` if omitted.
+                    Note: `metadata.name` is ASCII-only. For UTF-8 names, use `spec.username`, but ASCII is advised for compatibility.
+                  maxLength: 63
                   type: string
                   x-kubernetes-validations:
                     - message: Value is immutable

--- a/config/crd/bases/aiven.io_clickhousedatabases.yaml
+++ b/config/crd/bases/aiven.io_clickhousedatabases.yaml
@@ -15,6 +15,9 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
+        - jsonPath: .spec.databaseName
+          name: Database name
+          type: string
         - jsonPath: .spec.serviceName
           name: Service Name
           type: string
@@ -59,6 +62,15 @@ spec:
                     - key
                     - name
                   type: object
+                databaseName:
+                  description: |-
+                    Specifies the Clickhouse database name. Defaults to `metadata.name` if omitted.
+                    Note: `metadata.name` is ASCII-only. For UTF-8 names, use `spec.databaseName`, but ASCII is advised for compatibility.
+                  maxLength: 63
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
                 project:
                   description: Identifies the project this resource belongs to
                   maxLength: 63
@@ -81,6 +93,9 @@ spec:
                 - project
                 - serviceName
               type: object
+              x-kubernetes-validations:
+                - message: databaseName is required once set
+                  rule: "!has(oldSelf.databaseName) || has(self.databaseName)"
             status:
               description: ClickhouseDatabaseStatus defines the observed state of ClickhouseDatabase
               properties:

--- a/config/crd/bases/aiven.io_clickhouseroles.yaml
+++ b/config/crd/bases/aiven.io_clickhouseroles.yaml
@@ -73,7 +73,6 @@ spec:
                 role:
                   description: The role that is to be created
                   maxLength: 255
-                  pattern: ^[a-zA-Z_][0-9a-zA-Z_]*$
                   type: string
                   x-kubernetes-validations:
                     - message: Value is immutable

--- a/config/crd/bases/aiven.io_clickhouseusers.yaml
+++ b/config/crd/bases/aiven.io_clickhouseusers.yaml
@@ -15,6 +15,9 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
+        - jsonPath: .spec.username
+          name: Username
+          type: string
         - jsonPath: .spec.serviceName
           name: Service Name
           type: string
@@ -119,6 +122,15 @@ spec:
                     belongs to
                   maxLength: 63
                   pattern: ^[a-z][-a-z0-9]+$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                username:
+                  description: |-
+                    Name of the Clickhouse user. Defaults to `metadata.name` if omitted.
+                    Note: `metadata.name` is ASCII-only. For UTF-8 names, use `spec.username`, but ASCII is advised for compatibility.
+                  maxLength: 63
                   type: string
                   x-kubernetes-validations:
                     - message: Value is immutable

--- a/controllers/clickhousedatabase_controller.go
+++ b/controllers/clickhousedatabase_controller.go
@@ -50,9 +50,10 @@ func (h *ClickhouseDatabaseHandler) createOrUpdate(ctx context.Context, avn *aiv
 		return err
 	}
 
-	_, err = avn.ClickhouseDatabase.Get(ctx, db.Spec.Project, db.Spec.ServiceName, db.Name)
+	dbName := db.GetDatabaseName()
+	_, err = avn.ClickhouseDatabase.Get(ctx, db.Spec.Project, db.Spec.ServiceName, dbName)
 	if isNotFound(err) {
-		err = avn.ClickhouseDatabase.Create(ctx, db.Spec.Project, db.Spec.ServiceName, db.Name)
+		err = avn.ClickhouseDatabase.Create(ctx, db.Spec.Project, db.Spec.ServiceName, dbName)
 	}
 
 	if err != nil {
@@ -79,7 +80,8 @@ func (h *ClickhouseDatabaseHandler) delete(ctx context.Context, avn *aiven.Clien
 		return false, err
 	}
 
-	err = avn.ClickhouseDatabase.Delete(ctx, db.Spec.Project, db.Spec.ServiceName, db.Name)
+	dbName := db.GetDatabaseName()
+	err = avn.ClickhouseDatabase.Delete(ctx, db.Spec.Project, db.Spec.ServiceName, dbName)
 	if err != nil && !isNotFound(err) {
 		return false, err
 	}
@@ -93,7 +95,8 @@ func (h *ClickhouseDatabaseHandler) get(ctx context.Context, avn *aiven.Client, 
 		return nil, err
 	}
 
-	_, err = avn.ClickhouseDatabase.Get(ctx, db.Spec.Project, db.Spec.ServiceName, db.Name)
+	dbName := db.GetDatabaseName()
+	_, err = avn.ClickhouseDatabase.Get(ctx, db.Spec.Project, db.Spec.ServiceName, dbName)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/clickhouseuser_controller.go
+++ b/controllers/clickhouseuser_controller.go
@@ -53,7 +53,7 @@ func (h *clickhouseUserHandler) createOrUpdate(ctx context.Context, avn *aiven.C
 		return err
 	}
 
-	r, err := avn.ClickhouseUser.Create(ctx, user.Spec.Project, user.Spec.ServiceName, user.Name)
+	r, err := avn.ClickhouseUser.Create(ctx, user.Spec.Project, user.Spec.ServiceName, user.GetName())
 	if err != nil {
 		return err
 	}
@@ -119,12 +119,12 @@ func (h *clickhouseUserHandler) get(ctx context.Context, avn *aiven.Client, avnG
 		prefix + "HOST":     s.URIParams["host"],
 		prefix + "PORT":     s.URIParams["port"],
 		prefix + "PASSWORD": password,
-		prefix + "USERNAME": user.Name,
+		prefix + "USERNAME": user.GetUsername(),
 		// todo: remove in future releases
 		"HOST":     s.URIParams["host"],
 		"PORT":     s.URIParams["port"],
 		"PASSWORD": password,
-		"USERNAME": user.Name,
+		"USERNAME": user.GetUsername(),
 	}
 
 	secret := newSecret(user, stringData, false)

--- a/controllers/clickhouseuser_controller.go
+++ b/controllers/clickhouseuser_controller.go
@@ -53,12 +53,29 @@ func (h *clickhouseUserHandler) createOrUpdate(ctx context.Context, avn *aiven.C
 		return err
 	}
 
-	r, err := avn.ClickhouseUser.Create(ctx, user.Spec.Project, user.Spec.ServiceName, user.GetName())
+	list, err := avn.ClickhouseUser.List(ctx, user.Spec.Project, user.Spec.ServiceName)
 	if err != nil {
 		return err
 	}
 
-	user.Status.UUID = r.User.UUID
+	var uuid string
+	for _, u := range list.Users {
+		if u.Name == user.GetUsername() {
+			uuid = u.UUID
+			break
+		}
+	}
+
+	if uuid == "" {
+		r, err := avn.ClickhouseUser.Create(ctx, user.Spec.Project, user.Spec.ServiceName, user.GetUsername())
+		if err != nil {
+			return err
+		}
+
+		uuid = r.User.UUID
+	}
+
+	user.Status.UUID = uuid
 
 	meta.SetStatusCondition(&user.Status.Conditions,
 		getInitializedCondition("Created",

--- a/docs/docs/api-reference/clickhouse.md
+++ b/docs/docs/api-reference/clickhouse.md
@@ -16,12 +16,21 @@ title: "Clickhouse"
         key: token
     
       connInfoSecretTarget:
-        name: clickhouse-secret
-        prefix: MY_SECRET_PREFIX_
+        name: my-clickhouse
         annotations:
           foo: bar
         labels:
           baz: egg
+    
+      tags:
+        env: test
+        instance: foo
+    
+      userConfig:
+        ip_filter:
+          - network: 0.0.0.0/32
+            description: bar
+          - network: 10.20.0.0/16
     
       project: my-aiven-project
       cloudName: google-europe-west1

--- a/docs/docs/api-reference/clickhousedatabase.md
+++ b/docs/docs/api-reference/clickhousedatabase.md
@@ -15,8 +15,9 @@ title: "ClickhouseDatabase"
         name: aiven-token
         key: token
     
-      project: aiven-project-name
+      project: my-aiven-project
       serviceName: my-clickhouse
+      databaseName: my-db
     ```
 
 ## ClickhouseDatabase {: #ClickhouseDatabase }
@@ -44,6 +45,8 @@ ClickhouseDatabaseSpec defines the desired state of ClickhouseDatabase.
 **Optional**
 
 - [`authSecretRef`](#spec.authSecretRef-property){: name='spec.authSecretRef-property'} (object). Authentication reference to Aiven token in a secret. See below for [nested schema](#spec.authSecretRef).
+- [`databaseName`](#spec.databaseName-property){: name='spec.databaseName-property'} (string, Immutable, MaxLength: 63). Specifies the Clickhouse database name. Defaults to `metadata.name` if omitted.
+Note: `metadata.name` is ASCII-only. For UTF-8 names, use `spec.databaseName`, but ASCII is advised for compatibility.
 
 ## authSecretRef {: #spec.authSecretRef }
 

--- a/docs/docs/api-reference/clickhouserole.md
+++ b/docs/docs/api-reference/clickhouserole.md
@@ -17,7 +17,7 @@ title: "ClickhouseRole"
     
       project: my-aiven-project
       serviceName: my-clickhouse
-      role: my_role
+      role: my-role
     ```
 
 ## ClickhouseRole {: #ClickhouseRole }
@@ -40,7 +40,7 @@ ClickhouseRoleSpec defines the desired state of ClickhouseRole.
 **Required**
 
 - [`project`](#spec.project-property){: name='spec.project-property'} (string, Immutable, Pattern: `^[a-zA-Z0-9_-]+$`, MaxLength: 63). Identifies the project this resource belongs to.
-- [`role`](#spec.role-property){: name='spec.role-property'} (string, Immutable, Pattern: `^[a-zA-Z_][0-9a-zA-Z_]*$`, MaxLength: 255). The role that is to be created.
+- [`role`](#spec.role-property){: name='spec.role-property'} (string, Immutable, MaxLength: 255). The role that is to be created.
 - [`serviceName`](#spec.serviceName-property){: name='spec.serviceName-property'} (string, Immutable, Pattern: `^[a-z][-a-z0-9]+$`, MaxLength: 63). Specifies the name of the service that this resource belongs to.
 
 **Optional**

--- a/docs/docs/api-reference/clickhouseuser.md
+++ b/docs/docs/api-reference/clickhouseuser.md
@@ -17,7 +17,6 @@ title: "ClickhouseUser"
     
       connInfoSecretTarget:
         name: clickhouse-user-secret
-        prefix: MY_SECRET_PREFIX_
         annotations:
           foo: bar
         labels:
@@ -25,6 +24,22 @@ title: "ClickhouseUser"
     
       project: my-aiven-project
       serviceName: my-clickhouse
+      username: example-username
+    
+    ---
+    
+    apiVersion: aiven.io/v1alpha1
+    kind: Clickhouse
+    metadata:
+      name: my-clickhouse
+    spec:
+      authSecretRef:
+        name: aiven-token
+        key: token
+    
+      project: my-aiven-project
+      cloudName: google-europe-west1
+      plan: startup-16
     ```
 
 ## ClickhouseUser {: #ClickhouseUser }
@@ -58,6 +73,8 @@ ClickhouseUserSpec defines the desired state of ClickhouseUser.
 - [`authSecretRef`](#spec.authSecretRef-property){: name='spec.authSecretRef-property'} (object). Authentication reference to Aiven token in a secret. See below for [nested schema](#spec.authSecretRef).
 - [`connInfoSecretTarget`](#spec.connInfoSecretTarget-property){: name='spec.connInfoSecretTarget-property'} (object). Secret configuration. See below for [nested schema](#spec.connInfoSecretTarget).
 - [`connInfoSecretTargetDisabled`](#spec.connInfoSecretTargetDisabled-property){: name='spec.connInfoSecretTargetDisabled-property'} (boolean, Immutable). When true, the secret containing connection information will not be created, defaults to false. This field cannot be changed after resource creation.
+- [`username`](#spec.username-property){: name='spec.username-property'} (string, Immutable, MaxLength: 63). Name of the Clickhouse user. Defaults to `metadata.name` if omitted.
+Note: `metadata.name` is ASCII-only. For UTF-8 names, use `spec.username`, but ASCII is advised for compatibility.
 
 ## authSecretRef {: #spec.authSecretRef }
 

--- a/docs/docs/api-reference/examples/clickhouse.yaml
+++ b/docs/docs/api-reference/examples/clickhouse.yaml
@@ -8,12 +8,21 @@ spec:
     key: token
 
   connInfoSecretTarget:
-    name: clickhouse-secret
-    prefix: MY_SECRET_PREFIX_
+    name: my-clickhouse
     annotations:
       foo: bar
     labels:
       baz: egg
+
+  tags:
+    env: test
+    instance: foo
+
+  userConfig:
+    ip_filter:
+      - network: 0.0.0.0/32
+        description: bar
+      - network: 10.20.0.0/16
 
   project: my-aiven-project
   cloudName: google-europe-west1

--- a/docs/docs/api-reference/examples/clickhousedatabase.yaml
+++ b/docs/docs/api-reference/examples/clickhousedatabase.yaml
@@ -7,5 +7,6 @@ spec:
     name: aiven-token
     key: token
 
-  project: aiven-project-name
+  project: my-aiven-project
   serviceName: my-clickhouse
+  databaseName: example-db

--- a/docs/docs/api-reference/examples/clickhouserole.yaml
+++ b/docs/docs/api-reference/examples/clickhouserole.yaml
@@ -9,4 +9,4 @@ spec:
 
   project: my-aiven-project
   serviceName: my-clickhouse
-  role: my_role
+  role: my-role

--- a/docs/docs/api-reference/examples/clickhouseuser.yaml
+++ b/docs/docs/api-reference/examples/clickhouseuser.yaml
@@ -9,7 +9,6 @@ spec:
 
   connInfoSecretTarget:
     name: clickhouse-user-secret
-    prefix: MY_SECRET_PREFIX_
     annotations:
       foo: bar
     labels:
@@ -17,3 +16,19 @@ spec:
 
   project: my-aiven-project
   serviceName: my-clickhouse
+  username: example-username
+
+---
+
+apiVersion: aiven.io/v1alpha1
+kind: Clickhouse
+metadata:
+  name: my-clickhouse
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: startup-16


### PR DESCRIPTION
Previously the username was set from Metadata.name, which doesn't support UTF-8:

    The ClickhouseUser "testuser-🦄" is invalid: metadata.name: Invalid
    value: "testuser-🦄": a lowercase RFC 1123

Clickhouse usernames have UTF-8 support. This can be verified by running:

    CREATE USER 'testuser-🦄' IDENTIFIED BY 'testpassword'