### PR TITLE
ci: run `task lint:go` on push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,24 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6
+
+  lint-go:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip workflows')) || github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: task lint:go
+
   trunk:
     runs-on: ubuntu-latest
     permissions:

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -130,11 +130,16 @@ tasks:
       - task: internal:fmt:trunk
       - task: internal:fmt:imports
 
+  lint:go:
+    desc: Run Go linters.
+    cmds:
+      - task: internal:lint:vet
+      - task: internal:lint:golangci-lint
+
   lint:
     desc: Run all linters.
     cmds:
-      - task: internal:lint:vet
-      - task: internal:lint:go
+      - task: lint-go
       - task: internal:lint:trunk
 
   tools:setup:

--- a/Taskfile.internal.yml
+++ b/Taskfile.internal.yml
@@ -247,7 +247,7 @@ tasks:
     cmds:
       - "{{.GOLANGCILINT}} fmt"
 
-  lint:go:
+  lint:golangci-lint:
     desc: Run Go linters
     deps: [tools:install:golangci-lint]
     cmds:

--- a/controllers/generic_service_handler.go
+++ b/controllers/generic_service_handler.go
@@ -79,7 +79,7 @@ func (h *genericServiceHandler) createOrUpdate(ctx context.Context, avnGen avnge
 			Plan:                  spec.Plan,
 			ProjectVpcId:          toOptionalStringPointer(projectVPCID),
 			ServiceName:           ometa.Name,
-			ServiceType:           o.getServiceType(),
+			ServiceType:           string(o.getServiceType()),
 			TerminationProtection: spec.TerminationProtection,
 			UserConfig:            &userConfig,
 			TechEmails:            &technicalEmails,


### PR DESCRIPTION
- Adds a linting step to the lint workflow.
- Adds a new task `lint:go` that doesn't run the `trunk`: ci uses `trunk-io/trunk-action@v1` action.