### PR TITLE
refactor(kafkaschema): migrate to managed reconciler

### DIFF
--- a/controllers/kafkaschema_controller.go
+++ b/controllers/kafkaschema_controller.go
@@ -8,55 +8,129 @@ import (
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkaschemaregistry"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-// KafkaSchemaReconciler reconciles a KafkaSchema object
-type KafkaSchemaReconciler struct {
-	Controller
-}
-
-func newKafkaSchemaReconciler(c Controller) reconcilerType {
-	return &KafkaSchemaReconciler{Controller: c}
-}
-
-type KafkaSchemaHandler struct{}
-
 //+kubebuilder:rbac:groups=aiven.io,resources=kafkaschemas,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=aiven.io,resources=kafkaschemas/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=aiven.io,resources=kafkaschemas/finalizers,verbs=get;create;update
 
-func (r *KafkaSchemaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.reconcileInstance(ctx, req, KafkaSchemaHandler{}, &v1alpha1.KafkaSchema{})
+// KafkaSchemaController reconciles a KafkaSchema object.
+type KafkaSchemaController struct {
+	client.Client
+	avnGen avngen.Client
 }
 
-func (r *KafkaSchemaReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.KafkaSchema{}).
-		Complete(r)
+func newKafkaSchemaReconciler(c Controller) reconcilerType {
+	return newManagedReconciler(
+		c,
+		func(c Controller, avnGen avngen.Client) AivenController[*v1alpha1.KafkaSchema] {
+			return &KafkaSchemaController{Client: c.Client, avnGen: avnGen}
+		},
+		nil,
+	)
 }
 
-func (h KafkaSchemaHandler) createOrUpdate(ctx context.Context, avnGen avngen.Client, obj client.Object, _ []client.Object) error {
-	schema, err := h.convert(obj)
-	if err != nil {
-		return err
+func (r *KafkaSchemaController) Observe(ctx context.Context, schema *v1alpha1.KafkaSchema) (Observation, error) {
+	if _, err := getServiceIfOperational(ctx, r.avnGen, schema.Spec.Project, schema.Spec.ServiceName); err != nil {
+		return Observation{}, err
 	}
 
-	// This operation handles schema creation and updates idempotently:
-	// - New schemas get a new ID and version 1
-	// - Schema updates get a new ID and version
-	// - Submitting the same schema is idempotent (returns existing ID and version)
-	//
-	// Example:
-	// Schema A -> ID:1, Version:1
-	// Schema B -> ID:2, Version:2
-	// Revert to A -> ID:1, Version:1
+	versions, err := r.avnGen.ServiceSchemaRegistrySubjectVersionsGet(
+		ctx,
+		schema.Spec.Project,
+		schema.Spec.ServiceName,
+		schema.Spec.SubjectName,
+	)
+	switch {
+	case isServerError(err):
+		// The service is operational but the schema registry may not yet be ready.
+		// Surface this as a precondition miss so the reconciler does a soft requeue.
+		return Observation{}, fmt.Errorf("%w: schema registry not ready", errPreconditionNotMet)
+	case isNotFound(err):
+		// Subject is not registered yet
+		return Observation{ResourceExists: false}, nil
+	case err != nil:
+		return Observation{}, fmt.Errorf("listing Kafka Schema versions: %w", err)
+	}
+
+	if schema.Status.ID == 0 {
+		// No ID tracked yet, fall through to Create; it is idempotent.
+		return Observation{ResourceExists: false}, nil
+	}
+
+	for _, v := range versions {
+		got, err := r.avnGen.ServiceSchemaRegistrySubjectVersionGet(
+			ctx,
+			schema.Spec.Project,
+			schema.Spec.ServiceName,
+			schema.Spec.SubjectName,
+			v,
+		)
+		if err != nil {
+			return Observation{}, fmt.Errorf("getting Kafka Schema version %d: %w", v, err)
+		}
+
+		if got.Id != schema.Status.ID {
+			continue
+		}
+
+		schema.Status.Version = got.Version
+		meta.SetStatusCondition(&schema.Status.Conditions,
+			getRunningCondition(metav1.ConditionTrue, "CheckRunning", "Instance is running on Aiven side"))
+		metav1.SetMetaDataAnnotation(&schema.ObjectMeta, instanceIsRunningAnnotation, "true")
+
+		return Observation{
+			ResourceExists:   true,
+			ResourceUpToDate: hasLatestGeneration(schema),
+		}, nil
+	}
+
+	// Tracked version is not visible, maybe eventual-consistency lag after POST
+	return Observation{}, fmt.Errorf("%w: tracked schema ID %d not visible in registry", errPreconditionNotMet, schema.Status.ID)
+}
+
+func (r *KafkaSchemaController) Create(ctx context.Context, schema *v1alpha1.KafkaSchema) (CreateResult, error) {
+	delete(schema.GetAnnotations(), instanceIsRunningAnnotation)
+	if err := r.applySchema(ctx, schema); err != nil {
+		return CreateResult{}, err
+	}
+
+	const reason = "CreatedOrUpdated"
+	meta.SetStatusCondition(&schema.Status.Conditions, getInitializedCondition(reason, "Successfully created or updated the instance in Aiven"))
+	meta.SetStatusCondition(&schema.Status.Conditions, getRunningCondition(metav1.ConditionUnknown, reason, "Successfully created or updated the instance in Aiven, status remains unknown"))
+
+	return CreateResult{}, nil
+}
+
+func (r *KafkaSchemaController) Update(ctx context.Context, schema *v1alpha1.KafkaSchema) (UpdateResult, error) {
+	delete(schema.GetAnnotations(), instanceIsRunningAnnotation)
+	if err := r.applySchema(ctx, schema); err != nil {
+		return UpdateResult{}, err
+	}
+
+	const reason = "CreatedOrUpdated"
+	meta.SetStatusCondition(&schema.Status.Conditions, getInitializedCondition(reason, "Successfully created or updated the instance in Aiven"))
+	meta.SetStatusCondition(&schema.Status.Conditions, getRunningCondition(metav1.ConditionUnknown, reason, "Successfully created or updated the instance in Aiven, status remains unknown"))
+
+	return UpdateResult{}, nil
+}
+
+// applySchema handles schema creation and updates idempotently:
+// - New schemas get a new ID and version 1
+// - Schema updates get a new ID and version
+// - Submitting the same schema is idempotent (returns existing ID and version)
+//
+// Example:
+// Schema A -> ID:1, Version:1
+// Schema B -> ID:2, Version:2
+// Revert to A -> ID:1, Version:1
+func (r *KafkaSchemaController) applySchema(ctx context.Context, schema *v1alpha1.KafkaSchema) error {
 	postIn := &kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionPostIn{
 		Schema:     schema.Spec.Schema,
 		SchemaType: schema.Spec.SchemaType,
@@ -64,17 +138,17 @@ func (h KafkaSchemaHandler) createOrUpdate(ctx context.Context, avnGen avngen.Cl
 
 	if len(schema.Spec.References) > 0 {
 		refs := make([]kafkaschemaregistry.ReferenceIn, len(schema.Spec.References))
-		for i, r := range schema.Spec.References {
+		for i, ref := range schema.Spec.References {
 			refs[i] = kafkaschemaregistry.ReferenceIn{
-				Name:    r.Name,
-				Subject: r.Subject,
-				Version: r.Version,
+				Name:    ref.Name,
+				Subject: ref.Subject,
+				Version: ref.Version,
 			}
 		}
 		postIn.References = &refs
 	}
 
-	schemaID, err := avnGen.ServiceSchemaRegistrySubjectVersionPost(
+	schemaID, err := r.avnGen.ServiceSchemaRegistrySubjectVersionPost(
 		ctx,
 		schema.Spec.Project,
 		schema.Spec.ServiceName,
@@ -85,21 +159,22 @@ func (h KafkaSchemaHandler) createOrUpdate(ctx context.Context, avnGen avngen.Cl
 		return fmt.Errorf("cannot add Kafka Schema Subject: %w", err)
 	}
 
-	// The ID is used by the get() to poll the schema version which usually takes some time to be available.
+	// ID is used by Observe to look up the version, which may take some time to appear.
 	schema.Status.ID = schemaID
 
-	// Sets compatibility level if defined
+	// TODO: workaround for a stale-cache race in the managed. Remove once the reconciler fix lands.
+	if err := r.persistStatusID(ctx, schema); err != nil {
+		return fmt.Errorf("persisting Status.ID: %w", err)
+	}
+
 	if schema.Spec.CompatibilityLevel != "" {
-		_, err := avnGen.ServiceSchemaRegistrySubjectConfigPut(
+		if _, err := r.avnGen.ServiceSchemaRegistrySubjectConfigPut(
 			ctx,
 			schema.Spec.Project,
 			schema.Spec.ServiceName,
 			schema.Spec.SubjectName,
-			&kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn{
-				Compatibility: schema.Spec.CompatibilityLevel,
-			},
-		)
-		if err != nil {
+			&kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn{Compatibility: schema.Spec.CompatibilityLevel},
+		); err != nil {
 			return fmt.Errorf("cannot update Kafka Schema Configuration: %w", err)
 		}
 	}
@@ -107,113 +182,28 @@ func (h KafkaSchemaHandler) createOrUpdate(ctx context.Context, avnGen avngen.Cl
 	return nil
 }
 
-func (h KafkaSchemaHandler) delete(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {
-	schema, err := h.convert(obj)
-	if err != nil {
-		return false, err
-	}
-
-	// This is a soft delete, the schema still can be fetched with ?deleted=true flag.
-	// The hard delete operation is recommended to be only used in development environments or when the topic needs to be recycled.
-	err = avnGen.ServiceSchemaRegistrySubjectDelete(ctx, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName)
-	return isDeleted(err)
-}
-
-func (h KafkaSchemaHandler) get(ctx context.Context, avnGen avngen.Client, obj client.Object) (*corev1.Secret, error) {
-	schema, err := h.convert(obj)
-	if err != nil {
-		return nil, err
-	}
-
-	version, err := getKafkaSchemaVersion(
-		ctx,
-		avnGen,
-		schema.Spec.Project,
-		schema.Spec.ServiceName,
-		schema.Spec.SubjectName,
-		schema.Status.ID,
-	)
-
-	switch {
-	case isNotFound(err), isServerError(err):
-		// Eventual consistency issue.
-		// The resource is not replicated yet.
-		return nil, nil
-	case err != nil:
-		return nil, err
-	}
-
-	schema.Status.Version = version
-	meta.SetStatusCondition(&schema.Status.Conditions,
-		getRunningCondition(metav1.ConditionTrue, "CheckRunning",
-			"Instance is running on Aiven side"))
-
-	metav1.SetMetaDataAnnotation(&schema.ObjectMeta, instanceIsRunningAnnotation, "true")
-
-	return nil, nil
-}
-
-func (h KafkaSchemaHandler) checkPreconditions(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {
-	schema, err := h.convert(obj)
-	if err != nil {
-		return false, err
-	}
-
-	ok, err := checkServiceIsOperational(ctx, avnGen, schema.Spec.Project, schema.Spec.ServiceName)
-	if !ok || err != nil {
-		return ok, err
-	}
-
-	// Makes a GET call to retry 5xx errors.
-	// Even when the service is operational, the schema registry may not be ready yet.
-	// The client retries errors under the hood, but sometimes it's not enough.
-	// Let Kubernetes controller-runtime handle retries by returning false to requeue
-	// the reconciliation request.
-	_, err = avnGen.ServiceSchemaRegistrySubjectVersionsGet(
-		ctx,
-		schema.Spec.Project,
-		schema.Spec.ServiceName,
-		schema.Spec.SubjectName,
-	)
-
-	switch {
-	case isServerError(err):
-		// It is not a fatal error, just means that the schema registry is not ready yet.
-		return false, nil
-	case isNotFound(err):
-		// The schema does not exist yet, which is fine.
-		// If it exists, it will be updated in createOrUpdate.
-		return true, nil
-	}
-
-	return err == nil, err
-}
-
-func (h KafkaSchemaHandler) convert(i client.Object) (*v1alpha1.KafkaSchema, error) {
-	schema, ok := i.(*v1alpha1.KafkaSchema)
-	if !ok {
-		return nil, fmt.Errorf("cannot convert object to KafkaSchema")
-	}
-
-	return schema, nil
-}
-
-func getKafkaSchemaVersion(ctx context.Context, client avngen.Client, projectName, serviceName, subjectName string, schemaID int) (int, error) {
-	versions, err := client.ServiceSchemaRegistrySubjectVersionsGet(ctx, projectName, serviceName, subjectName)
-	if err != nil {
-		return 0, err
-	}
-
-	for _, v := range versions {
-		version, err := client.ServiceSchemaRegistrySubjectVersionGet(ctx, projectName, serviceName, subjectName, v)
-		if err != nil {
-			return 0, err
+// persistStatusID writes schema.Status.ID to the API server in its own status
+// subresource update, retrying on optimistic-concurrency conflicts.
+//
+// This is a workaround for the reconciler race issue.
+// It should be removed when updateStatus in the managed reconciler no longer clobbers
+// concurrently-written status fields.
+func (r *KafkaSchemaController) persistStatusID(ctx context.Context, schema *v1alpha1.KafkaSchema) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &v1alpha1.KafkaSchema{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(schema), latest); err != nil {
+			return err
 		}
+		latest.Status.ID = schema.Status.ID
+		return r.Status().Update(ctx, latest)
+	})
+}
 
-		if version.Id == schemaID {
-			return version.Version, nil
-		}
+func (r *KafkaSchemaController) Delete(ctx context.Context, schema *v1alpha1.KafkaSchema) error {
+	// Soft delete: the schema is still accessible via ?deleted=true.
+	err := r.avnGen.ServiceSchemaRegistrySubjectDelete(ctx, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName)
+	if err != nil && !isNotFound(err) {
+		return err
 	}
-
-	return 0, NewNotFound(fmt.Sprintf("the schema with id %d not found", schemaID))
+	return nil
 }

--- a/controllers/kafkaschema_controller_test.go
+++ b/controllers/kafkaschema_controller_test.go
@@ -1,0 +1,360 @@
+package controllers
+
+import (
+	"testing"
+
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/kafkaschemaregistry"
+	"github.com/aiven/go-client-codegen/handler/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aiven/aiven-operator/api/v1alpha1"
+)
+
+const yamlKafkaSchema = `
+apiVersion: aiven.io/v1alpha1
+kind: KafkaSchema
+metadata:
+  name: test-schema
+  namespace: default
+spec:
+  project: test-project
+  serviceName: test-service
+  subjectName: test-subject
+  schemaType: AVRO
+  schema: |
+    {"type":"record","name":"Test","fields":[{"name":"id","type":"string"}]}
+`
+
+func runKafkaSchemaScenario(
+	t *testing.T,
+	schema *v1alpha1.KafkaSchema,
+	avn avngen.Client,
+	additionalObjects ...client.Object,
+) (*Reconciler[*v1alpha1.KafkaSchema], ctrlruntime.Result, error) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	objects := append([]client.Object{schema}, additionalObjects...)
+
+	r := newKafkaSchemaReconciler(Controller{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&v1alpha1.KafkaSchema{}).
+			WithObjects(objects...).
+			Build(),
+		Scheme:       scheme,
+		Recorder:     record.NewFakeRecorder(10),
+		DefaultToken: "test-token",
+		PollInterval: testPollInterval,
+	}).(*Reconciler[*v1alpha1.KafkaSchema])
+	r.newAivenGeneratedClient = func(_, _, _ string) (avngen.Client, error) {
+		return avn, nil
+	}
+
+	res, err := r.Reconcile(t.Context(), ctrlruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      schema.Name,
+			Namespace: schema.Namespace,
+		},
+	})
+	return r, res, err
+}
+
+func runningService() *service.ServiceGetOut {
+	return &service.ServiceGetOut{
+		State: service.ServiceStateTypeRunning,
+		NodeStates: []service.NodeStateOut{
+			{State: service.NodeStateTypeRunning},
+		},
+	}
+}
+
+func TestKafkaSchemaReconciler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Requeues when service preconditions aren't met", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+			Return(nil, newAivenError(404, "service not found")).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got))
+		require.Contains(t, got.Finalizers, instanceDeletionFinalizer)
+		require.NotContains(t, got.Annotations, processedGenerationAnnotation)
+	})
+
+	t.Run("Requeues when schema registry returns server error", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+			Return(nil, newAivenError(500, "schema registry not ready")).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got))
+		require.NotContains(t, got.Annotations, processedGenerationAnnotation)
+	})
+
+	t.Run("Creates KafkaSchema on Aiven when subject does not exist", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+			Return(nil, newAivenError(404, "not found")).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionPost(
+				mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName,
+				mock.MatchedBy(func(in *kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionPostIn) bool {
+					return in.Schema == schema.Spec.Schema &&
+						in.SchemaType == schema.Spec.SchemaType &&
+						in.References == nil
+				}),
+			).Return(42, nil).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got))
+		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
+		require.NotContains(t, got.Annotations, instanceIsRunningAnnotation)
+		require.Equal(t, 42, got.Status.ID)
+	})
+
+	t.Run("Creates KafkaSchema with compatibility level", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 1
+		schema.Spec.CompatibilityLevel = kafkaschemaregistry.CompatibilityTypeBackward
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+			Return(nil, newAivenError(404, "not found")).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionPost(
+				mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, mock.Anything,
+			).Return(7, nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectConfigPut(
+				mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName,
+				mock.MatchedBy(func(in *kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn) bool {
+					return in.Compatibility == kafkaschemaregistry.CompatibilityTypeBackward
+				}),
+			).Return(kafkaschemaregistry.CompatibilityTypeBackward, nil).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got))
+		require.Equal(t, 7, got.Status.ID)
+	})
+
+	t.Run("Creates KafkaSchema with references (PROTOBUF)", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 1
+		schema.Spec.SchemaType = kafkaschemaregistry.SchemaTypeProtobuf
+		schema.Spec.References = []v1alpha1.SchemaReference{
+			{Name: "common.proto", Subject: "common-subject", Version: 1},
+		}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+			Return(nil, newAivenError(404, "not found")).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionPost(
+				mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName,
+				mock.MatchedBy(func(in *kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionPostIn) bool {
+					if in.References == nil || len(*in.References) != 1 {
+						return false
+					}
+					ref := (*in.References)[0]
+					return ref.Name == "common.proto" && ref.Subject == "common-subject" && ref.Version == 1
+				}),
+			).Return(11, nil).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got))
+		require.Equal(t, 11, got.Status.ID)
+	})
+
+	t.Run("Marks KafkaSchema running when tracked ID is visible", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 1
+		schema.Annotations = map[string]string{processedGenerationAnnotation: "1"}
+		schema.Status.ID = 42
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+			Return([]int{1}, nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, 1).
+			Return(&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionGetOut{Id: 42, Version: 1}, nil).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got))
+		require.Equal(t, 1, got.Status.Version)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+	})
+
+	t.Run("Updates KafkaSchema when generation changes", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 2
+		schema.Annotations = map[string]string{
+			processedGenerationAnnotation: "1",
+			instanceIsRunningAnnotation:   "true",
+		}
+		schema.Status.ID = 42
+		schema.Status.Version = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+			Return([]int{1}, nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, 1).
+			Return(&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionGetOut{Id: 42, Version: 1}, nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionPost(
+				mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, mock.Anything,
+			).Return(99, nil).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got))
+		require.Equal(t, "2", got.Annotations[processedGenerationAnnotation])
+		require.NotContains(t, got.Annotations, instanceIsRunningAnnotation)
+		require.Equal(t, 99, got.Status.ID)
+	})
+
+	t.Run("Requeues when tracked ID is not yet visible in the registry", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 1
+		schema.Annotations = map[string]string{processedGenerationAnnotation: "1"}
+		schema.Status.ID = 42
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+			Return([]int{1}, nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectVersionGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, 1).
+			Return(&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionGetOut{Id: 7, Version: 1}, nil).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got))
+		require.NotContains(t, got.Annotations, instanceIsRunningAnnotation)
+	})
+
+	t.Run("Deletes KafkaSchema and removes finalizer on deletion", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 1
+		schema.Finalizers = []string{instanceDeletionFinalizer}
+		now := metav1.Now()
+		schema.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectDelete(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+			Return(nil).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		err = r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+
+	t.Run("Treats 404 on delete as already deleted", func(t *testing.T) {
+		schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+		schema.Generation = 1
+		schema.Finalizers = []string{instanceDeletionFinalizer}
+		now := metav1.Now()
+		schema.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceSchemaRegistrySubjectDelete(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+			Return(newAivenError(404, "not found")).Once()
+
+		r, res, err := runKafkaSchemaScenario(t, schema, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		got := &v1alpha1.KafkaSchema{}
+		err = r.Get(t.Context(), types.NamespacedName{Name: schema.Name, Namespace: schema.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Migrates `KafkaSchema`to the new reconciler.
Resolves: NEX-2484

## Workaround for a reconciler race
- Diagnosing flaky e2e runs uncovered a pre-existing race in `controllers/reconciler.go`'s deferred `updateStatus`: a self-triggered follow-up reconcile pass can read `Status` from a stale cache and clobber the value the previous pass just persisted. `Status.ID` settles at the previous generation's value permanently, until the spec is edited again.

- **Workaround**: `applySchema` persists `Status.ID` synchronously via its own `r.Status().Update`

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
