### PR TITLE
fix(kafkaschema): relax subject name length validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Valkey major version
 - **BREAKING**: Change `ServiceIntegration` field `integrationType`: enum remove `m3aggregator`, `m3coordinator`
 - Add `MySQL` and `PostgreSQL` field `migrationSecretSource.deleteAfterMigration`, type `boolean`: When
   true, the operator deletes the referenced Secret after migration completes successfully. Defaults to `false`.
+- Remove the 63-character limit for the `KafkaSchema` field `subjectName`
 
 ## v0.37.0 - 2026-04-09
 

--- a/api/v1alpha1/kafkaschema_types.go
+++ b/api/v1alpha1/kafkaschema_types.go
@@ -12,7 +12,6 @@ import (
 type KafkaSchemaSpec struct {
 	ServiceDependant `json:",inline"`
 
-	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// Kafka Schema Subject name
 	SubjectName string `json:"subjectName"`

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
@@ -143,7 +143,6 @@ spec:
                       rule: self == oldSelf
                 subjectName:
                   description: Kafka Schema Subject name
-                  maxLength: 63
                   type: string
                   x-kubernetes-validations:
                     - message: Value is immutable

--- a/config/crd/bases/aiven.io_kafkaschemas.yaml
+++ b/config/crd/bases/aiven.io_kafkaschemas.yaml
@@ -143,7 +143,6 @@ spec:
                       rule: self == oldSelf
                 subjectName:
                   description: Kafka Schema Subject name
-                  maxLength: 63
                   type: string
                   x-kubernetes-validations:
                     - message: Value is immutable

--- a/docs/docs/resources/kafkaschema.md
+++ b/docs/docs/resources/kafkaschema.md
@@ -97,7 +97,7 @@ KafkaSchemaSpec defines the desired state of KafkaSchema.
 - [`project`](#spec.project-property){: name='spec.project-property'} (string, Immutable, Pattern: `^[a-zA-Z0-9_-]+$`, MaxLength: 63). Identifies the project this resource belongs to.
 - [`schema`](#spec.schema-property){: name='spec.schema-property'} (string). Kafka Schema configuration should be a valid Avro Schema JSON format.
 - [`serviceName`](#spec.serviceName-property){: name='spec.serviceName-property'} (string, Immutable, Pattern: `^[a-z][-a-z0-9]+$`, MaxLength: 63). Specifies the name of the service that this resource belongs to.
-- [`subjectName`](#spec.subjectName-property){: name='spec.subjectName-property'} (string, Immutable, MaxLength: 63). Kafka Schema Subject name.
+- [`subjectName`](#spec.subjectName-property){: name='spec.subjectName-property'} (string, Immutable). Kafka Schema Subject name.
 
 **Optional**
 

--- a/tests/kafkaschema_test.go
+++ b/tests/kafkaschema_test.go
@@ -31,7 +31,9 @@ func TestKafkaSchema(t *testing.T) {
 
 	kafkaName := kafka.GetName()
 	schemaName := randName("kafka-schema")
-	subjectName := randName("kafka-schema")
+	// Keep the subject over the old 63-character operator limit to verify the CRD accepts it.
+	subjectName := randName("kafka-schema-subject-name-longer-than-sixty-three-characters")
+	require.Greater(t, len(subjectName), 63)
 	yml := getKafkaSchemaYaml(cfg.Project, kafkaName, schemaName, subjectName)
 	s := NewSession(ctx, k8sClient)
 


### PR DESCRIPTION
Resolves: NEX-2497

Removed the 63-character CRD validation limit from `KafkaSchema.spec.subjectName`.