### PR TITLE
docs: use tabs for code snippets

### DIFF
--- a/docs/docs/resources/alloydbomni.md
+++ b/docs/docs/resources/alloydbomni.md
@@ -8,53 +8,52 @@ title: "AlloyDBOmni"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: AlloyDBOmni
-    metadata:
-      name: my-alloydbomni
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: adbo-secret
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: startup-4
-      disk_space: 90GiB
-    
-      maintenanceWindowDow: sunday
-      maintenanceWindowTime: 11:00:00
-    
-      serviceAccountCredentials: |
-        {
-          "private_key_id": "valid_private_key_id",
-          "private_key": "-----BEGIN PRIVATE KEY-----...-----END PRIVATE KEY-----",
-          "client_email": "example@aiven.io",
-          "client_id": "example_user_id",
-          "type": "service_account",
-          "project_id": "example_project_id"
-        }
-    
-      tags:
-        env: test
-        instance: foo
-    
-      userConfig:
-        service_log: true
-        ip_filter:
-          - network: 0.0.0.0/32
-            description: bar
-          - network: 10.20.0.0/16
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: AlloyDBOmni
+metadata:
+  name: my-alloydbomni
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: adbo-secret
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: startup-4
+  disk_space: 90GiB
+
+  maintenanceWindowDow: sunday
+  maintenanceWindowTime: 11:00:00
+
+  serviceAccountCredentials: |
+    {
+      "private_key_id": "valid_private_key_id",
+      "private_key": "-----BEGIN PRIVATE KEY-----...-----END PRIVATE KEY-----",
+      "client_email": "example@aiven.io",
+      "client_id": "example_user_id",
+      "type": "service_account",
+      "project_id": "example_project_id"
+    }
+
+  tags:
+    env: test
+    instance: foo
+
+  userConfig:
+    service_log: true
+    ip_filter:
+      - network: 0.0.0.0/32
+        description: bar
+      - network: 10.20.0.0/16
+```
 
 Apply the resource with:
 
@@ -98,6 +97,8 @@ The output is similar to the following:
 	"ALLOYDBOMNI_DATABASE_URI": "<secret>",
 }
 ```
+
+---
 
 ## AlloyDBOmni {: #AlloyDBOmni }
 

--- a/docs/docs/resources/cassandra.md
+++ b/docs/docs/resources/cassandra.md
@@ -11,41 +11,40 @@ title: "Cassandra [DEPRECATED]"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: Cassandra
-    metadata:
-      name: my-cassandra
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: cassandra-secret
-        prefix: MY_SECRET_PREFIX_
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: aiven-project-name
-      cloudName: google-europe-west1
-      plan: startup-4
-    
-      maintenanceWindowDow: sunday
-      maintenanceWindowTime: 11:00:00
-    
-      userConfig:
-        migrate_sstableloader: true
-        public_access:
-          prometheus: true
-        ip_filter:
-          - network: 0.0.0.0
-            description: whatever
-          - network: 10.20.0.0/16
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: Cassandra
+metadata:
+  name: my-cassandra
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: cassandra-secret
+    prefix: MY_SECRET_PREFIX_
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: aiven-project-name
+  cloudName: google-europe-west1
+  plan: startup-4
+
+  maintenanceWindowDow: sunday
+  maintenanceWindowTime: 11:00:00
+
+  userConfig:
+    migrate_sstableloader: true
+    public_access:
+      prometheus: true
+    ip_filter:
+      - network: 0.0.0.0
+        description: whatever
+      - network: 10.20.0.0/16
+```
 
 Apply the resource with:
 
@@ -89,6 +88,8 @@ The output is similar to the following:
 	"CASSANDRA_CA_CERT": "<secret>",
 }
 ```
+
+---
 
 ## Cassandra {: #Cassandra }
 

