### PR TITLE
fix: docs example generation

### DIFF
--- a/generators/docs/generator.go
+++ b/generators/docs/generator.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/goccy/go-yaml"
 	"golang.org/x/exp/slices"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/sync v0.10.0
 	golang.org/x/tools v0.29.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.15
 	k8s.io/apimachinery v0.26.15
 	k8s.io/client-go v0.26.15
@@ -100,7 +101,6 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.10 // indirect
 	k8s.io/component-base v0.26.10 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect


### PR DESCRIPTION
`goccy/go-yaml` broke docs example generation due to some incompatability