### PR TITLE
fix(postgres): added retry logic for errors during upgrade task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix `PostgreSQL`: added retry logic for errors during upgrade task
+
 ## v0.33.1 - 2025-10-08
 
 - Fix `PostgreSQL`: resolved panic during upgrade check task fails

--- a/tests/postgresql_test.go
+++ b/tests/postgresql_test.go
@@ -329,7 +329,8 @@ func TestPgUpgradeVersion(t *testing.T) {
 			return false, err
 		}
 
-		return pgAvnUpd.UserConfig["pg_version"] != startingVersion, nil
+		// keep retrying while still on the old version
+		return pgAvnUpd.UserConfig["pg_version"] == startingVersion, nil
 	}))
 
 	pgUpd := new(v1alpha1.PostgreSQL)


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Resolves: NEX-1941.

- Edited `PostgreSQL` upgrade check task handling: Replaced custom `waitForTaskToComplete` function with `retry.Do`. Added retry logic for errors: (5xx), 404, and in-progress states
- Corrected `TestPgUpgradeVersion` retry condition from `!= startingVersion` (stop when changed) to `== startingVersion` (keep retrying while unchanged), fixing test hanging

I believe it may also impact corner case situation like [this](https://github.com/aiven/aiven-operator/issues/1033) issue.

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