--- a/docs/docs/resources/clickhouse.md
+++ b/docs/docs/resources/clickhouse.md
@@ -8,41 +8,40 @@ title: "Clickhouse"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: Clickhouse
-    metadata:
-      name: my-clickhouse
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: my-clickhouse
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      tags:
-        env: test
-        instance: foo
-    
-      userConfig:
-        ip_filter:
-          - network: 0.0.0.0/32
-            description: bar
-          - network: 10.20.0.0/16
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: startup-16
-    
-      maintenanceWindowDow: friday
-      maintenanceWindowTime: 23:00:00
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: Clickhouse
+metadata:
+  name: my-clickhouse
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: my-clickhouse
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  tags:
+    env: test
+    instance: foo
+
+  userConfig:
+    ip_filter:
+      - network: 0.0.0.0/32
+        description: bar
+      - network: 10.20.0.0/16
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: startup-16
+
+  maintenanceWindowDow: friday
+  maintenanceWindowTime: 23:00:00
+```
 
 Apply the resource with:
 
@@ -83,6 +82,8 @@ The output is similar to the following:
 	"CLICKHOUSE_PASSWORD": "<secret>",
 }
 ```
+
+---
 
 ## Clickhouse {: #Clickhouse }
 

--- a/docs/docs/resources/clickhousedatabase.md
+++ b/docs/docs/resources/clickhousedatabase.md
@@ -8,21 +8,20 @@ title: "ClickhouseDatabase"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: ClickhouseDatabase
-    metadata:
-      name: my-db
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: my-aiven-project
-      serviceName: my-clickhouse
-      databaseName: example-db
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: ClickhouseDatabase
+metadata:
+  name: my-db
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: my-aiven-project
+  serviceName: my-clickhouse
+  databaseName: example-db
+```
 
 Apply the resource with:
 
@@ -41,6 +40,8 @@ The output is similar to the following:
 Name     Database name    Service Name     Project             
 my-db    example-db       my-clickhouse    my-aiven-project    
 ```
+
+---
 
 ## ClickhouseDatabase {: #ClickhouseDatabase }
 

--- a/docs/docs/resources/clickhousegrant.md
+++ b/docs/docs/resources/clickhousegrant.md
@@ -8,8 +8,10 @@ title: "ClickhouseGrant"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example "example_2"
-    ```yaml
+	
+=== "example_2"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ClickhouseGrant
     metadata:
@@ -50,8 +52,10 @@ title: "ClickhouseGrant"
             - role: my-role
     ```
 
-??? example 
-    ```yaml
+	
+=== "example"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ClickhouseGrant
     metadata:
@@ -155,6 +159,8 @@ The output is similar to the following:
 Name             Project             Service Name     
 demo-ch-grant    my-aiven-project    my-clickhouse    
 ```
+
+---
 
 ## ClickhouseGrant {: #ClickhouseGrant }
 

--- a/docs/docs/resources/clickhouserole.md
+++ b/docs/docs/resources/clickhouserole.md
@@ -8,21 +8,20 @@ title: "ClickhouseRole"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: ClickhouseRole
-    metadata:
-      name: my-role
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: my-aiven-project
-      serviceName: my-clickhouse
-      role: my-role
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: ClickhouseRole
+metadata:
+  name: my-role
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: my-aiven-project
+  serviceName: my-clickhouse
+  role: my-role
+```
 
 Apply the resource with:
 
@@ -41,6 +40,8 @@ The output is similar to the following:
 Name       Project             Service Name     Role       
 my-role    my-aiven-project    my-clickhouse    my-role    
 ```
+
+---
 
 ## ClickhouseRole {: #ClickhouseRole }
 

--- a/docs/docs/resources/clickhouseuser.md
+++ b/docs/docs/resources/clickhouseuser.md
@@ -8,43 +8,42 @@ title: "ClickhouseUser"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: ClickhouseUser
-    metadata:
-      name: my-clickhouse-user
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: clickhouse-user-secret
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: my-aiven-project
-      serviceName: my-clickhouse
-      username: example-username
-    
-    ---
-    
-    apiVersion: aiven.io/v1alpha1
-    kind: Clickhouse
-    metadata:
-      name: my-clickhouse
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: startup-16
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: ClickhouseUser
+metadata:
+  name: my-clickhouse-user
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: clickhouse-user-secret
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: my-aiven-project
+  serviceName: my-clickhouse
+  username: example-username
+
+---
+
+apiVersion: aiven.io/v1alpha1
+kind: Clickhouse
+metadata:
+  name: my-clickhouse
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: startup-16
+```
 
 Apply the resource with:
 
@@ -85,6 +84,8 @@ The output is similar to the following:
 	"CLICKHOUSEUSER_PASSWORD": "<secret>",
 }
 ```
