### PR TITLE
docs: add instructions for app users to authentication page

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -15,15 +15,20 @@ An Aiven user account. [Sign up for free](https://console.aiven.io/signup?utm_so
 
 ## Store a token in a Secret
 
-1\. [Create a personal token](https://aiven.io/docs/platform/howto/create_authentication_token) in the Aiven Console.
+1\. Create an [application user](https://aiven.io/docs/platform/concepts/application-users) in the Aiven Console.
 
-2\. To create a Kubernetes Secret, run: 
+2\. Create an [application token](https://aiven.io/docs/platform/howto/manage-application-users#create-a-token-for-an-application-user) for the application user.
+
+!!! note
+    You can also use a [personal token](https://aiven.io/docs/platform/howto/create_authentication_token).
+
+3\. To create a Kubernetes Secret with the token, run:
 
 ```shell
 kubectl create secret generic aiven-token --from-literal=token="TOKEN"
 ```
 
-Where `TOKEN` is your personal token. This creates a Secret named `aiven-token`.
+Where `TOKEN` is the token. This creates a Secret named `aiven-token`.
 
 When managing your Aiven resources, you use the Secret in the `authSecretRef` field. The following is an example
 for a PostgreSQL service with the token:


### PR DESCRIPTION
## About this change—what it does

Adds instructions for using an application user to the authentication page since this is the recommended method.