### PR TITLE
feat(service_user): deleted old secrets for service users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- **BREAKING CHANGE**: Removed unprefixed keys from ServiceUser secrets to resolve environment variable collisions. Previously ServiceUser secrets contained both prefixed keys (e.g., `SERVICEUSER_HOST`, `SERVICEUSER_PASSWORD`) and unprefixed keys (e.g., `HOST`, `PASSWORD`). The unprefixed keys have been removed.
 - Add `AlloyDBOmni` field `userConfig.pg.max_sync_workers_per_subscription`, type `integer`: Maximum
   number of synchronization workers per subscription. The default is `2`
 - Change `AlloyDBOmni` field `userConfig.pg.max_logical_replication_workers`: maximum ~~`64`~~ → `256`

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -169,14 +169,6 @@ func (h *ServiceUserHandler) get(ctx context.Context, avnGen avngen.Client, obj 
 		prefix + "ACCESS_CERT": fromAnyPointer(u.AccessCert),
 		prefix + "ACCESS_KEY":  fromAnyPointer(u.AccessKey),
 		prefix + "CA_CERT":     caCert,
-		// todo: remove in future releases
-		"HOST":        component.Host,
-		"PORT":        fmt.Sprintf("%d", component.Port),
-		"USERNAME":    u.Username,
-		"PASSWORD":    u.Password,
-		"ACCESS_CERT": fromAnyPointer(u.AccessCert),
-		"ACCESS_KEY":  fromAnyPointer(u.AccessKey),
-		"CA_CERT":     caCert,
 	}
 
 	return newSecret(user, stringData, false), nil

--- a/tests/serviceuser_test.go
+++ b/tests/serviceuser_test.go
@@ -100,13 +100,6 @@ func TestServiceUserKafka(t *testing.T) {
 	// Validates Secret
 	secret, err := s.GetSecret("my-service-user-secret")
 	require.NoError(t, err)
-	assert.NotEmpty(t, secret.Data["HOST"])
-	assert.NotEmpty(t, secret.Data["PORT"])
-	assert.NotEmpty(t, secret.Data["USERNAME"])
-	assert.NotEmpty(t, secret.Data["PASSWORD"])
-	assert.NotEmpty(t, secret.Data["CA_CERT"])
-	assert.Contains(t, secret.Data, "ACCESS_CERT")
-	assert.Contains(t, secret.Data, "ACCESS_KEY")
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_HOST"])
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_PORT"])
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_USERNAME"])
@@ -222,13 +215,6 @@ func TestServiceUserPg(t *testing.T) {
 	// Validates Secret
 	secret, err := s.GetSecret("my-service-user-secret")
 	require.NoError(t, err)
-	assert.NotEmpty(t, secret.Data["HOST"])
-	assert.NotEmpty(t, secret.Data["PORT"])
-	assert.NotEmpty(t, secret.Data["USERNAME"])
-	assert.NotEmpty(t, secret.Data["PASSWORD"])
-	assert.NotEmpty(t, secret.Data["CA_CERT"])
-	assert.Contains(t, secret.Data, "ACCESS_CERT")
-	assert.Contains(t, secret.Data, "ACCESS_KEY")
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_HOST"])
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_PORT"])
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_USERNAME"])
@@ -241,7 +227,7 @@ func TestServiceUserPg(t *testing.T) {
 
 	// Default port is exposed
 	assert.NotEmpty(t, pgAvn.ServiceUriParams["port"])
-	assert.Equal(t, pgAvn.ServiceUriParams["port"], string(secret.Data["PORT"]))
+	assert.Equal(t, pgAvn.ServiceUriParams["port"], string(secret.Data["SERVICEUSER_PORT"]))
 
 	// We need to validate deletion,
 	// because we can get false positive here:
@@ -312,14 +298,14 @@ spec:
 
 		secret, err := s.GetSecret("my-service-user-secret")
 		require.NoError(t, err)
-		assert.NotEmpty(t, secret.Data["HOST"])
-		assert.NotEmpty(t, secret.Data["PORT"])
-		assert.NotEmpty(t, secret.Data["USERNAME"])
-		assert.NotEmpty(t, secret.Data["PASSWORD"])
-		assert.NotEmpty(t, secret.Data["CA_CERT"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_HOST"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_PORT"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_USERNAME"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_PASSWORD"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_CA_CERT"])
 
 		// verify the password matches predefined value from source secret
-		actualPassword := string(secret.Data["PASSWORD"])
+		actualPassword := string(secret.Data["SERVICEUSER_PASSWORD"])
 		assert.Equal(t, "MyCustomPassword123!", actualPassword, "Password should match predefined value")
 
 		assert.Equal(t, map[string]string{"test": "predefined-password"}, secret.Annotations)
@@ -350,17 +336,17 @@ spec:
 
 		secret, err := s.GetSecret("my-avnadmin-secret")
 		require.NoError(t, err)
-		assert.NotEmpty(t, secret.Data["HOST"])
-		assert.NotEmpty(t, secret.Data["PORT"])
-		assert.NotEmpty(t, secret.Data["USERNAME"])
-		assert.NotEmpty(t, secret.Data["PASSWORD"])
-		assert.NotEmpty(t, secret.Data["CA_CERT"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_HOST"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_PORT"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_USERNAME"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_PASSWORD"])
+		assert.NotEmpty(t, secret.Data["SERVICEUSER_CA_CERT"])
 
-		actualUsernameInSecret := string(secret.Data["USERNAME"])
+		actualUsernameInSecret := string(secret.Data["SERVICEUSER_USERNAME"])
 		assert.Equal(t, "avnadmin", actualUsernameInSecret, "Username should be avnadmin")
 
 		// verify the password was reset to custom value
-		actualPassword := string(secret.Data["PASSWORD"])
+		actualPassword := string(secret.Data["SERVICEUSER_PASSWORD"])
 		assert.Equal(t, "NewAvnadminPassword999!", actualPassword, "Password should match our custom avnadmin password")
 
 		assert.Equal(t, map[string]string{"test": "avnadmin-reset"}, secret.Annotations)


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-747
- deleted old secrets for service users

## Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
