### PR TITLE
refactor: consolidate status conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - **BREAKING CHANGE**: Removed unprefixed keys from ServiceUser secrets to resolve environment variable collisions. Previously ServiceUser secrets contained both prefixed keys (e.g., `SERVICEUSER_HOST`, `SERVICEUSER_PASSWORD`) and unprefixed keys (e.g., `HOST`, `PASSWORD`). The unprefixed keys have been removed.
+- **Important:** Status conditions `Create`, `Update` and `CreateOrUpdate` (all cases) have been consolidated into `CreatedOrUpdated` due to limitations in reliably determining operation type
 - Add `AlloyDBOmni` field `userConfig.pg.max_sync_workers_per_subscription`, type `integer`: Maximum
   number of synchronization workers per subscription. The default is `2`
 - Change `AlloyDBOmni` field `userConfig.pg.max_logical_replication_workers`: maximum ~~`64`~~ → `256`

--- a/controllers/clickhousedatabase_controller.go
+++ b/controllers/clickhousedatabase_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/clickhouse"
@@ -64,13 +63,6 @@ func (h *ClickhouseDatabaseHandler) createOrUpdate(ctx context.Context, avnGen a
 	case err != nil:
 		return fmt.Errorf("cannot create clickhouse database on Aiven side: %w", err)
 	}
