### PR TITLE
feat: return error when service is powered-off

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -139,7 +139,7 @@ tasks:
   lint:
     desc: Run all linters.
     cmds:
-      - task: lint-go
+      - task: lint:go
       - task: internal:lint:trunk
 
   tools:setup:

--- a/controllers/clickhousegrant_controller.go
+++ b/controllers/clickhousegrant_controller.go
@@ -124,8 +124,8 @@ func (h *ClickhouseGrantHandler) checkPreconditions(ctx context.Context, avnGen 
 	meta.SetStatusCondition(&g.Status.Conditions,
 		getInitializedCondition("Preconditions", "Checking preconditions"))
 
-	serviceIsRunning, err := checkServiceIsOperational(ctx, avnGen, g.Spec.Project, g.Spec.ServiceName)
-	if !serviceIsRunning || err != nil {
+	isOperational, err := checkServiceIsOperational(ctx, avnGen, g.Spec.Project, g.Spec.ServiceName)
+	if !isOperational || err != nil {
 		return false, err
 	}
 

--- a/controllers/generic_service_handler.go
+++ b/controllers/generic_service_handler.go
@@ -199,7 +199,7 @@ func (h *genericServiceHandler) get(ctx context.Context, avnGen avngen.Client, o
 	}
 
 	status := o.getServiceStatus()
-	if !serviceIsRunning(s.State) {
+	if s.State != service.ServiceStateTypeRunning {
 		status.State = s.State
 		return nil, nil
 	}
@@ -250,9 +250,9 @@ func (h *genericServiceHandler) checkPreconditions(ctx context.Context, avnGen a
 	for _, s := range spec.ServiceIntegrations {
 		// Validates that read_replica is running
 		// If not, the wrapper controller will try later
-		r, err := checkServiceIsOperational(ctx, avnGen, spec.Project, s.SourceServiceName)
-		if !r || err != nil {
-			if s.IntegrationType == service.IntegrationTypeReadReplica {
+		if s.IntegrationType == service.IntegrationTypeReadReplica {
+			isOperational, err := checkServiceIsOperational(ctx, avnGen, spec.Project, s.SourceServiceName)
+			if !isOperational || err != nil {
 				return false, err
 			}
 

--- a/tests/session.go
+++ b/tests/session.go
@@ -158,7 +158,7 @@ func (s *session) GetRunning(obj client.Object, keys ...string) error {
 			}
 		}
 
-		return !controllers.IsAlreadyRunning(obj), nil
+		return !controllers.IsReadyToUse(obj), nil
 	})
 }
 


### PR DESCRIPTION
Contributes to NEX-1149.

- Improves `checkServiceIsOperational`: returns `errServicePoweredOff` when service is powered-off.
- Improves naming and documentation for annotation checks
- Fixes `read_replica` check that was presented in #952