### PR TITLE
feat(reconciler): confirm external deletion before removing finalizer

### DIFF
--- a/controllers/clickhouseuser_controller.go
+++ b/controllers/clickhouseuser_controller.go
@@ -41,6 +41,10 @@ func newClickhouseUserReconciler(c Controller) reconcilerType {
 }
 
 func (r *ClickhouseUserController) Observe(ctx context.Context, user *v1alpha1.ClickhouseUser) (Observation, error) {
+	if isMarkedForDeletion(user) {
+		return r.observeDeletion(ctx, user)
+	}
+
 	svc, err := getServiceIfOperational(ctx, r.avnGen, user.Spec.Project, user.Spec.ServiceName)
 	if err != nil {
 		return Observation{}, err
@@ -169,6 +173,26 @@ func (r *ClickhouseUserController) Delete(ctx context.Context, user *v1alpha1.Cl
 	}
 
 	return nil
+}
+
+func (r *ClickhouseUserController) observeDeletion(ctx context.Context, user *v1alpha1.ClickhouseUser) (Observation, error) {
+	if user.Status.UUID == "" || isBuiltInUser(user.GetUsername()) {
+		return Observation{ResourceExists: false}, nil
+	}
+
+	list, err := r.avnGen.ServiceClickHouseUserList(ctx, user.Spec.Project, user.Spec.ServiceName)
+	switch {
+	case isNotFound(err):
+		return Observation{ResourceExists: false}, nil
+	case err != nil:
+		return Observation{}, fmt.Errorf("listing Clickhouse users: %w", err)
+	}
+
+	resourceExists := slices.ContainsFunc(list, func(u clickhouse.UserOut) bool {
+		return u.Uuid == user.Status.UUID
+	})
+
+	return Observation{ResourceExists: resourceExists}, nil
 }
 
 func (r *ClickhouseUserController) buildConnectionDetails(ctx context.Context, user *v1alpha1.ClickhouseUser, password string) (SecretDetails, error) {

--- a/controllers/clickhouseuser_controller_test.go
+++ b/controllers/clickhouseuser_controller_test.go
@@ -177,6 +177,44 @@ func TestClickhouseUserController_Observe(t *testing.T) {
 		require.Equal(t, Observation{}, obs)
 	})
 
+	t.Run("Checks existence without service preconditions during deletion", func(t *testing.T) {
+		user := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
+		user.Status.UUID = "uuid-1"
+		now := metav1.Now()
+		user.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceClickHouseUserList(mock.Anything, user.Spec.Project, user.Spec.ServiceName).
+			Return([]clickhouse.UserOut{{Name: user.GetUsername(), Uuid: user.Status.UUID}}, nil).
+			Once()
+
+		ctrl := &ClickhouseUserController{
+			avnGen: avn,
+		}
+
+		obs, err := ctrl.Observe(t.Context(), user)
+
+		require.NoError(t, err)
+		require.True(t, obs.ResourceExists)
+		require.False(t, obs.ResourceUpToDate)
+	})
+
+	t.Run("Treats built-in user as absent during deletion", func(t *testing.T) {
+		user := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
+		user.Status.UUID = "uuid-builtin"
+		user.Spec.Username = defaultBuiltInUser
+		now := metav1.Now()
+		user.DeletionTimestamp = &now
+
+		ctrl := &ClickhouseUserController{}
+
+		obs, err := ctrl.Observe(t.Context(), user)
+
+		require.NoError(t, err)
+		require.Equal(t, Observation{ResourceExists: false}, obs)
+	})
+
 	t.Run("Returns error when getting service details fails in Observe", func(t *testing.T) {
 		user := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/liip/sheriff"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -157,6 +158,13 @@ func getErrorCondition(reason errCondition, err error) metav1.Condition {
 		Status:  metav1.ConditionUnknown,
 		Reason:  string(reason),
 		Message: err.Error(),
+	}
+}
+
+func removeErrorConditionIfReason(obj v1alpha1.AivenManagedObject, reason errCondition) {
+	cond := meta.FindStatusCondition(*obj.Conditions(), ConditionTypeError)
+	if cond != nil && cond.Reason == string(reason) {
+		meta.RemoveStatusCondition(obj.Conditions(), ConditionTypeError)
 	}
 }
 

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -5,6 +5,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkatopic"
@@ -47,17 +48,18 @@ type KafkaTopicController struct {
 var topicListCallGroup singleflight.Group
 
 func (r *KafkaTopicController) Observe(ctx context.Context, topic *v1alpha1.KafkaTopic) (Observation, error) {
+	if isMarkedForDeletion(topic) {
+		return r.observeDeletion(ctx, topic)
+	}
+
 	if err := r.checkPreconditions(ctx, topic); err != nil {
 		return Observation{}, err
 	}
 
-	callKey := fmt.Sprintf("%s/%s", topic.Spec.Project, topic.Spec.ServiceName)
 	targetTopicName := topic.GetTopicName()
 
 	// let requeuing handle retries
-	result, err, _ := topicListCallGroup.Do(callKey, func() (any, error) {
-		return r.avnGen.ServiceKafkaTopicList(ctx, topic.Spec.Project, topic.Spec.ServiceName)
-	})
+	topicList, err := r.listTopics(ctx, topic.Spec.Project, topic.Spec.ServiceName)
 
 	switch {
 	case isServerError(err):
@@ -70,11 +72,6 @@ func (r *KafkaTopicController) Observe(ctx context.Context, topic *v1alpha1.Kafk
 		}, nil
 	case err != nil:
 		return Observation{}, err
-	}
-
-	topicList, ok := result.([]kafkatopic.TopicOut)
-	if !ok {
-		return Observation{}, fmt.Errorf("unexpected result type from ServiceKafkaTopicList") // this should not happen
 	}
 
 	for _, topicInfo := range topicList {
@@ -170,6 +167,41 @@ func (r *KafkaTopicController) Delete(ctx context.Context, topic *v1alpha1.Kafka
 	}
 
 	return nil
+}
+
+func (r *KafkaTopicController) observeDeletion(ctx context.Context, topic *v1alpha1.KafkaTopic) (Observation, error) {
+	targetTopicName := topic.GetTopicName()
+
+	topicList, err := r.listTopics(ctx, topic.Spec.Project, topic.Spec.ServiceName)
+	switch {
+	case isNotFound(err):
+		return Observation{ResourceExists: false}, nil
+	case err != nil:
+		return Observation{}, err
+	}
+
+	resourceExists := slices.ContainsFunc(topicList, func(topicInfo kafkatopic.TopicOut) bool {
+		return topicInfo.TopicName == targetTopicName
+	})
+	return Observation{ResourceExists: resourceExists}, nil
+}
+
+func (r *KafkaTopicController) listTopics(ctx context.Context, project, serviceName string) ([]kafkatopic.TopicOut, error) {
+	callKey := fmt.Sprintf("%s/%s", project, serviceName)
+
+	result, err, _ := topicListCallGroup.Do(callKey, func() (any, error) {
+		return r.avnGen.ServiceKafkaTopicList(ctx, project, serviceName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	topicList, ok := result.([]kafkatopic.TopicOut)
+	if !ok {
+		return nil, fmt.Errorf("unexpected result type from ServiceKafkaTopicList")
+	}
+
+	return topicList, nil
 }
 
 func (r *KafkaTopicController) checkPreconditions(ctx context.Context, topic *v1alpha1.KafkaTopic) error {

--- a/controllers/kafkatopic_controller_test.go
+++ b/controllers/kafkatopic_controller_test.go
@@ -404,6 +404,9 @@ func TestKafkaTopicReconciler(t *testing.T) {
 		topic.Spec.TerminationProtection = &enabled
 
 		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceKafkaTopicList(mock.Anything, topic.Spec.Project, topic.Spec.ServiceName).
+			Return([]kafkatopic.TopicOut{{TopicName: topic.GetTopicName()}}, nil).Once()
 		r, _, err := runScenario(t, topic, avn)
 		require.EqualError(t, err, `unable to delete instance: termination protection is on`)
 
@@ -412,7 +415,7 @@ func TestKafkaTopicReconciler(t *testing.T) {
 		require.Contains(t, got.Finalizers, instanceDeletionFinalizer)
 	})
 
-	t.Run("Deletes KafkaTopic and removes finalizer on deletion", func(t *testing.T) {
+	t.Run("Requests KafkaTopic deletion before removing finalizer", func(t *testing.T) {
 		topic := newObjectFromYAML[v1alpha1.KafkaTopic](t, yamlKafkaTopic)
 		topic.Generation = 1
 		topic.Finalizers = []string{instanceDeletionFinalizer}
@@ -423,14 +426,29 @@ func TestKafkaTopicReconciler(t *testing.T) {
 
 		avn := avngen.NewMockClient(t)
 		avn.EXPECT().
+			ServiceKafkaTopicList(mock.Anything, topic.Spec.Project, topic.Spec.ServiceName).
+			Return([]kafkatopic.TopicOut{{TopicName: topic.GetTopicName()}}, nil).Once()
+		avn.EXPECT().
 			ServiceKafkaTopicDelete(mock.Anything, topic.Spec.Project, topic.Spec.ServiceName, topic.GetTopicName()).
 			Return(nil).Once()
+		avn.EXPECT().
+			ServiceKafkaTopicList(mock.Anything, topic.Spec.Project, topic.Spec.ServiceName).
+			Return([]kafkatopic.TopicOut{}, nil).Once()
 
 		r, res, err := runScenario(t, topic, avn)
 		require.NoError(t, err)
-		require.Equal(t, ctrlruntime.Result{}, res)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
 
 		got := &v1alpha1.KafkaTopic{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: topic.Name, Namespace: topic.Namespace}, got))
+		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+
+		res, err = r.Reconcile(t.Context(), ctrlruntime.Request{
+			NamespacedName: types.NamespacedName{Name: topic.Name, Namespace: topic.Namespace},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
 		err = r.Get(t.Context(), types.NamespacedName{Name: topic.Name, Namespace: topic.Namespace}, got)
 		require.True(t, apierrors.IsNotFound(err))
 	})

--- a/controllers/reconciler.go
+++ b/controllers/reconciler.go
@@ -240,6 +240,16 @@ func (r *Reconciler[T]) updateStatus(ctx context.Context, orig v1alpha1.AivenMan
 	})
 }
 
+func (r *Reconciler[T]) finalizeDeletion(ctx context.Context, obj T) (ctrl.Result, error) {
+	if err := removeFinalizer(ctx, r.Client, obj, instanceDeletionFinalizer); err != nil {
+		r.Recorder.Event(obj, corev1.EventTypeWarning, eventUnableToDeleteFinalizer, err.Error())
+		return ctrl.Result{}, fmt.Errorf("unable to remove finalizer: %w", err)
+	}
+
+	logr.FromContextOrDiscard(ctx).Info("finalizer was removed, resource is deleted")
+	return ctrl.Result{}, nil
+}
+
 func (r *Reconciler[T]) newAivenClient(ctx context.Context, obj T) (avngen.Client, error) {
 	token, err := r.resolveToken(ctx, obj)
 	if err != nil {
@@ -393,71 +403,97 @@ func (r *Reconciler[T]) reconcileDeletion(ctx context.Context, obj T) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	// Parse the annotations for the deletion policy. For simplicity, we only allow 'Orphan'.
-	// If set will skip the deletion of the remote object. Disable by removing the annotation.
+	orig := obj.DeepCopyObject().(v1alpha1.AivenManagedObject)
+
+	// First decide whether this Kubernetes deletion should also delete the external Aiven resource.
 	switch policy, hasDeletionPolicy := obj.GetAnnotations()[deletionPolicyAnnotation]; {
 	case !hasDeletionPolicy:
-		avnGen, err := r.newAivenClient(ctx, obj)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
-		controller := r.newController(avnGen)
-		r.Recorder.Event(obj, corev1.EventTypeNormal, eventTryingToDeleteAtAiven, "trying to delete instance at aiven")
-		if err := controller.Delete(ctx, obj); err != nil {
-			if isInvalidTokenError(err) && !hasIsRunningAnnotation(obj) {
-				logr.FromContextOrDiscard(ctx).Info("invalid token error on deletion, removing finalizer", "apiError", err)
-			} else {
-				return r.handleDeleteError(ctx, obj, err)
-			}
-		}
-
-		logr.FromContextOrDiscard(ctx).Info("instance was successfully deleted at Aiven, removing finalizer")
-		r.Recorder.Event(obj, corev1.EventTypeNormal, eventSuccessfullyDeletedAtAiven, "instance is gone at aiven now")
 	case policy == deletionPolicyOrphan:
 		logr.FromContextOrDiscard(ctx).Info("finalizing with Orphan deletion policy - Aiven resource will be preserved on Kubernetes resource deletion")
+		return r.finalizeDeletion(ctx, obj)
 	default:
 		msg := fmt.Sprintf("invalid deletion policy %q, only %q is allowed", policy, deletionPolicyOrphan)
 		meta.SetStatusCondition(obj.Conditions(), getErrorCondition(errConditionDelete, errors.New(msg)))
-		return ctrl.Result{}, fmt.Errorf("unable to delete instance: %s", msg)
+		return ctrl.Result{}, errors.Join(
+			fmt.Errorf("unable to delete instance: %s", msg),
+			r.updateStatus(ctx, orig, obj),
+		)
 	}
 
-	// remove finalizer, once all finalizers have been removed, the object will be deleted.
-	if err := removeFinalizer(ctx, r.Client, obj, instanceDeletionFinalizer); err != nil {
-		r.Recorder.Event(obj, corev1.EventTypeWarning, eventUnableToDeleteFinalizer, err.Error())
-		return ctrl.Result{}, fmt.Errorf("unable to remove finalizer: %w", err)
+	avnGen, err := r.newAivenClient(ctx, obj)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
+	controller := r.newController(avnGen)
 
-	logr.FromContextOrDiscard(ctx).Info("finalizer was removed, resource is deleted")
-	return ctrl.Result{}, nil
-}
+	// Observe first so delete can distinguish between an already-gone resource and one that still exists before requesting deletion.
+	obs, err := controller.Observe(ctx, obj)
+	if err != nil {
+		// If we cannot confirm the external state, delete-path must stop here and surface a delete-specific failure.
+		meta.SetStatusCondition(obj.Conditions(), getErrorCondition(errConditionDelete, err))
 
-// handleDeleteError handles errors returned from Delete during deletion reconciliation.
-func (r *Reconciler[T]) handleDeleteError(ctx context.Context, obj T, err error) (ctrl.Result, error) {
-	meta.SetStatusCondition(obj.Conditions(), getErrorCondition(errConditionDelete, err))
+		if isRetryableAivenError(err) {
+			logr.FromContextOrDiscard(ctx).Info("unable to confirm instance deletion at Aiven, will requeue delete", "apiError", err)
+			return ctrl.Result{RequeueAfter: requeueTimeout}, r.updateStatus(ctx, orig, obj)
+		}
 
-	// There are dependencies on Aiven side.
-	// We keep the finalizer and trigger a soft requeue so that reconciliation can
-	// be retried once dependencies are removed, but do not surface this as a hard error.
-	if errors.Is(err, v1alpha1.ErrDeleteDependencies) {
-		logr.FromContextOrDiscard(ctx).Info("object has dependencies, requeue delete", "apiError", err)
-		return ctrl.Result{RequeueAfter: requeueTimeout}, nil
-	}
-
-	// If the deletion failed, don't remove the finalizer so that we can retry during the next reconciliation.
-	switch {
-	case isNotFound(err):
-		r.Recorder.Event(obj, corev1.EventTypeWarning, eventUnableToDeleteAtAiven, err.Error())
-		return ctrl.Result{}, fmt.Errorf("unable to delete instance at aiven: %w", err)
-	case isServerError(err):
-		// If failed to delete due to a transient server error, keep the finalizer
-		// and trigger a soft requeue so that deletion can be retried.
-		logr.FromContextOrDiscard(ctx).Info("unable to delete instance at Aiven, will requeue delete", "apiError", err)
-		return ctrl.Result{RequeueAfter: requeueTimeout}, nil
-	default:
 		r.Recorder.Event(obj, corev1.EventTypeWarning, eventUnableToDelete, err.Error())
-		return ctrl.Result{}, fmt.Errorf("unable to delete instance: %w", err)
+		return ctrl.Result{}, errors.Join(
+			fmt.Errorf("unable to confirm instance deletion: %w", err),
+			r.updateStatus(ctx, orig, obj),
+		)
 	}
+	if !obs.ResourceExists {
+		// Once Aiven confirms the resource is gone, the Kubernetes object can be finalized immediately.
+		removeErrorConditionIfReason(obj, errConditionDelete)
+		logr.FromContextOrDiscard(ctx).Info("instance is already gone at Aiven, removing finalizer")
+		r.Recorder.Event(obj, corev1.EventTypeNormal, eventSuccessfullyDeletedAtAiven, "instance is gone at aiven now")
+		return r.finalizeDeletion(ctx, obj)
+	}
+
+	// The external resource still exists, so ask Aiven to delete it.
+	r.Recorder.Event(obj, corev1.EventTypeNormal, eventTryingToDeleteAtAiven, "trying to delete instance at aiven")
+	if err := controller.Delete(ctx, obj); err != nil {
+		// Preserve legacy behavior for resources that never became running with an invalid token.
+		if isInvalidTokenError(err) && !hasIsRunningAnnotation(obj) {
+			removeErrorConditionIfReason(obj, errConditionDelete)
+			logr.FromContextOrDiscard(ctx).Info("invalid token error on deletion, removing finalizer", "apiError", err)
+			r.Recorder.Event(obj, corev1.EventTypeNormal, eventSuccessfullyDeletedAtAiven, "instance is gone at aiven now")
+			return r.finalizeDeletion(ctx, obj)
+		}
+
+		meta.SetStatusCondition(obj.Conditions(), getErrorCondition(errConditionDelete, err))
+
+		// After a failed delete request, keep retryable cases in the delete loop and surface terminal failures.
+		if errors.Is(err, v1alpha1.ErrDeleteDependencies) {
+			logr.FromContextOrDiscard(ctx).Info("object has dependencies, requeue delete", "apiError", err)
+			return ctrl.Result{RequeueAfter: requeueTimeout}, r.updateStatus(ctx, orig, obj)
+		}
+
+		switch {
+		case isNotFound(err):
+			r.Recorder.Event(obj, corev1.EventTypeWarning, eventUnableToDeleteAtAiven, err.Error())
+			return ctrl.Result{}, errors.Join(
+				fmt.Errorf("unable to delete instance at aiven: %w", err),
+				r.updateStatus(ctx, orig, obj),
+			)
+		case isServerError(err):
+			// If failed to delete due to a transient server error, keep the finalizer and trigger a soft requeue so that deletion can be retried.
+			logr.FromContextOrDiscard(ctx).Info("unable to delete instance at Aiven, will requeue delete", "apiError", err)
+			return ctrl.Result{RequeueAfter: requeueTimeout}, r.updateStatus(ctx, orig, obj)
+		default:
+			r.Recorder.Event(obj, corev1.EventTypeWarning, eventUnableToDelete, err.Error())
+			return ctrl.Result{}, errors.Join(
+				fmt.Errorf("unable to delete instance: %w", err),
+				r.updateStatus(ctx, orig, obj),
+			)
+		}
+	}
+
+	// A successful Delete() only means deletion was requested. Keep the finalizer until a later observe confirms absence.
+	removeErrorConditionIfReason(obj, errConditionDelete)
+	logr.FromContextOrDiscard(ctx).Info("delete requested at Aiven, waiting for resource to disappear")
+	return ctrl.Result{RequeueAfter: requeueTimeout}, r.updateStatus(ctx, orig, obj)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/reconciler_test.go
+++ b/controllers/reconciler_test.go
@@ -430,13 +430,16 @@ func TestReconciler_Reconcile(t *testing.T) {
 		}, recorderEvents(recorder))
 	})
 
-	t.Run("Calls finalize when object is marked for deletion", func(t *testing.T) {
+	t.Run("Requests delete before finalizing when object is marked for deletion", func(t *testing.T) {
 		obj := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
 		obj.DeletionTimestamp = new(metav1.Now())
 		obj.Finalizers = []string{instanceDeletionFinalizer}
 
 		m := &mock.Mock{}
 		t.Cleanup(func() { m.AssertExpectations(t) })
+		m.On("newAivenGeneratedClient", "default-token", "v1.30.0", "v0.0.0-test").
+			Return(avngen.NewMockClient(t), nil).
+			Once()
 		m.On("newAivenGeneratedClient", "default-token", "v1.30.0", "v0.0.0-test").
 			Return(avngen.NewMockClient(t), nil).
 			Once()
@@ -448,7 +451,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 		recorder := record.NewFakeRecorder(10)
 
 		c := NewMockAivenController[*v1alpha1.ClickhouseUser](t)
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: true}, nil).Once()
 		c.EXPECT().Delete(mock.Anything, mock.Anything).Return(nil).Once()
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: false}, nil).Once()
 
 		r := &Reconciler[*v1alpha1.ClickhouseUser]{
 			Controller: Controller{
@@ -473,9 +478,19 @@ func TestReconciler_Reconcile(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, ctrl.Result{}, res)
+		require.Equal(t, ctrl.Result{RequeueAfter: requeueTimeout}, res)
 
 		got := &v1alpha1.ClickhouseUser{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got))
+		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+
+		res, err = r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, res)
+
 		err = k8sClient.Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got)
 		require.True(t, apierrors.IsNotFound(err))
 		require.Equal(t, []string{
@@ -484,13 +499,16 @@ func TestReconciler_Reconcile(t *testing.T) {
 		}, recorderEvents(recorder))
 	})
 
-	t.Run("Bypasses refs before finalizing delete", func(t *testing.T) {
+	t.Run("Bypasses refs before confirming delete", func(t *testing.T) {
 		obj := newObjectFromYAML[v1alpha1.PostgreSQL](t, yamlPostgresWithRef)
 		obj.DeletionTimestamp = new(metav1.Now())
 		obj.Finalizers = []string{instanceDeletionFinalizer}
 
 		m := &mock.Mock{}
 		t.Cleanup(func() { m.AssertExpectations(t) })
+		m.On("newAivenGeneratedClient", "default-token", "v1.30.0", "v0.0.0-test").
+			Return(avngen.NewMockClient(t), nil).
+			Once()
 		m.On("newAivenGeneratedClient", "default-token", "v1.30.0", "v0.0.0-test").
 			Return(avngen.NewMockClient(t), nil).
 			Once()
@@ -502,7 +520,9 @@ func TestReconciler_Reconcile(t *testing.T) {
 		recorder := record.NewFakeRecorder(10)
 
 		c := NewMockAivenController[*v1alpha1.PostgreSQL](t)
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: true}, nil).Once()
 		c.EXPECT().Delete(mock.Anything, mock.Anything).Return(nil).Once()
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: false}, nil).Once()
 
 		r := &Reconciler[*v1alpha1.PostgreSQL]{
 			Controller: Controller{
@@ -526,9 +546,19 @@ func TestReconciler_Reconcile(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, ctrl.Result{}, res)
+		require.Equal(t, ctrl.Result{RequeueAfter: requeueTimeout}, res)
 
 		got := &v1alpha1.PostgreSQL{}
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got))
+		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+
+		res, err = r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, res)
+
 		err = k8sClient.Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got)
 		require.True(t, apierrors.IsNotFound(err))
 		require.Equal(t, []string{
@@ -2225,7 +2255,7 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 		require.Empty(t, normalizedConditions(obj.Status.Conditions))
 	})
 
-	t.Run("Deletes remote resource and removes finalizer on success", func(t *testing.T) {
+	t.Run("Requests delete and keeps finalizer while resource still exists", func(t *testing.T) {
 		obj := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
 		obj.Finalizers = []string{instanceDeletionFinalizer}
 
@@ -2242,7 +2272,49 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 			Once()
 
 		c := NewMockAivenController[*v1alpha1.ClickhouseUser](t)
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: true}, nil).Once()
 		c.EXPECT().Delete(mock.Anything, mock.Anything).Return(nil).Once()
+
+		r := newDeleteReconciler(
+			k8sClient,
+			recorder,
+			mockNewAivenGeneratedClient(m),
+			func(avngen.Client) AivenController[*v1alpha1.ClickhouseUser] {
+				return c
+			},
+		)
+
+		res, err := r.reconcileDeletion(t.Context(), obj)
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.ClickhouseUser{}
+		require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got))
+		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+		require.Empty(t, normalizedConditions(got.Status.Conditions))
+		require.Equal(t, []string{
+			"Normal TryingToDeleteAtAiven trying to delete instance at aiven",
+		}, recorderEvents(recorder))
+	})
+
+	t.Run("Removes finalizer when resource is already gone", func(t *testing.T) {
+		obj := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
+		obj.Finalizers = []string{instanceDeletionFinalizer}
+
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(obj).
+			Build()
+		recorder := record.NewFakeRecorder(10)
+
+		m := &mock.Mock{}
+		t.Cleanup(func() { m.AssertExpectations(t) })
+		m.On("newAivenGeneratedClient", "default-token", "v1.30.0", "v0.0.0-test").
+			Return(avngen.NewMockClient(t), nil).
+			Once()
+
+		c := NewMockAivenController[*v1alpha1.ClickhouseUser](t)
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: false}, nil).Once()
 
 		r := newDeleteReconciler(
 			k8sClient,
@@ -2262,8 +2334,108 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 		require.Empty(t, got.Finalizers)
 		require.Empty(t, normalizedConditions(got.Status.Conditions))
 		require.Equal(t, []string{
-			"Normal TryingToDeleteAtAiven trying to delete instance at aiven",
 			"Normal SuccessfullyDeletedAtAiven instance is gone at aiven now",
+		}, recorderEvents(recorder))
+	})
+
+	t.Run("Requeues when confirming deletion fails with retryable observe error", func(t *testing.T) {
+		obj := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
+		obj.Finalizers = []string{instanceDeletionFinalizer}
+
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&v1alpha1.ClickhouseUser{}).
+			WithObjects(obj).
+			Build()
+		recorder := record.NewFakeRecorder(10)
+
+		m := &mock.Mock{}
+		t.Cleanup(func() { m.AssertExpectations(t) })
+		m.On("newAivenGeneratedClient", "default-token", "v1.30.0", "v0.0.0-test").
+			Return(avngen.NewMockClient(t), nil).
+			Once()
+
+		observeErr := newAivenError(500, "internal error")
+
+		c := NewMockAivenController[*v1alpha1.ClickhouseUser](t)
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{}, observeErr).Once()
+
+		r := newDeleteReconciler(
+			k8sClient,
+			recorder,
+			mockNewAivenGeneratedClient(m),
+			func(avngen.Client) AivenController[*v1alpha1.ClickhouseUser] {
+				return c
+			},
+		)
+
+		res, err := r.reconcileDeletion(t.Context(), obj)
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.ClickhouseUser{}
+		require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got))
+		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+		require.ElementsMatch(t, []metav1.Condition{
+			{
+				Type:    ConditionTypeError,
+				Status:  metav1.ConditionUnknown,
+				Reason:  string(errConditionDelete),
+				Message: observeErr.Error(),
+			},
+		}, normalizedConditions(got.Status.Conditions))
+		require.Empty(t, recorderEvents(recorder))
+	})
+
+	t.Run("Returns error when confirming deletion fails with non-retryable observe error", func(t *testing.T) {
+		obj := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
+		obj.Finalizers = []string{instanceDeletionFinalizer}
+
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&v1alpha1.ClickhouseUser{}).
+			WithObjects(obj).
+			Build()
+		recorder := record.NewFakeRecorder(10)
+
+		m := &mock.Mock{}
+		t.Cleanup(func() { m.AssertExpectations(t) })
+		m.On("newAivenGeneratedClient", "default-token", "v1.30.0", "v0.0.0-test").
+			Return(avngen.NewMockClient(t), nil).
+			Once()
+
+		observeErr := fmt.Errorf("boom")
+
+		c := NewMockAivenController[*v1alpha1.ClickhouseUser](t)
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{}, observeErr).Once()
+
+		r := newDeleteReconciler(
+			k8sClient,
+			recorder,
+			mockNewAivenGeneratedClient(m),
+			func(avngen.Client) AivenController[*v1alpha1.ClickhouseUser] {
+				return c
+			},
+		)
+
+		res, err := r.reconcileDeletion(t.Context(), obj)
+		require.Equal(t, ctrl.Result{}, res)
+		require.EqualError(t, err, "unable to confirm instance deletion: "+observeErr.Error())
+		require.ErrorIs(t, err, observeErr)
+
+		got := &v1alpha1.ClickhouseUser{}
+		require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got))
+		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+		require.ElementsMatch(t, []metav1.Condition{
+			{
+				Type:    ConditionTypeError,
+				Status:  metav1.ConditionUnknown,
+				Reason:  string(errConditionDelete),
+				Message: observeErr.Error(),
+			},
+		}, normalizedConditions(got.Status.Conditions))
+		require.Equal(t, []string{
+			"Warning UnableToDelete " + observeErr.Error(),
 		}, recorderEvents(recorder))
 	})
 
