### PR TITLE
fix: webhook port can't be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Improve `KafkaSchema` controller: optimize polling and add better error handling
 - Improve `KafkaTopic`: better handle API 5xx errors.
 - Improve `KafkaConnector`: better handle API 404 and 5xx errors.
+- Fix webhooks `containerPort` configuration not being properly applied in deployment template
 
 ## v0.29.0 - 2025-04-29
 

--- a/charts/aiven-operator/templates/deployment.yaml
+++ b/charts/aiven-operator/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
             - --leader-elect={{ .Values.leaderElect }}
             - --metrics-bind-address={{ .Values.metricsBindAddress }}
             - --health-probe-bind-address={{ .Values.healthProbeBindAddress }}
+            - --webhook-port={{ .Values.webhooks.containerPort | default 9443 }}
 
           ports:
             - name: metrics

--- a/main.go
+++ b/main.go
@@ -36,7 +36,8 @@ var (
 // operatorVersion is the current version of the operator.
 var operatorVersion = "dev"
 
-const port = 9443
+// webhookDefaultPort is the default port for the webhook server.
+const webhookDefaultPort = 9443
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -48,6 +49,8 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var development bool
+	var webhookPort int
+	flag.IntVar(&webhookPort, "webhook-port", webhookDefaultPort, "Webhook server port (default: 9443)")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -65,7 +68,7 @@ func main() {
 	ctrlOptions := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
-		Port:                   port,
+		Port:                   webhookPort,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "40db2fac.aiven.io",


### PR DESCRIPTION
Resolves NEX-1630 https://github.com/aiven/aiven-charts/issues/38.