+
+---
 
 ## ClickhouseUser {: #ClickhouseUser }
 

--- a/docs/docs/resources/connectionpool.md
+++ b/docs/docs/resources/connectionpool.md
@@ -8,67 +8,66 @@ title: "ConnectionPool"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: ConnectionPool
-    metadata:
-      name: my-connection-pool
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: aiven-project-name
-      serviceName: my-pg
-      databaseName: my-database
-      username: my-service-user
-      poolMode: transaction
-      poolSize: 25
-    
-    ---
-    
-    apiVersion: aiven.io/v1alpha1
-    kind: PostgreSQL
-    metadata:
-      name: my-pg
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: aiven-project-name
-      cloudName: google-europe-west1
-      plan: startup-4
-    
-    ---
-    
-    apiVersion: aiven.io/v1alpha1
-    kind: Database
-    metadata:
-      name: my-database
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: aiven-project-name
-      serviceName: my-pg
-    
-    ---
-    
-    apiVersion: aiven.io/v1alpha1
-    kind: ServiceUser
-    metadata:
-      name: my-service-user
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: aiven-project-name
-      serviceName: my-pg
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: ConnectionPool
+metadata:
+  name: my-connection-pool
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: aiven-project-name
+  serviceName: my-pg
+  databaseName: my-database
+  username: my-service-user
+  poolMode: transaction
+  poolSize: 25
+
+---
+
+apiVersion: aiven.io/v1alpha1
+kind: PostgreSQL
+metadata:
+  name: my-pg
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: aiven-project-name
+  cloudName: google-europe-west1
+  plan: startup-4
+
+---
+
+apiVersion: aiven.io/v1alpha1
+kind: Database
+metadata:
+  name: my-database
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: aiven-project-name
+  serviceName: my-pg
+
+---
+
+apiVersion: aiven.io/v1alpha1
+kind: ServiceUser
+metadata:
+  name: my-service-user
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: aiven-project-name
+  serviceName: my-pg
+```
 
 Apply the resource with:
 
@@ -87,6 +86,8 @@ The output is similar to the following:
 Name                  Service Name    Project               Database       Username           Pool Size    Pool Mode      
 my-connection-pool    my-pg           aiven-project-name    my-database    my-service-user    25           transaction    
 ```
+
+---
 
 ## ConnectionPool {: #ConnectionPool }
 

--- a/docs/docs/resources/database.md
+++ b/docs/docs/resources/database.md
@@ -8,42 +8,41 @@ title: "Database"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: PostgreSQL
-    metadata:
-      name: my-pg
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: aiven-project-name
-      cloudName: google-europe-west1
-      plan: startup-4
-    
-    ---
-    
-    apiVersion: aiven.io/v1alpha1
-    kind: Database
-    metadata:
-      name: my-db
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: aiven-project-name
-      serviceName: my-pg
-    
-      # Database name will default to the value of `metadata.name` if `databaseName` is not specified.
-      # Use the `databaseName` field if the desired database name contains underscores.
-      databaseName: my_db_name
-    
-      lcCtype: en_US.UTF-8
-      lcCollate: en_US.UTF-8
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: PostgreSQL
+metadata:
+  name: my-pg
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: aiven-project-name
+  cloudName: google-europe-west1
+  plan: startup-4
+
+---
+
+apiVersion: aiven.io/v1alpha1
+kind: Database
+metadata:
+  name: my-db
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: aiven-project-name
+  serviceName: my-pg
+
+  # Database name will default to the value of `metadata.name` if `databaseName` is not specified.
+  # Use the `databaseName` field if the desired database name contains underscores.
+  databaseName: my_db_name
+
+  lcCtype: en_US.UTF-8
+  lcCollate: en_US.UTF-8
+```
 
 Apply the resource with:
 
@@ -62,6 +61,8 @@ The output is similar to the following:
 Name     Project               Service Name    
 my-db    aiven-project-name    my-pg           
 ```
+
+---
 
 ## Database {: #Database }
 

