### PR TITLE
chore(release): v0.27.0

### DIFF
--- a/charts/aiven-operator/templates/cluster_role.yaml
+++ b/charts/aiven-operator/templates/cluster_role.yaml
@@ -756,7 +756,7 @@ rules:
   - apiGroups:
       - aiven.io
     resources:
-      - valkeys
+      - valkey
     verbs:
       - create
       - delete
@@ -768,13 +768,15 @@ rules:
   - apiGroups:
       - aiven.io
     resources:
-      - valkeys/finalizers
+      - valkey/finalizers
     verbs:
+      - create
+      - get
       - update
   - apiGroups:
       - aiven.io
     resources:
-      - valkeys/status
+      - valkey/status
     verbs:
       - get
       - patch


### PR DESCRIPTION
## About this change—what it does

Release v0.27.0

Somehow valkey was incorrectly named in `charts/`. Running `make charts` made the changes.