### PR TITLE
fix(ci): enable commit signing for trunk upgrade PRs

### DIFF
--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           prefix: "ci(deps): "
           lowercase-title: true
+          sign-commits: true
 
   verify_trunk:
     needs: trunk_upgrade


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
  - Enable `sign-commits: true` in the trunk upgrade workflow to fix PR merge failures caused by the `required_signatures` branch protection rule on `main`

Resolves: NEX-2456
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
