### PR TITLE
fix(serviceuser): retry empty password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
-- Added secret watcher controller to automatically update resources when their `connInfoSecretSource` secrets change
 - **BREAKING CHANGE**: Removed unprefixed keys from ServiceUser secrets to resolve environment variable collisions. Previously ServiceUser secrets contained both prefixed keys (e.g., `SERVICEUSER_HOST`, `SERVICEUSER_PASSWORD`) and unprefixed keys (e.g., `HOST`, `PASSWORD`). The unprefixed keys have been removed.
 - **Important:** Status conditions `Create`, `Update` and `CreateOrUpdate` (all cases) have been consolidated into `CreatedOrUpdated` due to limitations in reliably determining operation type
+- Added secret watcher controller to automatically update resources when their `connInfoSecretSource` secrets change
+- Fix `ServiceUser`: retry API calls when password is not received in response
 - Add `AlloyDBOmni` field `userConfig.pg.max_sync_workers_per_subscription`, type `integer`: Maximum
   number of synchronization workers per subscription. The default is `2`
 - Change `AlloyDBOmni` field `userConfig.pg.max_logical_replication_workers`: maximum ~~`64`~~ → `256`


### PR DESCRIPTION
Resolves NEX-1795.

`ServiceUser` controller retries `ServiceUserGet` call for 1m if gets an empty password.

