### PR TITLE
docs(redis): add EOL notice to Redis resource [DOC-1302]

### DIFF
--- a/docs/docs/resources/clickhouse.md
+++ b/docs/docs/resources/clickhouse.md
@@ -6,9 +6,10 @@ weight: 55
 
 Aiven for ClickHouse® is a fully managed distributed columnar database based on open source ClickHouse.
 
-!!! note
-    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed
-    (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)), and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+## Prerequisites
+
+* A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md).
+* A [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Create a ClickHouse instance
 

--- a/docs/docs/resources/kafka/index.md
+++ b/docs/docs/resources/kafka/index.md
@@ -7,10 +7,10 @@ weight: 30
 Aiven for Apache Kafka is an excellent option if you need to run Apache Kafka at scale. With Aiven Kubernetes Operator
 you can get up and running with a suitably sized Apache Kafka service in a few minutes.
 
-!!! note
-    Before going through this guide, make sure you have a [Kubernetes cluster](../../installation/prerequisites.md) with the
-    operator installed (see instructions for [helm](../../installation/helm.md) or [kubectl](../../installation/kubectl.md)),
-    and a [Kubernetes Secret with an Aiven authentication token](../../authentication.md).
+## Prerequisites
+
+* A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../../installation/helm.md) or [kubectl](../../installation/kubectl.md).
+* A [Kubernetes Secret with an Aiven authentication token](../../authentication.md).
 
 ## Create a Kafka instance
 

--- a/docs/docs/resources/mysql.md
+++ b/docs/docs/resources/mysql.md
@@ -6,7 +6,10 @@ weight: 46
 
 Aiven for MySQL is a fully managed relational database service, deployable in the cloud of your choice.
 
-> Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)) and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+## Prerequisites
+
+* A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md).
+* A [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Create a MySQL instance
 

--- a/docs/docs/resources/opensearch.md
+++ b/docs/docs/resources/opensearch.md
@@ -6,9 +6,10 @@ weight: 45
 
 OpenSearch® is an open source search and analytics suite including search engine, NoSQL document database, and visualization interface. OpenSearch offers a distributed, full-text search engine based on Apache Lucene® with a RESTful API interface and support for JSON documents.
 
-!!! note
-    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
-    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+## Prerequisites
+
+* A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md).
+* A [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Create an OpenSearch instance
 

--- a/docs/docs/resources/postgresql.md
+++ b/docs/docs/resources/postgresql.md
@@ -11,9 +11,10 @@ extender for location queries. Aiven for PostgreSQL is the perfect fit for your 
 
 With Aiven Kubernetes Operator, you can manage Aiven for PostgreSQL through the well defined Kubernetes API.
 
-!!! note
-    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
-    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+## Prerequisites
+
+* A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md).
+* A [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Create a PostgreSQL instance
 

--- a/docs/docs/resources/project-vpc.md
+++ b/docs/docs/resources/project-vpc.md
@@ -10,9 +10,10 @@ directly without going through the public internet.
 
 Within the Aiven Kubernetes Operator, you can create a `ProjectVPC` on Aiven's side to connect to your cloud provider.
 
-!!! note
-    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
-    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+## Prerequisites
+
+* A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md).
+* A [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Create an Aiven VPC
 

--- a/docs/docs/resources/project.md
+++ b/docs/docs/resources/project.md
@@ -4,11 +4,14 @@ linkTitle: "Aiven Project"
 weight: 5
 ---
 
-!!! note
-    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)), 
-    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
-
 The `Project` CRD allows you to create Aiven Projects, where your resources can be located.
+
+## Prerequisites
+
+* A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md).
+* A [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+
+## Create a project
 
 To create a fully working Aiven Project with the Aiven Operator you need a source Aiven Project already created with a working billing configuration, like a credit card.
 

--- a/docs/docs/resources/redis.md
+++ b/docs/docs/resources/redis.md
@@ -6,9 +6,14 @@ weight: 50
 
 Aiven for Redis®\* is a fully managed in-memory NoSQL database that you can deploy in the cloud of your choice to store and access data quickly and efficiently.
 
-!!! note
-    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
-    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+!!! warning "End of life notice"
+
+    The Aiven for Caching offering (formerly Aiven for Redis®) is entering its [end-of-life cycle](https://aiven.io/docs/platform/reference/end-of-life). From **February 15th, 2025**, it will not be possible to start a new Aiven for Caching service, but existing services up until version 7.2 will still be available until end of life. From **March 31st, 2025**, Aiven for Caching will no longer be available and all existing services will be migrated to Aiven for Valkey™. You can [upgrade to Valkey for free yourself](https://aiven.io/docs/products/caching/howto/upgrade-aiven-for-caching-to-valkey) before then.
+
+## Prerequisites
+
+* A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md).
+* A [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Create a Redis instance
 

--- a/docs/docs/resources/service-integrations.md
+++ b/docs/docs/resources/service-integrations.md
@@ -10,9 +10,10 @@ See
 our [Getting Started with Service Integrations guide](https://aiven.io/docs/platform/concepts/service-integration)
 for more information.
 
-!!! note
-    Before going through this guide, make sure you have a [Kubernetes cluster](../installation/prerequisites.md) with the operator installed (see instructions for [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md)),
-    and a [Kubernetes Secret with an Aiven authentication token](../authentication.md).
+## Prerequisites
+
+* A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md).
+* A [Kubernetes Secret with an Aiven authentication token](../authentication.md).
 
 ## Send Kafka logs to a Kafka Topic
 


### PR DESCRIPTION
Adds EOL notice to Redis resource and updates language in API reference notice. Also replaces note callouts
across all docs with a prerequisites section
to make notices like this EOL callout more prominent.