--- a/docs/docs/resources/flink.md
+++ b/docs/docs/resources/flink.md
@@ -8,38 +8,37 @@ title: "Flink"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: Flink
-    metadata:
-      name: my-flink
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: flink-secret
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: business-4
-    
-      maintenanceWindowDow: sunday
-      maintenanceWindowTime: 11:00:00
-    
-      userConfig:
-        number_of_task_slots: 10
-        ip_filter:
-          - network: 0.0.0.0/32
-            description: whatever
-          - network: 10.20.0.0/16
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: Flink
+metadata:
+  name: my-flink
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: flink-secret
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: business-4
+
+  maintenanceWindowDow: sunday
+  maintenanceWindowTime: 11:00:00
+
+  userConfig:
+    number_of_task_slots: 10
+    ip_filter:
+      - network: 0.0.0.0/32
+        description: whatever
+      - network: 10.20.0.0/16
+```
 
 Apply the resource with:
 
@@ -82,6 +81,8 @@ The output is similar to the following:
 	"FLINK_HOSTS": "<secret>",
 }
 ```
+
+---
 
 ## Flink {: #Flink }
 

--- a/docs/docs/resources/grafana.md
+++ b/docs/docs/resources/grafana.md
@@ -8,40 +8,39 @@ title: "Grafana"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: Grafana
-    metadata:
-      name: my-grafana
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: grafana-secret
-        prefix: MY_SECRET_PREFIX_
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: startup-1
-    
-      maintenanceWindowDow: sunday
-      maintenanceWindowTime: 11:00:00
-    
-      userConfig:
-        public_access:
-          grafana: true
-        ip_filter:
-          - network: 0.0.0.0
-            description: whatever
-          - network: 10.20.0.0/16
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: Grafana
+metadata:
+  name: my-grafana
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: grafana-secret
+    prefix: MY_SECRET_PREFIX_
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: startup-1
+
+  maintenanceWindowDow: sunday
+  maintenanceWindowTime: 11:00:00
+
+  userConfig:
+    public_access:
+      grafana: true
+    ip_filter:
+      - network: 0.0.0.0
+        description: whatever
+      - network: 10.20.0.0/16
+```
 
 Apply the resource with:
 
@@ -84,6 +83,8 @@ The output is similar to the following:
 	"GRAFANA_HOSTS": "<secret>",
 }
 ```
+
+---
 
 ## Grafana {: #Grafana }
 

--- a/docs/docs/resources/kafka.md
+++ b/docs/docs/resources/kafka.md
@@ -8,32 +8,31 @@ title: "Kafka"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: Kafka
-    metadata:
-      name: my-kafka
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: kafka-secret
-        prefix: MY_SECRET_PREFIX_
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: startup-2
-    
-      maintenanceWindowDow: friday
-      maintenanceWindowTime: 23:00:00
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-kafka
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: kafka-secret
+    prefix: MY_SECRET_PREFIX_
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: startup-2
+
+  maintenanceWindowDow: friday
+  maintenanceWindowTime: 23:00:00
+```
 
 Apply the resource with:
 
@@ -85,6 +84,8 @@ The output is similar to the following:
 	"KAFKA_CA_CERT": "<secret>",
 }
 ```
+
+---
 
 ## Kafka {: #Kafka }
 

--- a/docs/docs/resources/kafkaacl.md
+++ b/docs/docs/resources/kafkaacl.md
@@ -8,23 +8,22 @@ title: "KafkaACL"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: KafkaACL
-    metadata:
-      name: my-kafka-acl
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: my-aiven-project
-      serviceName: my-kafka
-      topic: my-topic
-      username: my-user
-      permission: admin
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: KafkaACL
+metadata:
+  name: my-kafka-acl
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: my-aiven-project
+  serviceName: my-kafka
+  topic: my-topic
+  username: my-user
+  permission: admin
+```
 
 Apply the resource with:
 
@@ -43,6 +42,8 @@ The output is similar to the following:
 Name            Service Name    Project             Username    Permission    Topic       
 my-kafka-acl    my-kafka        my-aiven-project    my-user     admin         my-topic    
 ```
+
+---
 
 ## KafkaACL {: #KafkaACL }
 

