### PR TITLE
chore(ci): updated auto-commits signing

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -14,8 +14,8 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     outputs:
-      commit_hash: ${{ steps.auto_commit.outputs.commit_hash }}
-      changes_detected: ${{ steps.auto_commit.outputs.changes_detected }}
+      commit_hash: ${{ steps.auto_commit.outputs.commit-hash }}
+      changes_detected: ${{ steps.detect.outputs.changes_detected }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,10 +29,24 @@ jobs:
       - run: curl https://get.trunk.io -fsSL | bash
       - name: generate files
         run: make generate
-      - id: auto_commit
-        uses: stefanzweifel/git-auto-commit-action@v7
+      - name: detect changes
+        id: detect
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changes_detected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes_detected=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: commit generated files
+        if: steps.detect.outputs.changes_detected == 'true'
+        id: auto_commit
+        uses: planetscale/ghcommit-action@v0.2.20
         with:
           commit_message: "chore(userconfigs): generate files"
+          repo: ${{ github.repository }}
+          branch: ${{ github.event.pull_request.head.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run_lint:
     needs: generate


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Replace `stefanzweifel/git-auto-commit-action` with `planetscale/ghcommit-action` in generate.yml so auto-generated commits are signed via GitHub's API

**Why**
- The main branch has r`equired_signatures: true`. The old action pushed commits via plain git commit, which produces unsigned commits
Resolves: NEX-2493

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
