### PR TITLE
refactor: simplify secret credentials flow

### DIFF
--- a/controllers/secret_password_manager.go
+++ b/controllers/secret_password_manager.go
@@ -14,32 +14,12 @@ import (
 
 // PasswordSource defines an interface for resources that can provide password sources
 type PasswordSource interface {
-	GetConnInfoSecretSource() *v1alpha1.ConnInfoSecretSource
-	GetNamespace() string
 	metav1.Object
-}
-
-// PasswordModifier defines an interface for different password modification strategies
-type PasswordModifier[T PasswordSource] interface {
-	ModifyCredentials(ctx context.Context, resource T, password string) error
-}
-
-// PasswordManager handles password retrieval and modification for Aiven resources
-type PasswordManager[T PasswordSource] struct {
-	k8sClient client.Client
-	modifier  PasswordModifier[T]
-}
-
-// NewPasswordManager creates a new password manager with the given modifier strategy
-func NewPasswordManager[T PasswordSource](k8sClient client.Client, modifier PasswordModifier[T]) *PasswordManager[T] {
-	return &PasswordManager[T]{
-		k8sClient: k8sClient,
-		modifier:  modifier,
-	}
+	GetConnInfoSecretSource() *v1alpha1.ConnInfoSecretSource
 }
 
 // GetPasswordFromSecret retrieves and validates the password from connInfoSecretSource
-func (pm *PasswordManager[T]) GetPasswordFromSecret(ctx context.Context, resource T) (string, error) {
+func GetPasswordFromSecret(ctx context.Context, k8sClient client.Client, resource PasswordSource) (string, error) {
 	secretSource := resource.GetConnInfoSecretSource()
 	if secretSource == nil {
 		return "", nil
@@ -51,7 +31,7 @@ func (pm *PasswordManager[T]) GetPasswordFromSecret(ctx context.Context, resourc
 	}
 
 	sourceSecret := &corev1.Secret{}
-	err := pm.k8sClient.Get(ctx, types.NamespacedName{
+	err := k8sClient.Get(ctx, types.NamespacedName{
 		Name:      secretSource.Name,
 		Namespace: sourceNamespace,
 	}, sourceSecret)
@@ -73,9 +53,4 @@ func (pm *PasswordManager[T]) GetPasswordFromSecret(ctx context.Context, resourc
 	}
 
 	return newPassword, nil
-}
-
-// ModifyCredentials modifies the credentials using the configured strategy
-func (pm *PasswordManager[T]) ModifyCredentials(ctx context.Context, resource T, password string) error {
-	return pm.modifier.ModifyCredentials(ctx, resource, password)
 }


### PR DESCRIPTION
Contributes to NEX-1662.

- Simplifies secret credentials flow
- Sets password for both cases (with and no secret) in `get()` for `ClickhouseUser` kind
- Removes http error wrapping to let `isServerError` detect retryable errors