### PR TITLE
chore: improved orphan deletion description

### DIFF
--- a/docs/docs/guides/deletion-policy.md
+++ b/docs/docs/guides/deletion-policy.md
@@ -1,0 +1,35 @@
+# Deletion Policy
+
+The Aiven Operator provides a deletion policy annotation that prevents deletion of Aiven resources when Kubernetes resources are removed. This feature works with all Aiven operator resources.
+
+## Overview
+
+By default, when you delete an Aiven operator resource (like `PostgreSQL`, `KafkaTopic`, `ServiceUser`, etc.), the operator deletes both the Kubernetes resource and the corresponding Aiven service. The `controllers.aiven.io/deletion-policy: Orphan` annotation allows you to override this behavior and preserve the Aiven resource while removing only the Kubernetes resource.
+
+## Using the Deletion Policy
+
+### Step 1: Add the Annotation
+
+Add the deletion policy annotation to the resource you want to protect:
+
+```yaml
+apiVersion: aiven.io/v1alpha1
+kind: PostgreSQL  # or any other Aiven resource
+metadata:
+  name: my-database
+  namespace: my-namespace
+  annotations:
+    controllers.aiven.io/deletion-policy: Orphan
+spec:
+  # ... existing configuration
+```
+
+### Step 2: Delete the Kubernetes Resource
+
+Now you can safely delete the Kubernetes resource:
+
+```bash
+kubectl delete postgresql my-database -n my-namespace
+```
+
+The Kubernetes resource is deleted, but the Aiven service remains intact and continues running.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
           - troubleshooting.md
           - installation/uninstalling.md
           - guides/token-management.md
+          - guides/deletion-policy.md
       - Resources: &crds
           - resources/alloydbomni.md
           - resources/cassandra.md


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1877 & #1022 

  - added log when `Orphan` policy is detected and will be applied
  - only emit deletion events when actually deleting Aiven resources
  - added guide for `Orphan` deletion policy

Log entries example for `Orphan` deletion:

> 2025-09-24T11:05:26Z	INFO	kafkatopic-resource	validate delete	{"name": "test-deletion-policy"}
2025-09-24T11:05:26Z	INFO	controllers.KafkaTopic	'Orphan' deletion policy detected - Aiven resource will be preserved on Kubernetes resource deletion	{"kind": "kafkatopic", "name": "default/test-deletion-policy", "annotations": {"controllers.aiven.io/generation-was-processed":"1","controllers.aiven.io/instance-is-running":"true"}}
2025-09-24T11:05:26Z	INFO	controllers.KafkaTopic	Kubernetes resource finalized with orphan policy - Aiven resource preserved	{"kind": "kafkatopic", "name": "default/test-deletion-policy", "annotations": {"controllers.aiven.io/generation-was-processed":"1","controllers.aiven.io/instance-is-running":"true"}}
2025-09-24T11:05:26Z	INFO	kafkatopic-resource	default	{"name": "test-deletion-policy"}
2025-09-24T11:05:26Z	INFO	kafkatopic-resource	validate update	{"name": "test-deletion-policy"}
2025-09-24T11:05:26Z	INFO	controllers.KafkaTopic	finalizer was removed, resource is deleted	{"kind": "kafkatopic", "name": "default/test-deletion-policy", "annotations": {"controllers.aiven.io/generation-was-processed":"1","controllers.aiven.io/instance-is-running":"true"}}

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
