### PR TITLE
fix: tests broken after go-client-codegen updates

### DIFF
--- a/tests/cassandra_test.go
+++ b/tests/cassandra_test.go
@@ -75,7 +75,7 @@ func TestCassandra(t *testing.T) {
 	assert.Equal(t, csAvn.Plan, cs.Spec.Plan)
 	assert.Equal(t, csAvn.CloudName, cs.Spec.CloudName)
 	assert.Equal(t, "450GiB", cs.Spec.DiskSpace)
-	assert.Equal(t, float64(460800), *csAvn.DiskSpaceMb)
+	assert.Equal(t, int(460800), *csAvn.DiskSpaceMb)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, cs.Spec.Tags)
 	csResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)

--- a/tests/kafka_test.go
+++ b/tests/kafka_test.go
@@ -76,7 +76,7 @@ func TestKafka(t *testing.T) {
 	assert.Equal(t, ksAvn.Plan, ks.Spec.Plan)
 	assert.Equal(t, ksAvn.CloudName, ks.Spec.CloudName)
 	assert.Equal(t, "600GiB", ks.Spec.DiskSpace)
-	assert.Equal(t, float64(614400), *ksAvn.DiskSpaceMb)
+	assert.Equal(t, int(614400), *ksAvn.DiskSpaceMb)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, ks.Spec.Tags)
 	ksResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -74,7 +74,7 @@ func TestMySQL(t *testing.T) {
 	assert.Equal(t, msAvn.Plan, ms.Spec.Plan)
 	assert.Equal(t, msAvn.CloudName, ms.Spec.CloudName)
 	assert.Equal(t, "100GiB", ms.Spec.DiskSpace)
-	assert.Equal(t, float64(102400), *msAvn.DiskSpaceMb)
+	assert.Equal(t, int(102400), *msAvn.DiskSpaceMb)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, ms.Spec.Tags)
 	msResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)

--- a/tests/opensearch_test.go
+++ b/tests/opensearch_test.go
@@ -79,7 +79,7 @@ func TestOpenSearch(t *testing.T) {
 	assert.Equal(t, osAvn.Plan, os.Spec.Plan)
 	assert.Equal(t, osAvn.CloudName, os.Spec.CloudName)
 	assert.Equal(t, "240GiB", os.Spec.DiskSpace)
-	assert.Equal(t, float64(245760), *osAvn.DiskSpaceMb)
+	assert.Equal(t, int(245760), *osAvn.DiskSpaceMb)
 	assert.Equal(t, map[string]string{"env": "test", "instance": "foo"}, os.Spec.Tags)
 	osResp, err := avnClient.ServiceTags.Get(ctx, cfg.Project, name)
 	require.NoError(t, err)

--- a/tests/serviceintegration_test.go
+++ b/tests/serviceintegration_test.go
@@ -75,7 +75,7 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 	// Validates ServiceIntegration
 	siAvn, err := avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "clickhouse_postgresql", siAvn.IntegrationType)
+	assert.EqualValues(t, "clickhouse_postgresql", siAvn.IntegrationType)
 	assert.EqualValues(t, siAvn.IntegrationType, si.Spec.IntegrationType)
 	assert.Equal(t, pgName, siAvn.SourceService)
 	assert.Equal(t, chName, *siAvn.DestService)
@@ -142,7 +142,7 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 	// Validates ServiceIntegration
 	siAvn, err := avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "kafka_logs", siAvn.IntegrationType)
+	assert.EqualValues(t, "kafka_logs", siAvn.IntegrationType)
 	assert.EqualValues(t, siAvn.IntegrationType, si.Spec.IntegrationType)
 	assert.Equal(t, ksName, siAvn.SourceService)
 	assert.Equal(t, ksName, *siAvn.DestService)
@@ -213,7 +213,7 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 	// Validates ServiceIntegration
 	siAvn, err := avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "kafka_connect", siAvn.IntegrationType)
+	assert.EqualValues(t, "kafka_connect", siAvn.IntegrationType)
 	assert.EqualValues(t, siAvn.IntegrationType, si.Spec.IntegrationType)
 	assert.Equal(t, ksName, siAvn.SourceService)
 	assert.Equal(t, kcName, *siAvn.DestService)
@@ -277,7 +277,7 @@ func TestServiceIntegrationDatadog(t *testing.T) {
 	// Validates Datadog
 	siAvn, err := avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "datadog", siAvn.IntegrationType)
+	assert.EqualValues(t, "datadog", siAvn.IntegrationType)
 	assert.EqualValues(t, siAvn.IntegrationType, si.Spec.IntegrationType)
 	assert.True(t, siAvn.Active)
 	assert.True(t, siAvn.Enabled)


### PR DESCRIPTION
Fixes broken tests, see e.g. this run https://github.com/aiven/aiven-operator/actions/runs/11564675507