### PR TITLE
fix(tests): resolve parallel test resource conflicts in tests

### DIFF
--- a/docs/docs/resources/examples/clickhouseuser.yaml
+++ b/docs/docs/resources/examples/clickhouseuser.yaml
@@ -17,18 +17,3 @@ spec:
   project: my-aiven-project
   serviceName: my-clickhouse
   username: example-username
-
----
-
-apiVersion: aiven.io/v1alpha1
-kind: Clickhouse
-metadata:
-  name: my-clickhouse
-spec:
-  authSecretRef:
-    name: aiven-token
-    key: token
-
-  project: my-aiven-project
-  cloudName: google-europe-west1
-  plan: startup-16

--- a/tests/kafkaacl_test.go
+++ b/tests/kafkaacl_test.go
@@ -76,8 +76,8 @@ func TestKafkaACL(t *testing.T) {
 	ctx, cancel := testCtx()
 	defer cancel()
 
-	kafkaName := "test-0hpnor2-kafka-acl" // randName("kafka-acl")
-	topicName := randName("kafka-acl")
+	kafkaName := randName("kafka-service")
+	topicName := randName("kafka-topic")
 	aclName := randName("kafka-acl")
 	yml := getKafkaACLYaml(cfg.Project, kafkaName, topicName, aclName, cfg.PrimaryCloudName)
 	s := NewSession(ctx, k8sClient)

--- a/tests/kafkaconnector_test.go
+++ b/tests/kafkaconnector_test.go
@@ -21,9 +21,9 @@ func TestKafkaConnector(t *testing.T) {
 	ctx, cancel := testCtx()
 	defer cancel()
 
-	kafkaName := randName("kafka-connector")
-	osName := randName("kafka-connector")
-	topicName := randName("kafka-connector")
+	kafkaName := randName("kafka-service")
+	osName := randName("opensearch-service")
+	topicName := randName("kafka-topic")
 	connectorName := randName("kafka-connector")
 	yml, err := loadExampleYaml("kafkaconnector.yaml", map[string]string{
 		// Kafka
@@ -42,9 +42,10 @@ func TestKafkaConnector(t *testing.T) {
 		"doc[2].spec.cloudName": cfg.PrimaryCloudName,
 
 		// Kafka Connector
-		"doc[3].metadata.name":    connectorName,
-		"doc[3].spec.project":     cfg.Project,
-		"doc[3].spec.serviceName": kafkaName,
+		"doc[3].metadata.name":          connectorName,
+		"doc[3].spec.project":           cfg.Project,
+		"doc[3].spec.serviceName":       kafkaName,
+		"doc[3].spec.userConfig.topics": topicName,
 	})
 	require.NoError(t, err)
 	s := NewSession(ctx, k8sClient)

--- a/tests/kafkschemaregistryacl_test.go
+++ b/tests/kafkschemaregistryacl_test.go
@@ -75,7 +75,7 @@ func TestKafkaSchemaRegistryACL(t *testing.T) {
 	defer cancel()
 
 	kafkaName := randName("kafka-service")
-	topicName := randName("kafka-topic")
+	topicName := randName("schema-registry-topic")
 	aclName := randName("kafka-schema-registry-acl")
 	yml := getKafkaSchemaRegistryACLYaml(cfg.Project, cfg.PrimaryCloudName, kafkaName, topicName, aclName)
 	s := NewSession(ctx, k8sClient)


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1782

**Problem**:
  - `TestClickhouseGrant` and `TestClickhouseGrantExample` both used hardcoded resource name "`writer`" for `ClickhouseRole`
  - When running in parallel (t.Parallel()), both tests created resources with identical names in the same Kubernetes cluster
  - This caused race conditions where one test would overwrite another's resources
 
Additionaly:
  - In secret watcher patch implementation using more idiomatic `client.MergeFrom()` 
  - Fixed conflicts with shared resources in tests

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
