### PR TITLE
fix(kafkaconnector): better handle api errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Change `KafkaSchema` fields `schemaType` and `subjectName` to be immutable since these fields cannot be modified after creation in the Kafka Schema Registry API
 - Improve `KafkaSchema` controller: optimize polling and add better error handling
 - Improve `KafkaTopic`: better handle API 5xx errors.
+- Improve `KafkaConnector`: better handle API 404 and 5xx errors.
 
 ## v0.29.0 - 2025-04-29
 


### PR DESCRIPTION
Resolves NEX-1610.

- Doesn't call `ServiceKafkaConnectGetConnectorStatus` to know if the connector exists. 
  It might return OK, and `ServiceKafkaConnectCreateConnector` might fail with 404 right after. Instead calls "create", and `ServiceKafkaConnectEditConnector` to update it if gets a conflict.
- Additionally, retries all 5xx errors.