### PR TITLE
fix(userconfig): mixed types

### DIFF
--- a/generators/userconfigs/generator.go
+++ b/generators/userconfigs/generator.go
@@ -203,11 +203,12 @@ func (o *object) init(name string) {
 			case "null":
 				// Enums can't be nullable
 				o.Nullable = len(o.Enum) == 0
-			case "string":
-				o.Type = objectType(s)
+			case "":
+			//	Ignores invalid type
 			default:
-				// Sets if not empty, string is priority
-				if o.Type != "" {
+				// Prioritizes the object type.
+				// Usually it starts with a scalar type, and then mutates to object.
+				if o.Type != objectTypeObject {
 					o.Type = objectType(s)
 				}
 			}


### PR DESCRIPTION
Resolves NEX-1707.

This change affected the generator https://github.com/aiven/go-api-schemas/pull/334
Must prioritize object type, because the OP uses ip_filter objects.