--- a/docs/docs/resources/kafkaconnect.md
+++ b/docs/docs/resources/kafkaconnect.md
@@ -8,27 +8,26 @@ title: "KafkaConnect"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: KafkaConnect
-    metadata:
-      name: my-kafka-connect
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: business-4
-    
-      userConfig:
-        kafka_connect:
-          consumer_isolation_level: read_committed
-        public_access:
-          kafka_connect: true
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: KafkaConnect
+metadata:
+  name: my-kafka-connect
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: business-4
+
+  userConfig:
+    kafka_connect:
+      consumer_isolation_level: read_committed
+    public_access:
+      kafka_connect: true
+```
 
 Apply the resource with:
 
@@ -47,6 +46,8 @@ The output is similar to the following:
 Name                Project             Region                 Plan          State      
 my-kafka-connect    my-aiven-project    google-europe-west1    business-4    RUNNING    
 ```
+
+---
 
 ## KafkaConnect {: #KafkaConnect }
 

--- a/docs/docs/resources/kafkaschema.md
+++ b/docs/docs/resources/kafkaschema.md
@@ -8,36 +8,35 @@ title: "KafkaSchema"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: KafkaSchema
-    metadata:
-      name: my-schema
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: my-aiven-project
-      serviceName: my-kafka
-      subjectName: mny-subject
-      compatibilityLevel: BACKWARD
-      schema: |
-        {
-            "doc": "example_doc",
-            "fields": [{
-                "default": 5,
-                "doc": "field_doc",
-                "name": "field_name",
-                "namespace": "field_namespace",
-                "type": "int"
-            }],
-            "name": "example_name",
-            "namespace": "example_namespace",
-            "type": "record"
-        }
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: KafkaSchema
+metadata:
+  name: my-schema
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: my-aiven-project
+  serviceName: my-kafka
+  subjectName: mny-subject
+  compatibilityLevel: BACKWARD
+  schema: |
+    {
+        "doc": "example_doc",
+        "fields": [{
+            "default": 5,
+            "doc": "field_doc",
+            "name": "field_name",
+            "namespace": "field_namespace",
+            "type": "int"
+        }],
+        "name": "example_name",
+        "namespace": "example_namespace",
+        "type": "record"
+    }
+```
 
 Apply the resource with:
 
@@ -56,6 +55,8 @@ The output is similar to the following:
 Name         Service Name    Project             Subject        Compatibility Level    Version      
 my-schema    my-kafka        my-aiven-project    mny-subject    BACKWARD               <version>    
 ```
+
+---
 
 ## KafkaSchema {: #KafkaSchema }
 

--- a/docs/docs/resources/kafkaschemaregistryacl.md
+++ b/docs/docs/resources/kafkaschemaregistryacl.md
@@ -8,23 +8,22 @@ title: "KafkaSchemaRegistryACL"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: KafkaSchemaRegistryACL
-    metadata:
-      name: my-kafka-schema-registry-acl
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: aiven-project-name
-      serviceName: my-kafka
-      resource: Subject:my-topic
-      username: my-user
-      permission: schema_registry_read
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: KafkaSchemaRegistryACL
+metadata:
+  name: my-kafka-schema-registry-acl
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: aiven-project-name
+  serviceName: my-kafka
+  resource: Subject:my-topic
+  username: my-user
+  permission: schema_registry_read
+```
 
 Apply the resource with:
 
@@ -43,6 +42,8 @@ The output is similar to the following:
 Name                            Project               Service Name    Resource            Username    State      
 my-kafka-schema-registry-acl    aiven-project-name    my-kafka        Subject:my-topic    my-user     RUNNING    
 ```
+
+---
 
 ## KafkaSchemaRegistryACL {: #KafkaSchemaRegistryACL }
 

--- a/docs/docs/resources/kafkatopic.md
+++ b/docs/docs/resources/kafkatopic.md
@@ -8,27 +8,26 @@ title: "KafkaTopic"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: KafkaTopic
-    metadata:
-      name: kafka-topic
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: my-aiven-project
-      serviceName: my-kafka
-      topicName: my-kafka-topic
-    
-      replication: 2
-      partitions: 1
-    
-      config:
-        min_cleanable_dirty_ratio: 0.2
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: KafkaTopic
+metadata:
+  name: kafka-topic
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: my-aiven-project
+  serviceName: my-kafka
+  topicName: my-kafka-topic
+
+  replication: 2
+  partitions: 1
+
+  config:
+    min_cleanable_dirty_ratio: 0.2
+```
 
 Apply the resource with:
 
@@ -47,6 +46,8 @@ The output is similar to the following:
 Name           Service Name    Project             Partitions    Replication    
 kafka-topic    my-kafka        my-aiven-project    1             2              
 ```
