### PR TITLE
test: remove session project

### DIFF
--- a/tests/alloydbomni_test.go
+++ b/tests/alloydbomni_test.go
@@ -20,7 +20,7 @@ func TestAlloyDBOmni(t *testing.T) {
 	ctx, cancel := testCtx()
 	defer cancel()
 
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -112,7 +112,7 @@ func TestAlloyDBOmniServiceAccountCredentials(t *testing.T) {
 	defer cancel()
 
 	name := randName("alloydbomni")
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/cassandra_test.go
+++ b/tests/cassandra_test.go
@@ -54,7 +54,7 @@ func TestCassandra(t *testing.T) {
 
 	name := randName("cassandra")
 	yml := getCassandraYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/clickhouse_test.go
+++ b/tests/clickhouse_test.go
@@ -66,7 +66,7 @@ func TestClickhouse(t *testing.T) {
 	require.NoError(t, err)
 
 	yml := fmt.Sprintf("%s---\n%s---\n%s---\n%s---\n%s", ymlClickhouse, ymlDatabase1, ymlDatabase2, ymlRole1, ymlRole2)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/clickhousegrant_test.go
+++ b/tests/clickhousegrant_test.go
@@ -129,7 +129,7 @@ func TestClickhouseGrant(t *testing.T) {
 	dbName := "clickhouse-db"
 
 	yml := getClickhouseGrantYaml(cfg.Project, chName, cfg.PrimaryCloudName, dbName, userName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -422,7 +422,7 @@ func TestClickhouseGrantExample(t *testing.T) {
 	extraGrantName := randName("clickhouse-extra-grant")
 	extraYml := clickhouseGrantExampleExtra(cfg.Project, chName, dbName, extraUserName, extraRoleName, extraGrantName)
 
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/clickhouseuser_test.go
+++ b/tests/clickhouseuser_test.go
@@ -39,7 +39,7 @@ func TestClickhouseUser(t *testing.T) {
 		"doc[1].spec.cloudName": cfg.PrimaryCloudName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -180,7 +180,7 @@ func TestClickhouseUserCustomCredentials(t *testing.T) {
 	ctx, cancel := testCtx()
 	defer cancel()
 	chName := randName("clickhouseuser-scenarios")
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	defer s.Destroy(t)
 

--- a/tests/connectionpool_test.go
+++ b/tests/connectionpool_test.go
@@ -55,7 +55,7 @@ func TestConnectionPool(t *testing.T) {
 		"doc[3].spec.serviceName": pgName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -159,7 +159,7 @@ func TestConnectionPoolWithReuseInboundUser(t *testing.T) {
 		poolName    = randName("connection-pool-inbound")
 		userName    = randName("inbound-user") // Service user for testing "Reuse Inbound User" functionality
 
-		s = NewSession(ctx, k8sClient, cfg.Project)
+		s = NewSession(ctx, k8sClient)
 
 		findPoolFunc = func(poolName string) *service.ConnectionPoolOut {
 			var avnPool *service.ConnectionPoolOut

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -17,7 +17,7 @@ func TestDatabase(t *testing.T) {
 	// GIVEN
 	ctx, cancel := testCtx()
 	defer cancel()
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	pgName := randName("database-pg")
 	dbName := randName("database-db")
@@ -85,7 +85,7 @@ func TestDatabase_databaseName(t *testing.T) {
 	// GIVEN
 	ctx, cancel := testCtx()
 	defer cancel()
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/flink_test.go
+++ b/tests/flink_test.go
@@ -27,7 +27,7 @@ func TestFlink(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/generic_service_handler_test.go
+++ b/tests/generic_service_handler_test.go
@@ -76,7 +76,7 @@ func TestCreateUpdateService(t *testing.T) {
 
 	pgName := randName("generic-handler")
 	ymlCreate := getCreateServiceYaml(cfg.Project, pgName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -174,7 +174,7 @@ func TestErrorCondition(t *testing.T) {
 
 	pgName := randName("generic-handler")
 	yml := getErrorConditionYaml(cfg.Project, pgName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/grafana_test.go
+++ b/tests/grafana_test.go
@@ -53,7 +53,7 @@ func TestGrafana(t *testing.T) {
 
 	name := randName("grafana")
 	yml := getGrafanaYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/kafka_test.go
+++ b/tests/kafka_test.go
@@ -55,7 +55,7 @@ func TestKafka(t *testing.T) {
 
 	name := randName("kafka")
 	yml := getKafkaYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/kafka_with_projectvpc_ref_test.go
+++ b/tests/kafka_with_projectvpc_ref_test.go
@@ -57,7 +57,7 @@ func TestKafkaWithProjectVPCRef(t *testing.T) {
 	vpcName := randName("kafka-vpc")
 	kafkaName := randName("kafka-vpc")
 	yml := getKafkaWithProjectVPCRefYaml(cfg.Project, vpcName, kafkaName, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/kafkaacl_test.go
+++ b/tests/kafkaacl_test.go
@@ -78,7 +78,7 @@ func TestKafkaACL(t *testing.T) {
 	topicName := randName("kafka-acl")
 	aclName := randName("kafka-acl")
 	yml := getKafkaACLYaml(cfg.Project, kafkaName, topicName, aclName, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/kafkaconnect_test.go
+++ b/tests/kafkaconnect_test.go
@@ -26,7 +26,7 @@ func TestKafkaConnect(t *testing.T) {
 		"spec.cloudName": cfg.PrimaryCloudName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/kafkaconnector_test.go
+++ b/tests/kafkaconnector_test.go
@@ -45,7 +45,7 @@ func TestKafkaConnector(t *testing.T) {
 		"doc[3].spec.serviceName": kafkaName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/kafkanativeacl_test.go
+++ b/tests/kafkanativeacl_test.go
@@ -28,7 +28,7 @@ func TestKafkaNativeACL(t *testing.T) {
 		"doc[1].spec.serviceName": kafkaName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/kafkaschema_test.go
+++ b/tests/kafkaschema_test.go
@@ -77,7 +77,7 @@ func TestKafkaSchema(t *testing.T) {
 	schemaName := randName("kafka-schema")
 	subjectName := randName("kafka-schema")
 	yml := getKafkaSchemaYaml(cfg.Project, kafkaName, schemaName, subjectName, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/kafkatopic_test.go
+++ b/tests/kafkatopic_test.go
@@ -82,7 +82,7 @@ func TestKafkaTopic(t *testing.T) {
 
 	ksName := randName("kafka-topic")
 	yml := getKafkaTopicNameYaml(cfg.Project, ksName, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/kafkschemaregistryacl_test.go
+++ b/tests/kafkschemaregistryacl_test.go
@@ -76,7 +76,7 @@ func TestKafkaSchemaRegistryACL(t *testing.T) {
 	topicName := randName("kafka-topic")
 	aclName := randName("kafka-schema-registry-acl")
 	yml := getKafkaSchemaRegistryACLYaml(cfg.Project, cfg.PrimaryCloudName, kafkaName, topicName, aclName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -53,7 +53,7 @@ func TestMySQL(t *testing.T) {
 
 	name := randName("mysql")
 	yml := getMySQLYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/opensearch_test.go
+++ b/tests/opensearch_test.go
@@ -58,7 +58,7 @@ func TestOpenSearch(t *testing.T) {
 
 	name := randName("opensearch")
 	yml := getOpenSearchYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/postgresql_test.go
+++ b/tests/postgresql_test.go
@@ -73,7 +73,7 @@ func TestPgReadReplica(t *testing.T) {
 	masterName := randName("pg-master")
 	replicaName := randName("pg-replica")
 	yml := getPgReadReplicaYaml(cfg.Project, masterName, replicaName, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -191,7 +191,7 @@ func TestPgCustomPrefix(t *testing.T) {
 
 	pgName := randName("secret-prefix")
 	yml := getPgCustomPrefixYaml(cfg.Project, pgName, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -299,7 +299,7 @@ func TestPgUpgradeVersion(t *testing.T) {
 
 	pgName := randName("upgrade-test")
 	yaml := getPgUpgradeVersionYaml(cfg.Project, pgName, cfg.PrimaryCloudName, startingVersion)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	defer s.Destroy(t)
 

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -23,7 +23,7 @@ func TestProject(t *testing.T) {
 		"spec.accountId": cfg.AccountID,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/projectvpc_test.go
+++ b/tests/projectvpc_test.go
@@ -75,7 +75,7 @@ func TestProjectVPCID(t *testing.T) {
 	vpcName1 := randName("project-vpc-id")
 	vpcName2 := randName("project-vpc-id")
 	vpcYaml := getProjectVPCsYaml(cfg.Project, vpcName1, cfg.SecondaryCloudName, vpcName2, cfg.TertiaryCloudName)
-	vpcSession := NewSession(ctx, k8sClient, cfg.Project)
+	vpcSession := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer vpcSession.Destroy(t)
@@ -112,7 +112,7 @@ func TestProjectVPCID(t *testing.T) {
 	// Creates Kafka with given vpcID
 	kafkaName := randName("project-vpc-id")
 	kafkaYaml := getKafkaForProjectVPCYaml(cfg.Project, vpc1.Status.ID, kafkaName, cfg.SecondaryCloudName)
-	kafkaSession := NewSession(ctx, k8sClient, cfg.Project)
+	kafkaSession := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer kafkaSession.Destroy(t)

--- a/tests/redis_test.go
+++ b/tests/redis_test.go
@@ -52,7 +52,7 @@ func TestRedis(t *testing.T) {
 
 	name := randName("redis")
 	yml := getRedisYaml(cfg.Project, name, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/service_opts_test.go
+++ b/tests/service_opts_test.go
@@ -46,7 +46,7 @@ func TestServiceTechnicalEmails(t *testing.T) {
 
 	name := randName("grafana")
 	yml := getTechnicalEmailsYaml(cfg.Project, name, cfg.PrimaryCloudName, true)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -118,7 +118,7 @@ func runTest(t *testing.T, scenario TestScenario) {
 	ctx, cancel := testCtx()
 	defer cancel()
 
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/serviceintegration_test.go
+++ b/tests/serviceintegration_test.go
@@ -39,7 +39,7 @@ func TestServiceIntegrationClickhousePostgreSQL(t *testing.T) {
 		"doc[2].spec.cloudName": cfg.PrimaryCloudName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -118,7 +118,7 @@ func TestServiceIntegrationKafkaLogs(t *testing.T) {
 		"doc[2].spec.serviceName": ksName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -194,7 +194,7 @@ func TestServiceIntegrationKafkaConnect(t *testing.T) {
 		"doc[2].spec.cloudName": cfg.PrimaryCloudName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -274,7 +274,7 @@ func TestServiceIntegrationAutoscaler(t *testing.T) {
 		"doc[1].spec.cloudName": cfg.PrimaryCloudName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -336,7 +336,7 @@ func TestServiceIntegrationDatadog(t *testing.T) {
 		"doc[1].spec.cloudName": cfg.PrimaryCloudName,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -415,7 +415,7 @@ func TestWebhookMultipleUserConfigsDenied(t *testing.T) {
 	yml := getWebhookMultipleUserConfigsDeniedYaml(cfg.Project, siName)
 
 	// WHEN
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// THEN
 	err := s.Apply(yml)

--- a/tests/serviceintegrationendpoint_test.go
+++ b/tests/serviceintegrationendpoint_test.go
@@ -25,7 +25,7 @@ func TestServiceIntegrationEndpointExternalPostgres(t *testing.T) {
 		"spec.project":  cfg.Project,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -68,7 +68,7 @@ func TestServiceIntegrationEndpoint(t *testing.T) {
 		"spec.project":  cfg.Project,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -111,7 +111,7 @@ func TestServiceIntegrationEndpointAutoscaler(t *testing.T) {
 		"spec.project":  cfg.Project,
 	})
 	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)

--- a/tests/serviceuser_test.go
+++ b/tests/serviceuser_test.go
@@ -64,7 +64,7 @@ func TestServiceUserKafka(t *testing.T) {
 	kafkaName := randName("service-user")
 	userName := randName("service-user")
 	yml := getServiceUserKafkaYaml(cfg.Project, kafkaName, userName, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -179,7 +179,7 @@ func TestServiceUserPg(t *testing.T) {
 	pgName := randName("connection-pool")
 	userName := randName("connection-pool")
 	yml := getServiceUserPgYaml(cfg.Project, pgName, userName, cfg.PrimaryCloudName)
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)
@@ -248,7 +248,7 @@ func TestServiceUserCustomCredentials(t *testing.T) {
 	ctx, cancel := testCtx()
 	defer cancel()
 	pgName := randName("serviceuser-scenarios")
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	defer s.Destroy(t)
 

--- a/tests/session.go
+++ b/tests/session.go
@@ -51,18 +51,16 @@ type Session interface {
 var _ Session = &session{}
 
 type session struct {
-	k8s     client.Client
-	ctx     context.Context
-	objs    map[string]client.Object
-	project string
+	k8s  client.Client
+	ctx  context.Context
+	objs map[string]client.Object
 }
 
-func NewSession(ctx context.Context, k8s client.Client, project string) Session {
+func NewSession(ctx context.Context, k8s client.Client) Session {
 	s := &session{
-		k8s:     k8s,
-		ctx:     ctx,
-		objs:    make(map[string]client.Object),
-		project: project,
+		k8s:  k8s,
+		ctx:  ctx,
+		objs: make(map[string]client.Object),
 	}
 	return s
 }

--- a/tests/valkey_test.go
+++ b/tests/valkey_test.go
@@ -28,7 +28,7 @@ func TestValkey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	s := NewSession(ctx, k8sClient, cfg.Project)
+	s := NewSession(ctx, k8sClient)
 
 	// Cleans test afterward
 	defer s.Destroy(t)


### PR DESCRIPTION
Contributes to NEX-1743.

The `project` argument is never used. 