### PR TITLE
refactor(kafkaschema): improve error handling and precondition checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Refactor `KafkaTopic`: replace HTTP client with code-generated one to improve maintainability and type safety
 - Add kind: `KafkaNativeACL`. Creates and manages Kafka-native access control lists (ACLs) for an Aiven for Apache Kafka® service.
 - Add key `OPENSEARCH_URI` to `OpenSearch` service secrets: Contains the OpenSearch service URI.
+- Change `KafkaSchema` fields `schemaType` and `subjectName` to be immutable since these fields cannot be modified after creation in the Kafka Schema Registry API
+- Improve `KafkaSchema` controller: optimize polling and add better error handling
 
 ## v0.29.0 - 2025-04-29
 

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -269,7 +269,7 @@ tasks:
 
   docs:build:
     desc: Builds docs website.
-    deps: [docs]
+    deps: [internal:generate:docs]
     cmds:
       - "{{.CONTAINER_TOOL}} run --rm -it -v $(pwd)/docs:/docs squidfunk/mkdocs-material build"
 

--- a/api/v1alpha1/kafkaschema_types.go
+++ b/api/v1alpha1/kafkaschema_types.go
@@ -12,6 +12,7 @@ type KafkaSchemaSpec struct {
 	ServiceDependant `json:",inline"`
 
 	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// Kafka Schema Subject name
 	SubjectName string `json:"subjectName"`
 
@@ -19,6 +20,7 @@ type KafkaSchemaSpec struct {
 	Schema string `json:"schema"`
 
 	// +kubebuilder:validation:Enum=AVRO;JSON;PROTOBUF
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// Schema type
 	SchemaType kafkaschemaregistry.SchemaType `json:"schemaType,omitempty"`
 
@@ -31,6 +33,9 @@ type KafkaSchemaSpec struct {
 type KafkaSchemaStatus struct {
 	// Conditions represent the latest available observations of an KafkaSchema state
 	Conditions []metav1.Condition `json:"conditions"`
+
+	// Schema ID
+	ID int `json:"id"`
 
 	// Kafka Schema configuration version
 	Version int `json:"version"`

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
@@ -99,6 +99,9 @@ spec:
                     - JSON
                     - PROTOBUF
                   type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
                 serviceName:
                   description:
                     Specifies the name of the service that this resource
@@ -113,6 +116,9 @@ spec:
                   description: Kafka Schema Subject name
                   maxLength: 63
                   type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
               required:
                 - project
                 - schema
@@ -195,11 +201,15 @@ spec:
                       - type
                     type: object
                   type: array
+                id:
+                  description: Schema ID
+                  type: integer
                 version:
                   description: Kafka Schema configuration version
                   type: integer
               required:
                 - conditions
+                - id
                 - version
               type: object
           type: object

--- a/config/crd/bases/aiven.io_kafkaschemas.yaml
+++ b/config/crd/bases/aiven.io_kafkaschemas.yaml
@@ -99,6 +99,9 @@ spec:
                     - JSON
                     - PROTOBUF
                   type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
                 serviceName:
                   description:
                     Specifies the name of the service that this resource
@@ -113,6 +116,9 @@ spec:
                   description: Kafka Schema Subject name
                   maxLength: 63
                   type: string
+                  x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
               required:
                 - project
                 - schema
@@ -195,11 +201,15 @@ spec:
                       - type
                     type: object
                   type: array
+                id:
+                  description: Schema ID
+                  type: integer
                 version:
                   description: Kafka Schema configuration version
                   type: integer
               required:
                 - conditions
+                - id
                 - version
               type: object
           type: object

--- a/controllers/basic_controller.go
+++ b/controllers/basic_controller.go
@@ -407,7 +407,7 @@ func (i *instanceReconcilerHelper) finalize(ctx context.Context, o v1alpha1.Aive
 		case isNotFound(err):
 			i.rec.Event(o, corev1.EventTypeWarning, eventUnableToDeleteAtAiven, err.Error())
 			return false, fmt.Errorf("unable to delete instance at aiven: %w", err)
-		case isAivenServerError(err):
+		case isServerError(err):
 			// If failed to delete, retries
 			i.log.Info(fmt.Sprintf("unable to delete instance at aiven: %s", err))
 			err = nil

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -132,14 +132,6 @@ func NilIfZero[T comparable](v T) *T {
 	return &v
 }
 
-func isAivenServerError(err error) bool {
-	var e avngen.Error
-	if errors.As(err, &e) {
-		return e.Status >= http.StatusInternalServerError
-	}
-	return false
-}
-
 // userAgent is a helper function to create a User-Agent string used for the Go client.
 func userAgent(kubeVersion, operatorVersion string) string {
 	// Remove the leading "v" from the version strings, if present.
@@ -246,7 +238,7 @@ func UpdateUserConfiguration(userConfig any) (map[string]any, error) {
 
 // isNotFound works both for old and new client errors
 func isNotFound(err error) bool {
-	return isAivenError(err, http.StatusNotFound)
+	return avngen.IsNotFound(err)
 }
 
 // isAlreadyExists works both for old and new client errors
@@ -272,5 +264,13 @@ func isAivenError(err error, code int) bool {
 		return e.Status == code
 	}
 
+	return false
+}
+
+func isServerError(err error) bool {
+	var e avngen.Error
+	if errors.As(err, &e) {
+		return e.Status >= http.StatusInternalServerError && e.Status < 600
+	}
 	return false
 }

--- a/docs/docs/resources/kafkaschema.md
+++ b/docs/docs/resources/kafkaschema.md
@@ -80,13 +80,13 @@ KafkaSchemaSpec defines the desired state of KafkaSchema.
 - [`project`](#spec.project-property){: name='spec.project-property'} (string, Immutable, Pattern: `^[a-zA-Z0-9_-]+$`, MaxLength: 63). Identifies the project this resource belongs to.
 - [`schema`](#spec.schema-property){: name='spec.schema-property'} (string). Kafka Schema configuration should be a valid Avro Schema JSON format.
 - [`serviceName`](#spec.serviceName-property){: name='spec.serviceName-property'} (string, Immutable, Pattern: `^[a-z][-a-z0-9]+$`, MaxLength: 63). Specifies the name of the service that this resource belongs to.
-- [`subjectName`](#spec.subjectName-property){: name='spec.subjectName-property'} (string, MaxLength: 63). Kafka Schema Subject name.
+- [`subjectName`](#spec.subjectName-property){: name='spec.subjectName-property'} (string, Immutable, MaxLength: 63). Kafka Schema Subject name.
 
 **Optional**
 
 - [`authSecretRef`](#spec.authSecretRef-property){: name='spec.authSecretRef-property'} (object). Authentication reference to Aiven token in a secret. See below for [nested schema](#spec.authSecretRef).
 - [`compatibilityLevel`](#spec.compatibilityLevel-property){: name='spec.compatibilityLevel-property'} (string, Enum: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`). Kafka Schemas compatibility level.
-- [`schemaType`](#spec.schemaType-property){: name='spec.schemaType-property'} (string, Enum: `AVRO`, `JSON`, `PROTOBUF`). Schema type.
+- [`schemaType`](#spec.schemaType-property){: name='spec.schemaType-property'} (string, Enum: `AVRO`, `JSON`, `PROTOBUF`, Immutable). Schema type.
 
 ## authSecretRef {: #spec.authSecretRef }
 


### PR DESCRIPTION
Resolves NEX-1607.

- Move schema version check to precondition phase for better flow control
- Add retry mechanism for 5xx errors to improve reliability
- Implement async version fetching to handle transient errors gracefully
- Mark `SubjectName` and `SchemaType` immutable