+
+---
 
 ## KafkaTopic {: #KafkaTopic }
 

--- a/docs/docs/resources/mysql.md
+++ b/docs/docs/resources/mysql.md
@@ -8,40 +8,39 @@ title: "MySQL"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: MySQL
-    metadata:
-      name: my-mysql
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: mysql-secret
-        prefix: MY_SECRET_PREFIX_
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: business-4
-    
-      maintenanceWindowDow: sunday
-      maintenanceWindowTime: 11:00:00
-    
-      userConfig:
-        backup_hour: 17
-        backup_minute: 11
-        ip_filter:
-          - network: 0.0.0.0
-            description: whatever
-          - network: 10.20.0.0/16
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: MySQL
+metadata:
+  name: my-mysql
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: mysql-secret
+    prefix: MY_SECRET_PREFIX_
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: business-4
+
+  maintenanceWindowDow: sunday
+  maintenanceWindowTime: 11:00:00
+
+  userConfig:
+    backup_hour: 17
+    backup_minute: 11
+    ip_filter:
+      - network: 0.0.0.0
+        description: whatever
+      - network: 10.20.0.0/16
+```
 
 Apply the resource with:
 
@@ -87,6 +86,8 @@ The output is similar to the following:
 	"MYSQL_CA_CERT": "<secret>",
 }
 ```
+
+---
 
 ## MySQL {: #MySQL }
 

--- a/docs/docs/resources/opensearch.md
+++ b/docs/docs/resources/opensearch.md
@@ -8,33 +8,32 @@ title: "OpenSearch"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: OpenSearch
-    metadata:
-      name: my-os
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: os-secret
-        prefix: MY_SECRET_PREFIX_
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: startup-4
-      disk_space: 80GiB
-    
-      maintenanceWindowDow: friday
-      maintenanceWindowTime: 23:00:00
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: OpenSearch
+metadata:
+  name: my-os
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: os-secret
+    prefix: MY_SECRET_PREFIX_
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: startup-4
+  disk_space: 80GiB
+
+  maintenanceWindowDow: friday
+  maintenanceWindowTime: 23:00:00
+```
 
 Apply the resource with:
 
@@ -75,6 +74,8 @@ The output is similar to the following:
 	"OPENSEARCH_PASSWORD": "<secret>",
 }
 ```
+
+---
 
 ## OpenSearch {: #OpenSearch }
 

--- a/docs/docs/resources/postgresql.md
+++ b/docs/docs/resources/postgresql.md
@@ -8,35 +8,34 @@ title: "PostgreSQL"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: PostgreSQL
-    metadata:
-      name: my-postgresql
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: postgresql-secret
-        prefix: MY_SECRET_PREFIX_
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: aiven-project-name
-      cloudName: google-europe-west1
-      plan: startup-4
-    
-      maintenanceWindowDow: sunday
-      maintenanceWindowTime: 11:00:00
-    
-      userConfig:
-        pg_version: "15"
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: PostgreSQL
+metadata:
+  name: my-postgresql
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: postgresql-secret
+    prefix: MY_SECRET_PREFIX_
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: aiven-project-name
+  cloudName: google-europe-west1
+  plan: startup-4
+
+  maintenanceWindowDow: sunday
+  maintenanceWindowTime: 11:00:00
+
+  userConfig:
+    pg_version: "15"
+```
 
 Apply the resource with:
 
@@ -81,6 +80,8 @@ The output is similar to the following:
 	"POSTGRESQL_CA_CERT": "<secret>",
 }
 ```
+
+---
 
 ## PostgreSQL {: #PostgreSQL }
 

--- a/docs/docs/resources/project.md
+++ b/docs/docs/resources/project.md
@@ -8,31 +8,30 @@ title: "Project"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: Project
-    metadata:
-      name: my-project
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: project-secret
-        prefix: MY_SECRET_PREFIX_
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      tags:
-        env: prod
-    
-      billingAddress: NYC
-      cloud: aws-eu-west-1
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: Project
+metadata:
+  name: my-project
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: project-secret
+    prefix: MY_SECRET_PREFIX_
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  tags:
+    env: prod
+
+  billingAddress: NYC
+  cloud: aws-eu-west-1
+```
 
 Apply the resource with:
 
@@ -70,6 +69,8 @@ The output is similar to the following:
 	"PROJECT_CA_CERT": "<secret>",
 }
 ```
