### PR TITLE
feat: install operator-sdk and document new resource scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ $(LOCALBIN):
 KUBECTL ?= kubectl
 KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
+OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk-$(OPERATOR_SDK_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 SELPROJ = $(LOCALBIN)/selproj-$(SELPROJ_VERSION)
@@ -183,6 +184,7 @@ SELPROJ = $(LOCALBIN)/selproj-$(SELPROJ_VERSION)
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
+OPERATOR_SDK_VERSION ?= v1.36.0
 ENVTEST_VERSION ?= release-0.16
 GOLANGCI_LINT_VERSION ?= v1.54.2
 SELPROJ_VERSION ?= v0.1.0
@@ -196,6 +198,11 @@ $(KUSTOMIZE): $(LOCALBIN)
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
+
+.PHONY: operator-sdk
+operator-sdk: $(OPERATOR_SDK) ## Download operator-sdk locally if necessary.
+$(OPERATOR_SDK): $(LOCALBIN)
+	$(call go-install-tool,$(OPERATOR_SDK),github.com/operator-framework/operator-sdk/cmd/operator-sdk,$(OPERATOR_SDK_VERSION))
 
 # KUBEBUILDER_ASSETS is installed in this target so that it can be used by e.g. IDE test integrations.
 .PHONY: envtest

--- a/docs/docs/contributing/developer-guide.md
+++ b/docs/docs/contributing/developer-guide.md
@@ -178,3 +178,14 @@ the source code during the documentation deployment. To generate it locally, run
 ```shell
 make docs
 ```
+
+## Generating new resources
+
+To create new resources, install `operator-sdk` with `make operator-sdk` and run:
+
+```shell
+# Replace `<VERSION>` with your operator-sdk version.
+# Replace `<KIND>` with the new resource type. E.g. "Flink" or "Valkey".
+./bin/operator-sdk-<VERSION> create api --version v1alpha1 --kind <KIND> --force
+./bin/operator-sdk-<VERSION> create webhook --version v1alpha1 --kind <KIND> --defaulting --programmatic-validation --conversion
+```


### PR DESCRIPTION
* Install `operator-sdk`
  * v1.36.0 is chosen as it supports `go.kubebuilder.io/v3` version which we use in PROJECT. This version is deprecated and we should migrate our project structure to v3. See https://kubebuilder.io/migration/migration_guide_gov3_to_gov4
  * ```shell
      ❯ ./bin/operator-sdk-v1.36.0 create api --version v1alpha1 --kind Valkey --force
        ./bin/operator-sdk-v1.36.0 create webhook --version v1alpha1 --kind Valkey --defaulting --programmatic-validation --conversion
      [Deprecation Notice] This version is deprecated.The `go/v3` cannot scaffold projects using kustomize versions v4x+ and cannot fully support Kubernetes 1.25+.It is recommended to upgrade your project to the latest versions available (go/v4).Please, check the migration guide to learn how to upgrade your project
      ...
      ```

* Documents commands used to scaffold new resources in the "Developer guide" page
![Capture](https://github.com/user-attachments/assets/d822f048-1dba-4631-99b4-49c5ad5a16e5)
