### PR TITLE
feat: add `include_secrets` query param to `ServiceIntegrationEndointGet` calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.28.2
 	github.com/aiven/aiven-go-client/v2 v2.26.0
 	github.com/aiven/go-api-schemas v1.85.0
-	github.com/aiven/go-client-codegen v0.26.0
+	github.com/aiven/go-client-codegen v0.27.0
 	github.com/dave/jennifer v1.7.0
 	github.com/docker/go-units v0.5.0
 	github.com/ghodss/yaml v1.0.0
@@ -88,7 +88,7 @@ require (
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
-	golang.org/x/sys v0.24.0 // indirect
+	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/aiven/go-api-schemas v1.85.0 h1:wpTCQWjTLKQvVQq184u6Ji0ZksDZkNPqS6f6z
 github.com/aiven/go-api-schemas v1.85.0/go.mod h1:/F7Rr8UVErsRxhgGN7CSo+Ac/uAg/OiAVCEKCfm3VAo=
 github.com/aiven/go-client-codegen v0.26.0 h1:GtOL+KYWsjY02pZr0rrjZaTeq3gkDrccKaNS33Ss2lI=
 github.com/aiven/go-client-codegen v0.26.0/go.mod h1:6AHM+oM2tNc10eOfPeyiTWFObkVz2dZY2gqRkTPQoVo=
+github.com/aiven/go-client-codegen v0.27.0 h1:LSOrvMJUIRCTl2y6auiwtmKE3hzN1S/M5vxHTk58QaI=
+github.com/aiven/go-client-codegen v0.27.0/go.mod h1:6AHM+oM2tNc10eOfPeyiTWFObkVz2dZY2gqRkTPQoVo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -531,6 +533,8 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
 golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=

--- a/tests/serviceintegration_test.go
+++ b/tests/serviceintegration_test.go
@@ -73,12 +73,12 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 	assert.Equal(t, pgAvn.Maintenance.Time, pg.Spec.MaintenanceWindowTime)
 
 	// Validates ServiceIntegration
-	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, cfg.Project, si.Status.ID)
+	siAvn, err := avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "clickhouse_postgresql", siAvn.IntegrationType)
 	assert.Equal(t, siAvn.IntegrationType, si.Spec.IntegrationType)
-	assert.Equal(t, pgName, ptrValue(siAvn.SourceService))
-	assert.Equal(t, chName, ptrValue(siAvn.DestinationService))
+	assert.Equal(t, pgName, siAvn.SourceService)
+	assert.Equal(t, chName, *siAvn.DestService)
 	assert.True(t, siAvn.Active)
 	assert.True(t, siAvn.Enabled)
 }
@@ -140,12 +140,12 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 	assert.Len(t, ktAvn.Partitions, kt.Spec.Partitions)
 
 	// Validates ServiceIntegration
-	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, cfg.Project, si.Status.ID)
+	siAvn, err := avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "kafka_logs", siAvn.IntegrationType)
 	assert.Equal(t, siAvn.IntegrationType, si.Spec.IntegrationType)
-	assert.Equal(t, ksName, *siAvn.SourceService)
-	assert.Equal(t, ksName, *siAvn.DestinationService)
+	assert.Equal(t, ksName, siAvn.SourceService)
+	assert.Equal(t, ksName, *siAvn.DestService)
 	assert.True(t, siAvn.Active)
 	assert.True(t, siAvn.Enabled)
 	require.NotNil(t, si.Spec.KafkaLogsUserConfig)
@@ -211,12 +211,12 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 	assert.True(t, *kc.Spec.UserConfig.PublicAccess.KafkaConnect)
 
 	// Validates ServiceIntegration
-	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, cfg.Project, si.Status.ID)
+	siAvn, err := avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "kafka_connect", siAvn.IntegrationType)
 	assert.Equal(t, siAvn.IntegrationType, si.Spec.IntegrationType)
-	assert.Equal(t, ksName, *siAvn.SourceService)
-	assert.Equal(t, kcName, *siAvn.DestinationService)
+	assert.Equal(t, ksName, siAvn.SourceService)
+	assert.Equal(t, kcName, *siAvn.DestService)
 	assert.True(t, siAvn.Active)
 	assert.True(t, siAvn.Enabled)
 	require.NotNil(t, si.Spec.KafkaConnectUserConfig)
@@ -275,7 +275,7 @@ func TestServiceIntegrationDatadog(t *testing.T) {
 	assert.Equal(t, pgAvn.Plan, pg.Spec.Plan)
 
 	// Validates Datadog
-	siAvn, err := avnClient.ServiceIntegrations.Get(ctx, cfg.Project, si.Status.ID)
+	siAvn, err := avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "datadog", siAvn.IntegrationType)
 	assert.Equal(t, siAvn.IntegrationType, si.Spec.IntegrationType)

--- a/tests/serviceintegrationendpoint_test.go
+++ b/tests/serviceintegrationendpoint_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/aiven/go-client-codegen/handler/serviceintegration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -38,7 +39,7 @@ func TestServiceIntegrationEndpointExternalPostgres(t *testing.T) {
 	// Validates ServiceIntegrationEndpoint externalPostgresql
 	endpointPg := new(v1alpha1.ServiceIntegrationEndpoint)
 	require.NoError(t, s.GetRunning(endpointPg, endpointPgName))
-	endpointPgAvn, err := avnGen.ServiceIntegrationEndpointGet(ctx, cfg.Project, endpointPg.Status.ID)
+	endpointPgAvn, err := avnGen.ServiceIntegrationEndpointGet(ctx, cfg.Project, endpointPg.Status.ID, serviceintegration.ServiceIntegrationEndpointGetIncludeSecrets(true))
 	require.NoError(t, err)
 	assert.Equal(t, "external_postgresql", string(endpointPgAvn.EndpointType))
 	assert.Equal(t, "username", endpointPg.Spec.ExternalPostgresql.Username)
@@ -81,7 +82,7 @@ func TestServiceIntegrationEndpoint(t *testing.T) {
 	// Validates ServiceIntegrationEndpoint externalSchemaRegistry
 	endpointRegistry := new(v1alpha1.ServiceIntegrationEndpoint)
 	require.NoError(t, s.GetRunning(endpointRegistry, endpointRegistryName))
-	endpointRegistryAvn, err := avnGen.ServiceIntegrationEndpointGet(ctx, cfg.Project, endpointRegistry.Status.ID)
+	endpointRegistryAvn, err := avnGen.ServiceIntegrationEndpointGet(ctx, cfg.Project, endpointRegistry.Status.ID, serviceintegration.ServiceIntegrationEndpointGetIncludeSecrets(true))
 	require.NoError(t, err)
 	assert.Equal(t, "external_schema_registry", string(endpointRegistryAvn.EndpointType))
 	assert.Equal(t, "https://schema-registry.example.com:8081", endpointRegistry.Spec.ExternalSchemaRegistry.Url)


### PR DESCRIPTION
Request secrets in `ServiceIntegrationEndointGet` calls