+
+---
 
 ## Project {: #Project }
 

--- a/docs/docs/resources/projectvpc.md
+++ b/docs/docs/resources/projectvpc.md
@@ -8,21 +8,20 @@ title: "ProjectVPC"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: ProjectVPC
-    metadata:
-      name: my-project-vpc
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      project: aiven-project-name
-      cloudName: google-europe-west1
-      networkCidr: 10.0.0.0/24
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: ProjectVPC
+metadata:
+  name: my-project-vpc
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: aiven-project-name
+  cloudName: google-europe-west1
+  networkCidr: 10.0.0.0/24
+```
 
 Apply the resource with:
 
@@ -41,6 +40,8 @@ The output is similar to the following:
 Name              Project               Cloud                  Network CIDR    State      
 my-project-vpc    aiven-project-name    google-europe-west1    10.0.0.0/24     RUNNING    
 ```
+
+---
 
 ## ProjectVPC {: #ProjectVPC }
 

--- a/docs/docs/resources/redis.md
+++ b/docs/docs/resources/redis.md
@@ -11,35 +11,34 @@ title: "Redis [DEPRECATED]"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: Redis
-    metadata:
-      name: k8s-redis
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: redis-token
-        prefix: MY_SECRET_PREFIX_
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: startup-4
-    
-      maintenanceWindowDow: friday
-      maintenanceWindowTime: 23:00:00
-    
-      userConfig:
-        redis_maxmemory_policy: allkeys-random
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: Redis
+metadata:
+  name: k8s-redis
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: redis-token
+    prefix: MY_SECRET_PREFIX_
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: startup-4
+
+  maintenanceWindowDow: friday
+  maintenanceWindowTime: 23:00:00
+
+  userConfig:
+    redis_maxmemory_policy: allkeys-random
+```
 
 Apply the resource with:
 
@@ -81,6 +80,8 @@ The output is similar to the following:
 	"REDIS_SSL": "<secret>",
 }
 ```
+
+---
 
 ## Redis {: #Redis }
 

--- a/docs/docs/resources/serviceintegration.md
+++ b/docs/docs/resources/serviceintegration.md
@@ -8,8 +8,10 @@ title: "ServiceIntegration"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example "autoscaler"
-    ```yaml
+	
+=== "autoscaler"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ServiceIntegration
     metadata:
@@ -41,8 +43,10 @@ title: "ServiceIntegration"
       plan: startup-4
     ```
 
-??? example "clickhouse_postgresql"
-    ```yaml
+	
+=== "clickhouse_postgresql"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ServiceIntegration
     metadata:
@@ -97,8 +101,10 @@ title: "ServiceIntegration"
       maintenanceWindowTime: 23:00:00
     ```
 
-??? example "datadog"
-    ```yaml
+	
+=== "datadog"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ServiceIntegration
     metadata:
@@ -135,8 +141,10 @@ title: "ServiceIntegration"
       plan: startup-4
     ```
 
-??? example "kafka_connect"
-    ```yaml
+	
+=== "kafka_connect"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ServiceIntegration
     metadata:
@@ -194,8 +202,10 @@ title: "ServiceIntegration"
           kafka_connect: true
     ```
 
-??? example "kafka_logs"
-    ```yaml
+	
+=== "kafka_logs"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ServiceIntegration
     metadata:
@@ -262,6 +272,8 @@ The output is similar to the following:
 Name                      Project               Type          Source Service Name    Destination Endpoint ID       
 my-service-integration    aiven-project-name    autoscaler    my-pg                  my-destination-endpoint-id    
 ```
+
+---
 
 ## ServiceIntegration {: #ServiceIntegration }
 

--- a/docs/docs/resources/serviceintegrationendpoint.md
+++ b/docs/docs/resources/serviceintegrationendpoint.md
@@ -8,8 +8,10 @@ title: "ServiceIntegrationEndpoint"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example "autoscaler"
-    ```yaml
+	
+=== "autoscaler"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ServiceIntegrationEndpoint
     metadata:
@@ -29,8 +31,10 @@ title: "ServiceIntegrationEndpoint"
             cap_gb: 100
     ```
 
