### PR TITLE
fix: clickhouse grant deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Ignore `http.StatusBadRequest` on `ClickhouseGrant` deletion
+
 ## v0.22.0 - 2024-07-02
 
 - Ignore `ClickhouseRole` deletion error (missing database)

--- a/controllers/clickhousegrant_controller.go
+++ b/controllers/clickhousegrant_controller.go
@@ -24,8 +24,6 @@ import (
 	chUtils "github.com/aiven/aiven-operator/utils/clickhouse"
 )
 
-const notFoundRole = "There is no role"
-
 // ClickhouseGrantReconciler reconciles a ClickhouseGrant object
 type ClickhouseGrantReconciler struct {
 	Controller
@@ -99,7 +97,8 @@ func (h *ClickhouseGrantHandler) delete(ctx context.Context, avn *aiven.Client, 
 	}
 
 	_, err = g.Spec.ExecuteStatements(ctx, avnGen, chUtils.REVOKE)
-	if err == nil || strings.Contains(err.Error(), notFoundRole) {
+	if isAivenError(err, http.StatusBadRequest) {
+		// "not found in user directories", "There is no role", etc
 		return true, nil
 	}
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -253,7 +253,7 @@ func UpdateUserConfiguration(userConfig any) (map[string]any, error) {
 
 // isNotFound works both for old and new client errors
 func isNotFound(err error) bool {
-	return aiven.IsNotFound(err) || avngen.IsNotFound(err)
+	return isAivenError(err, http.StatusNotFound)
 }
 
 // isAlreadyExists works both for old and new client errors
@@ -270,4 +270,19 @@ func isDeleted(err error) (bool, error) {
 		return true, nil
 	}
 	return err == nil, err
+}
+
+// isAivenError returns true if the error comes from the old or new client and has given http code
+func isAivenError(err error, code int) bool {
+	var oldErr aiven.Error
+	if errors.As(err, &oldErr) {
+		return oldErr.Status == code
+	}
+
+	var newErr avngen.Error
+	if errors.As(err, &newErr) {
+		return newErr.Status == code
+	}
+
+	return false
 }


### PR DESCRIPTION
`ClickhouseGrant` delete operation might return various 400 errors when dependencies are removed before the grant.