@@ -2286,6 +2458,7 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 		deleteErr := fmt.Errorf("Invalid token")
 
 		c := NewMockAivenController[*v1alpha1.ClickhouseUser](t)
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: true}, nil).Once()
 		c.EXPECT().Delete(mock.Anything, mock.Anything).Return(deleteErr).Once()
 
 		r := newDeleteReconciler(
@@ -2311,7 +2484,101 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 		}, recorderEvents(recorder))
 	})
 
-	t.Run("Delegates delete errors to handleDeleteError", func(t *testing.T) {
+	t.Run("Handles delete dependency, not found, and server errors", func(t *testing.T) {
+		errDeps := fmt.Errorf("%w: underlying error", v1alpha1.ErrDeleteDependencies)
+		errNotFound := NewNotFound("instance not found")
+
+		cases := []struct {
+			name          string
+			deletionError error
+			result        ctrl.Result
+			err           string
+			events        []string
+		}{
+			{
+				name:          "dependencies",
+				deletionError: errDeps,
+				result:        ctrl.Result{RequeueAfter: requeueTimeout},
+				events: []string{
+					"Normal TryingToDeleteAtAiven trying to delete instance at aiven",
+				},
+			},
+			{
+				name:          "not found",
+				deletionError: errNotFound,
+				err:           "unable to delete instance at aiven: " + errNotFound.Error(),
+				events: []string{
+					"Normal TryingToDeleteAtAiven trying to delete instance at aiven",
+					"Warning UnableToDeleteAtAiven " + errNotFound.Error(),
+				},
+			},
+			{
+				name:          "server error",
+				deletionError: newAivenError(500, "internal error"),
+				result:        ctrl.Result{RequeueAfter: requeueTimeout},
+				events: []string{
+					"Normal TryingToDeleteAtAiven trying to delete instance at aiven",
+				},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				obj := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
+				obj.Finalizers = []string{instanceDeletionFinalizer}
+
+				recorder := record.NewFakeRecorder(10)
+
+				m := &mock.Mock{}
+				t.Cleanup(func() { m.AssertExpectations(t) })
+				m.On("newAivenGeneratedClient", "default-token", "v1.30.0", "v0.0.0-test").
+					Return(avngen.NewMockClient(t), nil).
+					Once()
+
+				c := NewMockAivenController[*v1alpha1.ClickhouseUser](t)
+				c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: true}, nil).Once()
+				c.EXPECT().Delete(mock.Anything, mock.Anything).Return(tc.deletionError).Once()
+
+				k8sClient := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithStatusSubresource(&v1alpha1.ClickhouseUser{}).
+					WithObjects(obj).
+					Build()
+
+				r := newDeleteReconciler(
+					k8sClient,
+					recorder,
+					mockNewAivenGeneratedClient(m),
+					func(avngen.Client) AivenController[*v1alpha1.ClickhouseUser] {
+						return c
+					},
+				)
+
+				res, err := r.reconcileDeletion(t.Context(), obj)
+				require.Equal(t, tc.result, res)
+				if tc.err == "" {
+					require.NoError(t, err)
+				} else {
+					require.EqualError(t, err, tc.err)
+				}
+
+				got := &v1alpha1.ClickhouseUser{}
+				require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got))
+				require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+				require.ElementsMatch(t, []metav1.Condition{
+					{
+						Type:    ConditionTypeError,
+						Status:  metav1.ConditionUnknown,
+						Reason:  string(errConditionDelete),
+						Message: tc.deletionError.Error(),
+					},
+				}, normalizedConditions(got.Status.Conditions))
+				require.Equal(t, tc.events, recorderEvents(recorder))
+			})
+		}
+	})
+
+	t.Run("Returns error for generic delete failures", func(t *testing.T) {
 		obj := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
 		obj.Finalizers = []string{instanceDeletionFinalizer}
 
@@ -2324,10 +2591,17 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 			Once()
 
 		c := NewMockAivenController[*v1alpha1.ClickhouseUser](t)
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: true}, nil).Once()
 		c.EXPECT().Delete(mock.Anything, mock.Anything).Return(assert.AnError).Once()
 
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&v1alpha1.ClickhouseUser{}).
+			WithObjects(obj).
+			Build()
+
 		r := newDeleteReconciler(
-			nil,
+			k8sClient,
 			recorder,
 			mockNewAivenGeneratedClient(m),
 			func(avngen.Client) AivenController[*v1alpha1.ClickhouseUser] {
@@ -2339,6 +2613,17 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 
 		require.Equal(t, ctrl.Result{}, res)
 		require.EqualError(t, err, `unable to delete instance: `+assert.AnError.Error())
+		got := &v1alpha1.ClickhouseUser{}
+		require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got))
+		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+		require.ElementsMatch(t, []metav1.Condition{
+			{
+				Type:    ConditionTypeError,
+				Status:  metav1.ConditionUnknown,
+				Reason:  string(errConditionDelete),
+				Message: assert.AnError.Error(),
+			},
+		}, normalizedConditions(got.Status.Conditions))
 		require.Equal(t, []string{
 			"Normal TryingToDeleteAtAiven trying to delete instance at aiven",
 			"Warning UnableToDelete " + assert.AnError.Error(),
@@ -2357,11 +2642,7 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 			WithObjects(obj).
 			Build()
 
-		r := &Reconciler[*v1alpha1.ClickhouseUser]{
-			Controller: Controller{
-				Client: k8sClient,
-			},
-		}
+		r := &Reconciler[*v1alpha1.ClickhouseUser]{Controller: Controller{Client: k8sClient}}
 
 		res, err := r.reconcileDeletion(t.Context(), obj)
 		require.NoError(t, err)
@@ -2380,11 +2661,24 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 			deletionPolicyAnnotation: "invalid",
 		}
 
-		r := &Reconciler[*v1alpha1.ClickhouseUser]{}
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&v1alpha1.ClickhouseUser{}).
+			WithObjects(obj).
+			Build()
+
+		r := &Reconciler[*v1alpha1.ClickhouseUser]{
+			Controller: Controller{
+				Client: k8sClient,
+				Scheme: scheme,
+			},
+		}
 
 		res, err := r.reconcileDeletion(t.Context(), obj)
 		require.EqualError(t, err, `unable to delete instance: invalid deletion policy "invalid", only "Orphan" is allowed`)
 		require.Equal(t, ctrl.Result{}, res)