-??? example "external_postgresql"
-    ```yaml
+	
+=== "external_postgresql"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ServiceIntegrationEndpoint
     metadata:
@@ -52,8 +56,10 @@ title: "ServiceIntegrationEndpoint"
         ssl_mode: require
     ```
 
-??? example "external_schema_registry"
-    ```yaml
+	
+=== "external_schema_registry"
+
+    ```yaml linenums="1"
     apiVersion: aiven.io/v1alpha1
     kind: ServiceIntegrationEndpoint
     metadata:
@@ -91,6 +97,8 @@ The output is similar to the following:
 Name                               Project               Endpoint Name    Endpoint Type    ID      
 my-service-integration-endpoint    aiven-project-name    my-autoscaler    autoscaler       <id>    
 ```
+
+---
 
 ## ServiceIntegrationEndpoint {: #ServiceIntegrationEndpoint }
 

--- a/docs/docs/resources/serviceuser.md
+++ b/docs/docs/resources/serviceuser.md
@@ -8,28 +8,27 @@ title: "ServiceUser"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: ServiceUser
-    metadata:
-      name: my-service-user
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: service-user-secret
-        prefix: MY_SECRET_PREFIX_
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: aiven-project-name
-      serviceName: my-service-name
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: ServiceUser
+metadata:
+  name: my-service-user
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: service-user-secret
+    prefix: MY_SECRET_PREFIX_
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: aiven-project-name
+  serviceName: my-service-name
+```
 
 Apply the resource with:
 
@@ -73,6 +72,8 @@ The output is similar to the following:
 	"SERVICEUSER_ACCESS_KEY": "<secret>",
 }
 ```
+
+---
 
 ## ServiceUser {: #ServiceUser }
 

--- a/docs/docs/resources/valkey.md
+++ b/docs/docs/resources/valkey.md
@@ -8,41 +8,40 @@ title: "Valkey"
 	* A Kubernetes cluster with the operator installed using [helm](../installation/helm.md), [kubectl](../installation/kubectl.md) or [kind](../contributing/developer-guide.md) (for local development).
 	* A Kubernetes [Secret](../authentication.md) with an Aiven authentication token.
 
-??? example 
-    ```yaml
-    apiVersion: aiven.io/v1alpha1
-    kind: Valkey
-    metadata:
-      name: my-valkey
-    spec:
-      authSecretRef:
-        name: aiven-token
-        key: token
-    
-      connInfoSecretTarget:
-        name: my-valkey-secret
-        annotations:
-          foo: bar
-        labels:
-          baz: egg
-    
-      project: my-aiven-project
-      cloudName: google-europe-west1
-      plan: startup-4
-    
-      maintenanceWindowDow: sunday
-      maintenanceWindowTime: 11:00:00
-    
-      tags:
-        env: test
-        instance: foo
-    
-      userConfig:
-        ip_filter:
-          - network: 0.0.0.0/32
-            description: bar
-          - network: 10.20.0.0/16
-    ```
+```yaml linenums="1"
+apiVersion: aiven.io/v1alpha1
+kind: Valkey
+metadata:
+  name: my-valkey
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: my-valkey-secret
+    annotations:
+      foo: bar
+    labels:
+      baz: egg
+
+  project: my-aiven-project
+  cloudName: google-europe-west1
+  plan: startup-4
+
+  maintenanceWindowDow: sunday
+  maintenanceWindowTime: 11:00:00
+
+  tags:
+    env: test
+    instance: foo
+
+  userConfig:
+    ip_filter:
+      - network: 0.0.0.0/32
+        description: bar
+      - network: 10.20.0.0/16
+```
 
 Apply the resource with:
 
@@ -84,6 +83,8 @@ The output is similar to the following:
 	"VALKEY_SSL": "<secret>",
 }
 ```
+
+---
 
 ## Valkey {: #Valkey }
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -17,6 +17,8 @@ markdown_extensions:
       check_paths: true
       base_path:
         - docs/.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.tilde
   - pymdownx.details
   - pymdownx.magiclink
@@ -40,6 +42,7 @@ theme:
     - content.code.copy
     - content.code.annotate
     - content.action.view
+    - content.tabs.link
   palette:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
Expandable blocks reduce text size making code snippets hard to read.

- Removes expandable blocks
- Uses tabs to display multiple examples