-
-	meta.SetStatusCondition(&db.Status.Conditions,
-		getInitializedCondition("Created",
-			"Successfully created or updated the instance in Aiven"))
-
-	metav1.SetMetaDataAnnotation(&db.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(db.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }

--- a/controllers/clickhousegrant_controller.go
+++ b/controllers/clickhousegrant_controller.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/go-multierror"
@@ -62,19 +61,7 @@ func (h *ClickhouseGrantHandler) createOrUpdate(ctx context.Context, avnGen avng
 	}
 
 	// Grants new privileges
-	err = grantSpecGrants(ctx, avnGen, g)
-	if err != nil {
-		return err
-	}
-
-	meta.SetStatusCondition(&g.Status.Conditions,
-		getInitializedCondition("Created",
-			"Successfully created or updated the instance in Aiven"))
-
-	metav1.SetMetaDataAnnotation(&g.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(g.GetGeneration(), formatIntBaseDecimal))
-
-	return nil
+	return grantSpecGrants(ctx, avnGen, g)
 }
 
 func (h *ClickhouseGrantHandler) delete(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {

--- a/controllers/clickhouserole_controller.go
+++ b/controllers/clickhouserole_controller.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	avngen "github.com/aiven/go-client-codegen"
@@ -58,19 +57,7 @@ func (h *clickhouseRoleHandler) createOrUpdate(ctx context.Context, avnGen avnge
 		return err
 	}
 
-	err = clickhouseRoleCreate(ctx, avnGen, role)
-	if err != nil {
-		return err
-	}
-
-	meta.SetStatusCondition(&role.Status.Conditions,
-		getInitializedCondition("Created",
-			"Successfully created or updated the instance in Aiven"))
-
-	metav1.SetMetaDataAnnotation(&role.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(role.GetGeneration(), formatIntBaseDecimal))
-
-	return nil
+	return clickhouseRoleCreate(ctx, avnGen, role)
 }
 
 func (h *clickhouseRoleHandler) delete(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {

--- a/controllers/clickhouseuser_controller.go
+++ b/controllers/clickhouseuser_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/clickhouse"
@@ -90,14 +89,6 @@ func (h *clickhouseUserHandler) createOrUpdate(ctx context.Context, avnGen avnge
 
 	// Set the UUID in the status first, so the password modifier can use it
 	user.Status.UUID = uuid
-
-	meta.SetStatusCondition(&user.Status.Conditions,
-		getInitializedCondition("Created",
-			"Successfully created or updated the instance in Aiven"))
-
-	metav1.SetMetaDataAnnotation(&user.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(user.GetGeneration(), formatIntBaseDecimal))
-
 	return nil
 }
 

--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/service"
@@ -65,13 +64,6 @@ func (h DatabaseHandler) createOrUpdate(ctx context.Context, avnGen avngen.Clien
 			return fmt.Errorf("cannot create database on Aiven side: %w", err)
 		}
 	}
-
-	meta.SetStatusCondition(&db.Status.Conditions,
-		getInitializedCondition("Created",
-			"Successfully created or updated the instance in Aiven"))
-
-	metav1.SetMetaDataAnnotation(&db.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(db.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }

--- a/controllers/generic_service_handler.go
+++ b/controllers/generic_service_handler.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/service"
@@ -66,9 +65,7 @@ func (h *genericServiceHandler) createOrUpdate(ctx context.Context, avnGen avnge
 	}
 
 	// Creates if not exists or updates existing service
-	var reason string
 	if !exists {
-		reason = "Created"
 		userConfig, err := CreateUserConfiguration(o.getUserConfig())
 		if err != nil {
 			return err
@@ -105,7 +102,6 @@ func (h *genericServiceHandler) createOrUpdate(ctx context.Context, avnGen avnge
 			return fmt.Errorf("failed to create service: %w", err)
 		}
 	} else {
-		reason = "Updated"
 		userConfig, err := UpdateUserConfiguration(o.getUserConfig())
 		if err != nil {
 			return err
@@ -152,18 +148,6 @@ func (h *genericServiceHandler) createOrUpdate(ctx context.Context, avnGen avnge
 	if err := o.createOrUpdateServiceSpecific(ctx, avnGen, oldService); err != nil {
 		return fmt.Errorf("failed to create or update service-specific: %w", err)
 	}
-
-	status := o.getServiceStatus()
-	meta.SetStatusCondition(&status.Conditions,
-		getInitializedCondition(reason, "Successfully created or updated the instance in Aiven"))
-	meta.SetStatusCondition(&status.Conditions,
-		getRunningCondition(metav1.ConditionUnknown, reason,
-			"Successfully created or updated the instance in Aiven, status remains unknown"))
-	metav1.SetMetaDataAnnotation(
-		o.getObjectMeta(),
-		processedGenerationAnnotation,
-		strconv.FormatInt(obj.GetGeneration(), formatIntBaseDecimal),
-	)
 
 	return nil
 }

--- a/controllers/kafkaacl_controller.go
+++ b/controllers/kafkaacl_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafka"
@@ -81,16 +80,6 @@ func (h KafkaACLHandler) createOrUpdate(ctx context.Context, avnGen avngen.Clien
 	if err != nil {
 		return err
 	}
-	meta.SetStatusCondition(&acl.Status.Conditions,
-		getInitializedCondition("CreatedOrUpdate",
-			"Successfully created or updated the instance in Aiven"))
-
-	meta.SetStatusCondition(&acl.Status.Conditions,
-		getRunningCondition(metav1.ConditionUnknown, "CreatedOrUpdate",
-			"Successfully created or updated the instance in Aiven, status remains unknown"))
-
-	metav1.SetMetaDataAnnotation(&acl.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(acl.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }

--- a/controllers/kafkaconnector_controller.go
+++ b/controllers/kafkaconnector_controller.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -68,10 +67,8 @@ func (h KafkaConnectorHandler) createOrUpdate(ctx context.Context, avnGen avngen
 	// and POST (ServiceKafkaConnectCreateConnector) returns NotFound error.
 	// So instead of asking Aiven API if the connector exists,
 	// we try to create it.
-	reason := "Created"
 	_, err = avnGen.ServiceKafkaConnectCreateConnector(ctx, conn.Spec.Project, conn.Spec.ServiceName, connCfg)
 	if isAlreadyExists(err) {
-		reason = "Updated"
 		_, err = avnGen.ServiceKafkaConnectEditConnector(ctx, conn.Spec.Project, conn.Spec.ServiceName, conn.Name, connCfg)
 		if err != nil {
 			return err
@@ -90,17 +87,6 @@ func (h KafkaConnectorHandler) createOrUpdate(ctx context.Context, avnGen avngen
 	case err != nil:
 		return err
 	}
-
-	meta.SetStatusCondition(&conn.Status.Conditions,
-		getInitializedCondition(reason,
-			"Successfully created or updated the instance in Aiven"))
-
-	meta.SetStatusCondition(&conn.Status.Conditions,
-		getRunningCondition(metav1.ConditionUnknown, reason,
-			"Successfully created or updated the instance in Aiven, status remains unknown"))
-
-	metav1.SetMetaDataAnnotation(&conn.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(conn.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }

--- a/controllers/kafkanativeacl_controller.go
+++ b/controllers/kafkanativeacl_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafka"
@@ -85,16 +84,6 @@ func (h KafkaNativeACLHandler) createOrUpdate(ctx context.Context, avnGen avngen
 	}
 
 	acl.Status.ID = rsp.Id
-	meta.SetStatusCondition(&acl.Status.Conditions,
-		getInitializedCondition("CreatedOrUpdate",
-			"Successfully created or updated the instance in Aiven"))
-
-	meta.SetStatusCondition(&acl.Status.Conditions,
-		getRunningCondition(metav1.ConditionUnknown, "CreatedOrUpdate",
-			"Successfully created or updated the instance in Aiven, status remains unknown"))
-
-	metav1.SetMetaDataAnnotation(&acl.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(acl.GetGeneration(), formatIntBaseDecimal))
 	return nil
 }
 

--- a/controllers/kafkaschema_controller.go
+++ b/controllers/kafkaschema_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkaschemaregistry"
@@ -90,17 +89,6 @@ func (h KafkaSchemaHandler) createOrUpdate(ctx context.Context, avnGen avngen.Cl
 			return fmt.Errorf("cannot update Kafka Schema Configuration: %w", err)
 		}
 	}
-
-	meta.SetStatusCondition(&schema.Status.Conditions,
-		getInitializedCondition("Added",
-			"Successfully created or updated the instance in Aiven"))
-
-	meta.SetStatusCondition(&schema.Status.Conditions,
-		getRunningCondition(metav1.ConditionUnknown, "Added",
-			"Successfully created or updated the instance in Aiven, status remains unknown"))
-
-	metav1.SetMetaDataAnnotation(&schema.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(schema.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }

--- a/controllers/kafkaschemaregistryacl_controller.go
+++ b/controllers/kafkaschemaregistryacl_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkaschemaregistry"
@@ -80,17 +79,6 @@ func (h KafkaSchemaRegistryACLHandler) createOrUpdate(ctx context.Context, avnGe
 			}
 		}
 	}
-
-	meta.SetStatusCondition(&acl.Status.Conditions,
-		getInitializedCondition("Created",
-			"Successfully created or updated the instance in Aiven"))
-
-	meta.SetStatusCondition(&acl.Status.Conditions,
-		getRunningCondition(metav1.ConditionUnknown, "Created",
-			"Successfully created or updated the instance in Aiven, status remains unknown"))
-
-	metav1.SetMetaDataAnnotation(&acl.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(acl.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	proj "github.com/aiven/go-client-codegen/handler/project"
@@ -92,7 +91,6 @@ func (h ProjectHandler) createOrUpdate(ctx context.Context, avnGen avngen.Client
 		return fmt.Errorf("cannot get long card id: %w", err)
 	}
 
-	var reason string
 	if !exists {
 		req := &proj.ProjectCreateIn{
 			CardId:           cardID,
@@ -120,7 +118,6 @@ func (h ProjectHandler) createOrUpdate(ctx context.Context, avnGen avngen.Client
 		project.Status.AvailableCredits = fromAnyPointer(p.AvailableCredits)
 		project.Status.Country = p.Country
 		project.Status.PaymentMethod = p.PaymentMethod
-		reason = "Created"
 	} else {
 		req := &proj.ProjectUpdateIn{
 			CardId:           cardID,
@@ -145,19 +142,7 @@ func (h ProjectHandler) createOrUpdate(ctx context.Context, avnGen avngen.Client
 		project.Status.AvailableCredits = fromAnyPointer(p.AvailableCredits)
 		project.Status.Country = p.Country
 		project.Status.PaymentMethod = p.PaymentMethod
-		reason = "Updated"
 	}
-
-	meta.SetStatusCondition(&project.Status.Conditions,
-		getInitializedCondition(reason,
-			"Successfully created or updated the instance in Aiven"))
-
-	meta.SetStatusCondition(&project.Status.Conditions,
-		getRunningCondition(metav1.ConditionUnknown, reason,
-			"Successfully created or updated the instance in Aiven, status remains unknown"))
-
-	metav1.SetMetaDataAnnotation(&project.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(project.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }

--- a/controllers/projectvpc_controller.go
+++ b/controllers/projectvpc_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/vpc"
@@ -67,18 +66,6 @@ func (h *ProjectVPCHandler) createOrUpdate(ctx context.Context, avnGen avngen.Cl
 	}
 
 	projectVPC.Status.ID = avnVpc.ProjectVpcId
-
-	meta.SetStatusCondition(&projectVPC.Status.Conditions,
-		getInitializedCondition("Created",
-			"Successfully created or updated the instance in Aiven"))
-
-	meta.SetStatusCondition(&projectVPC.Status.Conditions,
-		getRunningCondition(metav1.ConditionUnknown, "Created",
-			"Successfully created or updated the instance in Aiven, status remains unknown"))
-
-	metav1.SetMetaDataAnnotation(&projectVPC.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(projectVPC.GetGeneration(), formatIntBaseDecimal))
-
 	return nil
 }
 

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -5,7 +5,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/service"
@@ -85,13 +84,6 @@ func (h *ServiceUserHandler) createOrUpdate(ctx context.Context, avnGen avngen.C
 	if u != nil {
 		user.Status.Type = u.Type
 	}
-
-	meta.SetStatusCondition(&user.Status.Conditions,
-		getInitializedCondition("Created",
-			"Successfully created or updated the instance in Aiven"))
-
-	metav1.SetMetaDataAnnotation(&user.ObjectMeta,
-		processedGenerationAnnotation, strconv.FormatInt(user.GetGeneration(), formatIntBaseDecimal))
 
 	return nil
 }


### PR DESCRIPTION
Resolves NEX-1670.

Consolidates status conditions `Create` and `Update` into `CreateOrUpdate` due to limitations in reliably determining operation type.

1. The go client's retry mechanism may create an instance successfully but receive a 5xx error,
causing the next attempt to get a conflict error
2. Remote state may be temporarily inconsistent, so GET checks can return false positives/negatives
3. Some handlers implement their own retry logic and keep trying to create instances until success

Therefore, we can't rely on "exists" checks to determine the operation type.