### PR TITLE
chore(alloydb): deprecated alloydb test

### DIFF
--- a/tests/alloydbomni_test.go
+++ b/tests/alloydbomni_test.go
@@ -109,6 +109,8 @@ func TestAlloyDBOmni(t *testing.T) {
 }
 
 func TestAlloyDBOmniServiceAccountCredentials(t *testing.T) {
+	t.Skip("AlloyDBOmni is deprecated")
+
 	defer recoverPanic(t)
 
 	// GIVEN


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1816
- skip alloyDB test as the service is deprecated

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
