### PR TITLE
fix(secret_watcher): replaced the update with patch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
             ${{ secrets.AIVEN_PROJECT_NAME_PREFIX }}${{ needs.setup_aiven_project_suffix.outputs.project_name_suffix }}
 
   notify-slack-success:
-    if: needs.test.result == 'success'
+    if: always() && needs.test.result == 'success'
     needs: [test, sweep]
     uses: ./.github/workflows/slack-notify.yml
     with:
@@ -89,7 +89,7 @@ jobs:
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
 
   notify-slack-failure:
-    if: needs.test.result == 'failure'
+    if: always() && (needs.test.result == 'failure' || needs.test.result == 'cancelled')
     needs: [test, sweep]
     uses: ./.github/workflows/slack-notify.yml
     with:

--- a/charts/aiven-operator/templates/cluster_role.yaml
+++ b/charts/aiven-operator/templates/cluster_role.yaml
@@ -789,6 +789,7 @@ rules:
       - delete
       - get
       - list
+      - patch
       - update
       - watch
   - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -786,6 +786,7 @@ rules:
       - delete
       - get
       - list
+      - patch
       - update
       - watch
   - apiGroups:

--- a/controllers/secret_watch_controller.go
+++ b/controllers/secret_watch_controller.go
@@ -4,6 +4,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
@@ -38,6 +39,8 @@ const (
 )
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=aiven.io,resources=serviceusers,verbs=patch
+// +kubebuilder:rbac:groups=aiven.io,resources=clickhouseusers,verbs=patch
 
 func (c *SecretWatchController) SetupWithManager(mgr ctrl.Manager) error {
 	resourcesWithSecretSource := c.getResourcesWithSecretSource()
@@ -207,28 +210,25 @@ func (c *SecretWatchController) findResourcesUsingSecret(ctx context.Context, se
 	return allResources, nil
 }
 
-// triggerReconciliation triggers reconciliation by updating the resource's annotation
+// triggerReconciliation triggers reconciliation by patching the resource's annotations
 func (c *SecretWatchController) triggerReconciliation(ctx context.Context, resource SecretSourceResource) error {
 	resourceName := types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}
 
-	latest := resource.DeepCopyObject().(client.Object)
-	if err := c.Get(ctx, resourceName, latest); err != nil {
-		return fmt.Errorf("failed to get latest version of resource: %w", err)
+	patchData := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				secretSourceUpdatedAnnotation: fmt.Sprintf("%d", time.Now().Unix()),
+				processedGenerationAnnotation: nil, // null remove the annotation
+			},
+		},
 	}
 
-	annotations := latest.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
+	patchBytes, err := json.Marshal(patchData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch data: %w", err)
 	}
 
