### PR TITLE
refactor: use gen client to check service is operational

### DIFF
--- a/controllers/clickhousedatabase_controller.go
+++ b/controllers/clickhousedatabase_controller.go
@@ -115,7 +115,7 @@ func (h *ClickhouseDatabaseHandler) checkPreconditions(ctx context.Context, avn 
 	meta.SetStatusCondition(&db.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsOperational(ctx, avn, avnGen, db.Spec.Project, db.Spec.ServiceName)
+	return checkServiceIsOperational(ctx, avnGen, db.Spec.Project, db.Spec.ServiceName)
 }
 
 func (h *ClickhouseDatabaseHandler) convert(i client.Object) (*v1alpha1.ClickhouseDatabase, error) {

--- a/controllers/clickhousegrant_controller.go
+++ b/controllers/clickhousegrant_controller.go
@@ -125,7 +125,7 @@ func (h *ClickhouseGrantHandler) checkPreconditions(ctx context.Context, avn *ai
 	meta.SetStatusCondition(&g.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	serviceIsRunning, err := checkServiceIsOperational(ctx, avn, avnGen, g.Spec.Project, g.Spec.ServiceName)
+	serviceIsRunning, err := checkServiceIsOperational(ctx, avnGen, g.Spec.Project, g.Spec.ServiceName)
 	if !serviceIsRunning || err != nil {
 		return false, err
 	}

--- a/controllers/clickhouserole_controller.go
+++ b/controllers/clickhouserole_controller.go
@@ -111,7 +111,7 @@ func (h *clickhouseRoleHandler) checkPreconditions(ctx context.Context, avn *aiv
 	meta.SetStatusCondition(&role.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsOperational(ctx, avn, avnGen, role.Spec.Project, role.Spec.ServiceName)
+	return checkServiceIsOperational(ctx, avnGen, role.Spec.Project, role.Spec.ServiceName)
 }
 
 func (h *clickhouseRoleHandler) convert(i client.Object) (*v1alpha1.ClickhouseRole, error) {

--- a/controllers/clickhouseuser_controller.go
+++ b/controllers/clickhouseuser_controller.go
@@ -156,7 +156,7 @@ func (h *clickhouseUserHandler) checkPreconditions(ctx context.Context, avn *aiv
 	meta.SetStatusCondition(&user.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsOperational(ctx, avn, avnGen, user.Spec.Project, user.Spec.ServiceName)
+	return checkServiceIsOperational(ctx, avnGen, user.Spec.Project, user.Spec.ServiceName)
 }
 
 func (h *clickhouseUserHandler) convert(i client.Object) (*v1alpha1.ClickhouseUser, error) {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -48,7 +48,7 @@ const (
 
 var errTerminationProtectionOn = errors.New("termination protection is on")
 
-func checkServiceIsOperational(ctx context.Context, _ *aiven.Client, avnGen avngen.Client, project, serviceName string) (bool, error) {
+func checkServiceIsOperational(ctx context.Context, avnGen avngen.Client, project, serviceName string) (bool, error) {
 	s, err := avnGen.ServiceGet(ctx, project, serviceName)
 	if err != nil {
 		// if service is not found, it is not running

--- a/controllers/connectionpool_controller.go
+++ b/controllers/connectionpool_controller.go
@@ -211,7 +211,7 @@ func (h ConnectionPoolHandler) checkPreconditions(ctx context.Context, avn *aive
 	meta.SetStatusCondition(&cp.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	isRunning, err := checkServiceIsOperational(ctx, avn, avnGen, cp.Spec.Project, cp.Spec.ServiceName)
+	isRunning, err := checkServiceIsOperational(ctx, avnGen, cp.Spec.Project, cp.Spec.ServiceName)
 	if err != nil {
 		return false, err
 	}

--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -136,7 +136,7 @@ func (h DatabaseHandler) checkPreconditions(ctx context.Context, avn *aiven.Clie
 	meta.SetStatusCondition(&db.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsOperational(ctx, avn, avnGen, db.Spec.Project, db.Spec.ServiceName)
+	return checkServiceIsOperational(ctx, avnGen, db.Spec.Project, db.Spec.ServiceName)
 }
 
 func (h DatabaseHandler) convert(i client.Object) (*v1alpha1.Database, error) {

--- a/controllers/generic_service_handler.go
+++ b/controllers/generic_service_handler.go
@@ -232,7 +232,7 @@ func (h *genericServiceHandler) checkPreconditions(ctx context.Context, avn *aiv
 		// Validates that read_replica is running
 		// If not, the wrapper controller will try later
 		if s.IntegrationType == "read_replica" {
-			r, err := checkServiceIsOperational(ctx, avn, avnGen, spec.Project, s.SourceServiceName)
+			r, err := checkServiceIsOperational(ctx, avnGen, spec.Project, s.SourceServiceName)
 			if !r || err != nil {
 				return false, err
 			}

--- a/controllers/kafkaacl_controller.go
+++ b/controllers/kafkaacl_controller.go
@@ -165,7 +165,7 @@ func (h KafkaACLHandler) checkPreconditions(ctx context.Context, avn *aiven.Clie
 	meta.SetStatusCondition(&acl.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsOperational(ctx, avn, avnGen, acl.Spec.Project, acl.Spec.ServiceName)
+	return checkServiceIsOperational(ctx, avnGen, acl.Spec.Project, acl.Spec.ServiceName)
 }
 
 func (h KafkaACLHandler) convert(i client.Object) (*v1alpha1.KafkaACL, error) {

--- a/controllers/kafkaconnector_controller.go
+++ b/controllers/kafkaconnector_controller.go
@@ -220,7 +220,7 @@ func (h KafkaConnectorHandler) checkPreconditions(ctx context.Context, avn *aive
 	meta.SetStatusCondition(&conn.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsOperational(ctx, avn, avnGen, conn.Spec.Project, conn.Spec.ServiceName)
+	return checkServiceIsOperational(ctx, avnGen, conn.Spec.Project, conn.Spec.ServiceName)
 }
 
 func (h KafkaConnectorHandler) convert(o client.Object) (*v1alpha1.KafkaConnector, error) {

--- a/controllers/kafkaschema_controller.go
+++ b/controllers/kafkaschema_controller.go
@@ -134,7 +134,7 @@ func (h KafkaSchemaHandler) checkPreconditions(ctx context.Context, avn *aiven.C
 		return false, err
 	}
 
-	return checkServiceIsOperational(ctx, avn, avnGen, schema.Spec.Project, schema.Spec.ServiceName)
+	return checkServiceIsOperational(ctx, avnGen, schema.Spec.Project, schema.Spec.ServiceName)
 }
 
 func (h KafkaSchemaHandler) convert(i client.Object) (*v1alpha1.KafkaSchema, error) {

--- a/controllers/kafkaschemaregistryacl_controller.go
+++ b/controllers/kafkaschemaregistryacl_controller.go
@@ -157,7 +157,7 @@ func (h KafkaSchemaRegistryACLHandler) checkPreconditions(ctx context.Context, a
 	meta.SetStatusCondition(&acl.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsOperational(ctx, avn, avnGen, acl.Spec.Project, acl.Spec.ServiceName)
+	return checkServiceIsOperational(ctx, avnGen, acl.Spec.Project, acl.Spec.ServiceName)
 }
 
 func (h KafkaSchemaRegistryACLHandler) convert(i client.Object) (*v1alpha1.KafkaSchemaRegistryACL, error) {

--- a/controllers/serviceintegration_controller.go
+++ b/controllers/serviceintegration_controller.go
@@ -174,7 +174,7 @@ func (h ServiceIntegrationHandler) checkPreconditions(ctx context.Context, avn *
 		if project == "" {
 			project = si.Spec.Project
 		}
-		running, err := checkServiceIsOperational(ctx, avn, avnGen, project, si.Spec.SourceServiceName)
+		running, err := checkServiceIsOperational(ctx, avnGen, project, si.Spec.SourceServiceName)
 		if !running || err != nil {
 			return false, err
 		}
@@ -185,7 +185,7 @@ func (h ServiceIntegrationHandler) checkPreconditions(ctx context.Context, avn *
 		if project == "" {
 			project = si.Spec.Project
 		}
-		running, err := checkServiceIsOperational(ctx, avn, avnGen, project, si.Spec.DestinationServiceName)
+		running, err := checkServiceIsOperational(ctx, avnGen, project, si.Spec.DestinationServiceName)
 		if !running || err != nil {
 			return false, err
 		}

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -161,7 +161,7 @@ func (h ServiceUserHandler) checkPreconditions(ctx context.Context, avn *aiven.C
 	meta.SetStatusCondition(&user.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	return checkServiceIsOperational(ctx, avn, avnGen, user.Spec.Project, user.Spec.ServiceName)
+	return checkServiceIsOperational(ctx, avnGen, user.Spec.Project, user.Spec.ServiceName)
 }
 
 func (h ServiceUserHandler) convert(i client.Object) (*v1alpha1.ServiceUser, error) {


### PR DESCRIPTION
No need to have it anymore in `checkServiceIsOperational`.