+		got := &v1alpha1.ClickhouseUser{}
+		require.NoError(t, k8sClient.Get(t.Context(), types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, got))
 		require.ElementsMatch(t, []metav1.Condition{
 			{
 				Type:    ConditionTypeError,
@@ -2392,7 +2686,7 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 				Reason:  string(errConditionDelete),
 				Message: `invalid deletion policy "invalid", only "Orphan" is allowed`,
 			},
-		}, normalizedConditions(obj.Status.Conditions))
+		}, normalizedConditions(got.Status.Conditions))
 	})
 
 	t.Run("Returns error when removing finalizer fails", func(t *testing.T) {
@@ -2420,7 +2714,7 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 		recorder := record.NewFakeRecorder(10)
 
 		c := NewMockAivenController[*v1alpha1.ClickhouseUser](t)
-		c.EXPECT().Delete(mock.Anything, mock.Anything).Return(nil).Once()
+		c.EXPECT().Observe(mock.Anything, mock.Anything).Return(Observation{ResourceExists: false}, nil).Once()
 
 		r := newDeleteReconciler(
 			k8sClient,
@@ -2440,77 +2734,10 @@ func TestReconciler_reconcileDeletion(t *testing.T) {
 		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
 		require.Empty(t, normalizedConditions(got.Status.Conditions))
 		require.Equal(t, []string{
-			"Normal TryingToDeleteAtAiven trying to delete instance at aiven",
 			"Normal SuccessfullyDeletedAtAiven instance is gone at aiven now",
 			"Warning UnableToDeleteFinalizer " + assert.AnError.Error(),
 		}, recorderEvents(recorder))
 	})
-}
-
-func TestReconciler_handleDeleteError(t *testing.T) {
-	t.Parallel()
-
-	errDeps := fmt.Errorf("%w: underlying error", v1alpha1.ErrDeleteDependencies)
-	errNotFound := NewNotFound("instance not found")
-
-	cases := []struct {
-		deletionError error
-		result        ctrl.Result
-		err           error
-		events        []string
-	}{
-		{
-			deletionError: fmt.Errorf("%w: underlying error", errDeps),
-			result:        ctrl.Result{RequeueAfter: requeueTimeout},
-			err:           nil,
-			events:        nil,
-		},
-		{
-			deletionError: errNotFound,
-			result:        ctrl.Result{},
-			err:           fmt.Errorf("unable to delete instance at aiven: %w", errNotFound),
-			events: []string{
-				"Warning UnableToDeleteAtAiven " + errNotFound.Error(),
-			},
-		},
-		{
-			deletionError: newAivenError(500, "internal error"),
-			result:        ctrl.Result{RequeueAfter: requeueTimeout},
-			err:           nil,
-			events:        nil,
-		},
-		{
-			deletionError: assert.AnError,
-			result:        ctrl.Result{},
-			err:           fmt.Errorf("unable to delete instance: %w", assert.AnError),
-			events:        []string{"Warning UnableToDelete " + assert.AnError.Error()},
-		},
-	}
-
-	for i, c := range cases {
-		t.Run(fmt.Sprintf("[%d] %s", i, c.deletionError.Error()), func(t *testing.T) {
-			obj := newObjectFromYAML[v1alpha1.ClickhouseUser](t, yamlClickhouseUser)
-			recorder := record.NewFakeRecorder(10)
-			r := &Reconciler[*v1alpha1.ClickhouseUser]{
-				Controller: Controller{
-					Recorder: recorder,
-				},
-			}
-			res, err := r.handleDeleteError(t.Context(), obj, c.deletionError)
-
-			require.Equal(t, c.err, err)
-			require.Equal(t, c.result, res)
-			require.ElementsMatch(t, []metav1.Condition{
-				{
-					Type:    ConditionTypeError,
-					Status:  metav1.ConditionUnknown,
-					Reason:  string(errConditionDelete),
-					Message: c.deletionError.Error(),
-				},
-			}, normalizedConditions(obj.Status.Conditions))
-			require.Equal(t, c.events, recorderEvents(recorder))
-		})
-	}
 }
 
 func TestReconciler_SetupWithManager(t *testing.T) {

--- a/controllers/serviceintegration_controller.go
+++ b/controllers/serviceintegration_controller.go
@@ -45,7 +45,13 @@ type ServiceIntegrationController struct {
 	avnGen avngen.Client
 }
 
+const serviceIntegrationUpdateAttempts = 3
+
 func (r *ServiceIntegrationController) Observe(ctx context.Context, si *v1alpha1.ServiceIntegration) (Observation, error) {
+	if isMarkedForDeletion(si) {
+		return r.observeDeletion(ctx, si)
+	}
+
 	if err := r.checkPreconditions(ctx, si); err != nil {
 		return Observation{}, err
 	}
@@ -163,7 +169,7 @@ func (r *ServiceIntegrationController) Update(ctx context.Context, si *v1alpha1.
 			return updateErr
 		},
 		retry.RetryIf(isNotFound),
-		retry.Attempts(3), //nolint:mnd
+		retry.Attempts(serviceIntegrationUpdateAttempts),
 		retry.Delay(1*time.Second),
 	)
 	if err != nil {
@@ -195,6 +201,22 @@ func (r *ServiceIntegrationController) Delete(ctx context.Context, si *v1alpha1.
 	}
 
 	return nil
+}
+
+func (r *ServiceIntegrationController) observeDeletion(ctx context.Context, si *v1alpha1.ServiceIntegration) (Observation, error) {
+	if si.Status.ID == "" {
+		return Observation{ResourceExists: false}, nil
+	}
+
+	_, err := r.avnGen.ServiceIntegrationGet(ctx, si.Spec.Project, si.Status.ID)
+	switch {
+	case isNotFound(err):
+		return Observation{ResourceExists: false}, nil
+	case err != nil:
+		return Observation{}, fmt.Errorf("getting service integration: %w", err)
+	default:
+		return Observation{ResourceExists: true}, nil
+	}
 }
 
 func (r *ServiceIntegrationController) checkPreconditions(ctx context.Context, si *v1alpha1.ServiceIntegration) error {

--- a/controllers/serviceintegration_controller_test.go
+++ b/controllers/serviceintegration_controller_test.go
@@ -541,6 +541,45 @@ spec:
 		require.True(t, apierrors.IsNotFound(err))
 	})
 
+	t.Run("Requests ServiceIntegration deletion before removing finalizer", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegration](t, yamlServiceIntegrationAutoscalerLegacy)
+		si.Generation = 1
+		si.Finalizers = []string{instanceDeletionFinalizer}
+		si.Spec.SourceServiceName = ""
+		si.Spec.DestinationEndpointID = ""
+		si.Status.ID = "si-123"
+		now := metav1.Now()
+		si.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceIntegrationGet(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(&service.ServiceIntegrationGetOut{}, nil).Once()
+		avn.EXPECT().
+			ServiceIntegrationDelete(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(nil).Once()
+		avn.EXPECT().
+			ServiceIntegrationGet(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(nil, newAivenError(404, "not found")).Once()
+
+		r, res, err := runScenario(t, si, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.ServiceIntegration{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got))
+		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+
+		res, err = r.Reconcile(t.Context(), ctrlruntime.Request{
+			NamespacedName: types.NamespacedName{Name: si.Name, Namespace: si.Namespace},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		err = r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+
 	t.Run("Removes finalizer on deletion when Aiven returns NotFound", func(t *testing.T) {
 		si := newObjectFromYAML[v1alpha1.ServiceIntegration](t, yamlServiceIntegrationAutoscalerLegacy)
 		si.Generation = 1
@@ -553,8 +592,8 @@ spec:
 
 		avn := avngen.NewMockClient(t)
 		avn.EXPECT().
-			ServiceIntegrationDelete(mock.Anything, si.Spec.Project, si.Status.ID).
-			Return(newAivenError(404, "not found")).Once()
+			ServiceIntegrationGet(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(nil, newAivenError(404, "not found")).Once()
 
 		r, res, err := runScenario(t, si, avn)
 		require.NoError(t, err)

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -43,6 +43,10 @@ type ServiceUserController struct {
 }
 
 func (r *ServiceUserController) Observe(ctx context.Context, user *v1alpha1.ServiceUser) (Observation, error) {
+	if isMarkedForDeletion(user) {
+		return r.observeDeletion(ctx, user)
+	}
+
 	details, err := r.fetchSecretDetails(ctx, user)
 	if err != nil {
 		// ServiceUser 404 means "user doesn't exist yet" and should trigger Create.
@@ -151,6 +155,22 @@ func (r *ServiceUserController) setAivenPasswordIfProvided(ctx context.Context, 
 	}
 
 	return nil
+}
+
+func (r *ServiceUserController) observeDeletion(ctx context.Context, user *v1alpha1.ServiceUser) (Observation, error) {
+	if isBuiltInUser(user.Name) {
+		return Observation{ResourceExists: false}, nil
+	}
+
+	_, err := r.avnGen.ServiceUserGet(ctx, user.Spec.Project, user.Spec.ServiceName, user.Name)
+	switch {
+	case isNotFound(err):
+		return Observation{ResourceExists: false}, nil
+	case err != nil:
+		return Observation{}, fmt.Errorf("getting service user: %w", err)
+	default:
+		return Observation{ResourceExists: true}, nil
+	}
 }
 
 func (r *ServiceUserController) fetchSecretDetails(ctx context.Context, user *v1alpha1.ServiceUser) (SecretDetails, error) {

--- a/controllers/serviceuser_controller_test.go
+++ b/controllers/serviceuser_controller_test.go
@@ -200,7 +200,7 @@ func TestServiceUserReconciler(t *testing.T) {
 		require.Equal(t, []byte("pw"), secret.Data["SERVICEUSER_PASSWORD"])
 	})
 
-	t.Run("Deletes ServiceUser and removes finalizer on deletion", func(t *testing.T) {
+	t.Run("Requests ServiceUser deletion before removing finalizer", func(t *testing.T) {
 		user := newObjectFromYAML[v1alpha1.ServiceUser](t, yamlServiceUser)
 		user.Generation = 1
 		user.Finalizers = []string{instanceDeletionFinalizer}
@@ -209,14 +209,29 @@ func TestServiceUserReconciler(t *testing.T) {
 
 		avn := avngen.NewMockClient(t)
 		avn.EXPECT().
+			ServiceUserGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, user.Name).
+			Return(&service.ServiceUserGetOut{Username: user.Name}, nil).Once()
+		avn.EXPECT().
 			ServiceUserDelete(mock.Anything, user.Spec.Project, user.Spec.ServiceName, user.Name).
 			Return(nil).Once()
+		avn.EXPECT().
+			ServiceUserGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, user.Name).
+			Return(nil, newAivenError(404, "not found")).Once()
 
 		r, res := runScenario(t, user, avn)
-		require.Equal(t, ctrlruntime.Result{}, res)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
 
 		got := &v1alpha1.ServiceUser{}
-		err := r.Get(t.Context(), types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, got)
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, got))
+		require.Equal(t, []string{instanceDeletionFinalizer}, got.Finalizers)
+
+		res, err := r.Reconcile(t.Context(), ctrlruntime.Request{
+			NamespacedName: types.NamespacedName{Name: user.Name, Namespace: user.Namespace},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		err = r.Get(t.Context(), types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, got)
 		require.True(t, apierrors.IsNotFound(err))
 	})
 }

--- a/tests/serviceintegration_test.go
+++ b/tests/serviceintegration_test.go
@@ -405,6 +405,68 @@ func TestServiceIntegrationAutoscalerRef(t *testing.T) {
 	assert.True(t, siAvn.Enabled)
 }
 
+func TestServiceIntegrationDeleteWithMissingDestinationEndpointRef(t *testing.T) {
+	t.Parallel()
+	defer recoverPanic(t)
+
+	ctx, cancel := testCtx()
+	defer cancel()
+
+	pg, releasePostgreSQL, err := sharedResources.AcquirePostgreSQL(ctx)
+	require.NoError(t, err)
+	defer releasePostgreSQL()
+
+	pgName := pg.Name
+
+	endpointName := randName("autoscaler-endpoint")
+	endpointDisplayName := randName("autoscaler")
+	siName := randName("autoscaler")
+
+	yml, err := loadExampleYaml("serviceintegration.autoscaler.yaml", map[string]string{
+		"doc[0].metadata.name":     endpointName,
+		"doc[0].spec.project":      cfg.Project,
+		"doc[0].spec.endpointName": endpointDisplayName,
+
+		"doc[1].metadata.name":                    siName,
+		"doc[1].spec.project":                     cfg.Project,
+		"doc[1].spec.sourceServiceName":           pgName,
+		"doc[1].spec.destinationEndpointRef.name": endpointName,
+
+		"doc[2]": "REMOVE",
+	})
+	require.NoError(t, err)
+
+	s := NewSession(ctx, k8sClient)
+	defer s.Destroy(t)
+
+	require.NoError(t, s.Apply(yml))
+
+	endpoint := &v1alpha1.ServiceIntegrationEndpoint{}
+	require.NoError(t, s.GetRunning(endpoint, endpointName))
+
+	si := &v1alpha1.ServiceIntegration{}
+	require.NoError(t, s.GetRunning(si, siName))
+
+	if endpoint.Annotations == nil {
+		endpoint.Annotations = map[string]string{}
+	}
+	endpoint.Annotations["controllers.aiven.io/deletion-policy"] = "Orphan"
+	require.NoError(t, k8sClient.Update(ctx, endpoint))
+
+	require.NoError(t, s.(*session).delete(endpoint))
+
+	_, err = avnGen.ServiceIntegrationEndpointGet(ctx, cfg.Project, endpoint.Status.ID, service.ServiceIntegrationEndpointGetIncludeSecrets(true))
+	require.NoError(t, err)
+
+	_, err = avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, s.Delete(si, func() error {
+		_, err := avnGen.ServiceIntegrationGet(ctx, cfg.Project, si.Status.ID)
+		return err
+	}))
+}
+
 func TestServiceIntegrationRejectsEndpointIDAndRefTogether(t *testing.T) {
 	t.Parallel()
 	defer recoverPanic(t)


### PR DESCRIPTION
## About this change—what it does

Resolves: #2378.

This PR makes `Reconciler[T]` deletion explicit and safe for async delete APIs.

Before this change, `Delete()` returning `nil` was treated like the external resource was already gone, so the reconciler could remove `instanceDeletionFinalizer` before Aiven deletion was actually confirmed.

Now the reconciler first observes external state, treats a successful `Delete()` call as a delete request, and keeps the finalizer until a later reconcile confirms that the external resource no longer exists.
The delete path also persists delete-related status updates to Kubernetes instead of keeping them only in memory.
To support this, the migrated controllers use delete-safe observe paths where needed.