-	annotations[secretSourceUpdatedAnnotation] = fmt.Sprintf("%d", time.Now().Unix())
-
-	// clear the processed generation annotation to force the basic controller to reconcile
-	delete(annotations, processedGenerationAnnotation)
-
-	latest.SetAnnotations(annotations)
-
-	if err := c.Update(ctx, latest); err != nil {
+	if err = c.Patch(ctx, resource, client.RawPatch(types.MergePatchType, patchBytes)); err != nil {
 		if errors.IsConflict(err) {
 			c.Log.Info("resource modified by another controller, skipping annotation update",
 				"resource", resourceName,
@@ -236,12 +236,8 @@ func (c *SecretWatchController) triggerReconciliation(ctx context.Context, resou
 			return nil // this is expected - another controller is processing the resource
 		}
 
-		return fmt.Errorf("failed to update resource annotation: %w", err)
+		return fmt.Errorf("failed to patch resource annotations: %w", err)
 	}
-
-	c.Log.Info("triggered reconciliation for resource",
-		"resource", resourceName,
-		"kind", latest.GetObjectKind().GroupVersionKind().Kind)
 
 	return nil
 }

--- a/tests/connectionpool_test.go
+++ b/tests/connectionpool_test.go
@@ -189,6 +189,10 @@ func TestConnectionPoolWithReuseInboundUser(t *testing.T) {
 
 	// Step 1: Create PostgreSQL service directly
 	pgObj := &v1alpha1.PostgreSQL{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "aiven.io/v1alpha1",
+			Kind:       "PostgreSQL",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pgName,
 			Namespace: defaultNamespace,
@@ -215,6 +219,10 @@ func TestConnectionPoolWithReuseInboundUser(t *testing.T) {
 	}
 
 	dbObj := &v1alpha1.Database{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "aiven.io/v1alpha1",
+			Kind:       "Database",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dbName,
 			Namespace: defaultNamespace,
@@ -240,6 +248,10 @@ func TestConnectionPoolWithReuseInboundUser(t *testing.T) {
 	}
 
 	poolObj := &v1alpha1.ConnectionPool{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "aiven.io/v1alpha1",
+			Kind:       "ConnectionPool",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      poolName,
 			Namespace: defaultNamespace,
@@ -270,6 +282,10 @@ func TestConnectionPoolWithReuseInboundUser(t *testing.T) {
 
 	// Create service user for testing "Reuse Inbound User" functionality
 	userObj := &v1alpha1.ServiceUser{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "aiven.io/v1alpha1",
+			Kind:       "ServiceUser",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      userName,
 			Namespace: defaultNamespace,

--- a/tests/serviceuser_test.go
+++ b/tests/serviceuser_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func getServiceUserKafkaYaml(project, kafkaName, userName, cloudName string) string {
+	// secret name based on userName to avoid conflicts
+	secretName := userName + "-secret"
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: Kafka
@@ -44,7 +46,7 @@ spec:
     key: token
 
   connInfoSecretTarget:
-    name: my-service-user-secret
+    name: %[5]s
     annotations:
       foo: bar
     labels:
@@ -52,7 +54,7 @@ spec:
 
   project: %[1]s
   serviceName: %[2]s
-`, project, kafkaName, userName, cloudName)
+`, project, kafkaName, userName, cloudName, secretName)
 }
 
 // TestServiceUserKafka kafka with sasl enabled changes its port to expose
@@ -100,7 +102,7 @@ func TestServiceUserKafka(t *testing.T) {
 	assert.Equal(t, kafkaName, user.Spec.ServiceName)
 
 	// Validates Secret
-	secret, err := s.GetSecret("my-service-user-secret")
+	secret, err := s.GetSecret(userName + "-secret")
 	require.NoError(t, err)
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_HOST"])
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_PORT"])
@@ -133,6 +135,8 @@ func TestServiceUserKafka(t *testing.T) {
 }
 
 func getServiceUserPgYaml(project, pgName, userName, cloudName string) string {
+	// secret name based on userName to avoid conflicts
+	secretName := userName + "-secret"
 	return fmt.Sprintf(`
 apiVersion: aiven.io/v1alpha1
 kind: PostgreSQL
@@ -159,7 +163,7 @@ spec:
     key: token
 
   connInfoSecretTarget:
-    name: my-service-user-secret
+    name: %[5]s
     annotations:
       foo: bar
     labels:
@@ -167,7 +171,7 @@ spec:
 
   project: %[1]s
   serviceName: %[2]s
-`, project, pgName, userName, cloudName)
+`, project, pgName, userName, cloudName, secretName)
 }
 
 // TestServiceUserPg same as TestServiceUserKafka but runs with pg and expects the default port to be exposed
@@ -215,7 +219,7 @@ func TestServiceUserPg(t *testing.T) {
 	assert.Equal(t, pgName, user.Spec.ServiceName)
 
 	// Validates Secret
-	secret, err := s.GetSecret("my-service-user-secret")
+	secret, err := s.GetSecret(userName + "-secret")
 	require.NoError(t, err)
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_HOST"])
 	assert.NotEmpty(t, secret.Data["SERVICEUSER_PORT"])
@@ -298,7 +302,7 @@ spec:
 		assert.Equal(t, userName, userAvn.Username)
 		assert.Equal(t, pgName, user.Spec.ServiceName)
 
-		secret, err := s.GetSecret("my-service-user-secret")
+		secret, err := s.GetSecret(userName + "-secret")
 		require.NoError(t, err)
 		assert.NotEmpty(t, secret.Data["SERVICEUSER_HOST"])
 		assert.NotEmpty(t, secret.Data["SERVICEUSER_PORT"])
@@ -384,6 +388,8 @@ spec:
 }
 
 func getServiceUserWithSourceSecretYaml(project, pgName, userName, cloudName string) string {
+	// secret name based on userName to avoid conflicts
+	secretName := userName + "-secret"
 	return fmt.Sprintf(`
 apiVersion: v1
 kind: Secret
@@ -418,7 +424,7 @@ spec:
     key: token
 
   connInfoSecretTarget:
-    name: my-service-user-secret
+    name: %[5]s
     annotations:
       test: predefined-password
     labels:
@@ -430,7 +436,7 @@ spec:
 
   project: %[1]s
   serviceName: %[2]s
-`, project, pgName, userName, cloudName)
+`, project, pgName, userName, cloudName, secretName)
 }
 
 func getServiceUserAvnadminResetYaml(project, pgName, cloudName string) string {
@@ -484,6 +490,8 @@ spec:
 }
 
 func getServiceUserWithEmptyPasswordYaml(project, pgName, userName, cloudName string) string {
+	// secret name based on userName to avoid conflicts
+	secretName := userName + "-secret"
 	return fmt.Sprintf(`
 apiVersion: v1
 kind: Secret
@@ -530,5 +538,5 @@ spec:
 
   project: %[1]s
   serviceName: %[2]s
-`, project, pgName, userName, cloudName)
+`, project, pgName, userName, cloudName, secretName)
 }

--- a/tests/suite_shared_resources.go
+++ b/tests/suite_shared_resources.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
@@ -35,7 +36,12 @@ func NewSharedResources(ctx context.Context, k8sClient client.Client) SharedReso
 }
 
 func (s *sharedResourcesImpl) AcquirePostgreSQL(ctx context.Context) (*v1alpha1.PostgreSQL, func(), error) {
-	obj := new(v1alpha1.PostgreSQL)
+	obj := &v1alpha1.PostgreSQL{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "aiven.io/v1alpha1",
+			Kind:       "PostgreSQL",
+		},
+	}
 	obj.Spec.Plan = "startup-4"
 	obj.Spec.Project = cfg.Project
 	obj.Spec.CloudName = cfg.PrimaryCloudName
@@ -43,7 +49,12 @@ func (s *sharedResourcesImpl) AcquirePostgreSQL(ctx context.Context) (*v1alpha1.
 }
 
 func (s *sharedResourcesImpl) AcquireClickhouse(ctx context.Context) (*v1alpha1.Clickhouse, func(), error) {
-	obj := new(v1alpha1.Clickhouse)
+	obj := &v1alpha1.Clickhouse{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "aiven.io/v1alpha1",
+			Kind:       "Clickhouse",
+		},
+	}
 	obj.Spec.Plan = "startup-16"
 	obj.Spec.Project = cfg.Project
 	obj.Spec.CloudName = cfg.PrimaryCloudName


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1754

**Problem:**
- race conditions occurred when secret watcher and test session simultaneously updated the same `ServiceUser` resource, causing "the object has been modified" conflicts during testing

**Solution:**
  - Secret watcher: Replaced Update() with merge `Patch` for annotation updates to reduce conflicts
  - Test session: Switched from Create/Update to server-side apply (client.Apply) to match closer to `kubectl` [apply behavior](https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/apply/apply.go#L557)

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
