### PR TITLE
fix(connectionpool): make databaseName and username immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Valkey major version
 - Add `MySQL` and `PostgreSQL` field `migrationSecretSource.deleteAfterMigration`, type `boolean`: When
   true, the operator deletes the referenced Secret after migration completes successfully. Defaults to `false`.
 - Remove the 63-character limit for the `KafkaSchema` field `subjectName`
+- Make `ConnectionPool` fields `databaseName` and `username` immutable
 
 ## v0.37.0 - 2026-04-09
 

--- a/api/v1alpha1/connectionpool_types.go
+++ b/api/v1alpha1/connectionpool_types.go
@@ -8,15 +8,18 @@ import (
 )
 
 // ConnectionPoolSpec defines the desired state of ConnectionPool
+// +kubebuilder:validation:XValidation:rule="((!has(oldSelf.username) || size(oldSelf.username) == 0) && (!has(self.username) || size(self.username) == 0)) || (has(oldSelf.username) && size(oldSelf.username) > 0 && has(self.username) && self.username == oldSelf.username)",message="username is immutable"
 type ConnectionPoolSpec struct {
 	ServiceDependant `json:",inline"`
 	SecretFields     `json:",inline"`
 
 	// +kubebuilder:validation:MaxLength=40
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="databaseName is immutable"
 	// Name of the database the pool connects to
 	DatabaseName string `json:"databaseName"`
 
 	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="username is immutable"
 	// Name of the service user used to connect to the database
 	Username string `json:"username,omitempty"`
 

--- a/charts/aiven-operator-crds/templates/aiven.io_connectionpools.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_connectionpools.yaml
@@ -118,6 +118,9 @@ spec:
                   description: Name of the database the pool connects to
                   maxLength: 40
                   type: string
+                  x-kubernetes-validations:
+                    - message: databaseName is immutable
+                      rule: self == oldSelf
                 poolMode:
                   description: Mode the pool operates in (session, transaction, statement)
                   enum:
@@ -152,12 +155,20 @@ spec:
                   description: Name of the service user used to connect to the database
                   maxLength: 64
                   type: string
+                  x-kubernetes-validations:
+                    - message: username is immutable
+                      rule: self == oldSelf
               required:
                 - databaseName
                 - project
                 - serviceName
               type: object
               x-kubernetes-validations:
+                - message: username is immutable
+                  rule:
+                    ((!has(oldSelf.username) || size(oldSelf.username) == 0) && (!has(self.username)
+                    || size(self.username) == 0)) || (has(oldSelf.username) && size(oldSelf.username)
+                    > 0 && has(self.username) && self.username == oldSelf.username)
                 - message:
                     connInfoSecretTargetDisabled can only be set during resource
                     creation.

--- a/config/crd/bases/aiven.io_connectionpools.yaml
+++ b/config/crd/bases/aiven.io_connectionpools.yaml
@@ -118,6 +118,9 @@ spec:
                   description: Name of the database the pool connects to
                   maxLength: 40
                   type: string
+                  x-kubernetes-validations:
+                    - message: databaseName is immutable
+                      rule: self == oldSelf
                 poolMode:
                   description: Mode the pool operates in (session, transaction, statement)
                   enum:
@@ -152,12 +155,20 @@ spec:
                   description: Name of the service user used to connect to the database
                   maxLength: 64
                   type: string
+                  x-kubernetes-validations:
+                    - message: username is immutable
+                      rule: self == oldSelf
               required:
                 - databaseName
                 - project
                 - serviceName
               type: object
               x-kubernetes-validations:
+                - message: username is immutable
+                  rule:
+                    ((!has(oldSelf.username) || size(oldSelf.username) == 0) && (!has(self.username)
+                    || size(self.username) == 0)) || (has(oldSelf.username) && size(oldSelf.username)
+                    > 0 && has(self.username) && self.username == oldSelf.username)
                 - message:
                     connInfoSecretTargetDisabled can only be set during resource
                     creation.

--- a/docs/docs/resources/connectionpool.md
+++ b/docs/docs/resources/connectionpool.md
@@ -129,7 +129,7 @@ ConnectionPoolSpec defines the desired state of ConnectionPool.
 
 **Required**
 
-- [`databaseName`](#spec.databaseName-property){: name='spec.databaseName-property'} (string, MaxLength: 40). Name of the database the pool connects to.
+- [`databaseName`](#spec.databaseName-property){: name='spec.databaseName-property'} (string, Immutable, MaxLength: 40). Name of the database the pool connects to.
 - [`project`](#spec.project-property){: name='spec.project-property'} (string, Immutable, Pattern: `^[a-zA-Z0-9_-]+$`, MaxLength: 63). Identifies the project this resource belongs to.
 - [`serviceName`](#spec.serviceName-property){: name='spec.serviceName-property'} (string, Immutable, Pattern: `^[a-z][-a-z0-9]+$`, MaxLength: 63). Specifies the name of the service that this resource belongs to.
 
@@ -140,7 +140,7 @@ ConnectionPoolSpec defines the desired state of ConnectionPool.
 - [`connInfoSecretTargetDisabled`](#spec.connInfoSecretTargetDisabled-property){: name='spec.connInfoSecretTargetDisabled-property'} (boolean, Immutable). When true, the secret containing connection information will not be created, defaults to false. This field cannot be changed after resource creation.
 - [`poolMode`](#spec.poolMode-property){: name='spec.poolMode-property'} (string, Enum: `session`, `transaction`, `statement`). Mode the pool operates in (session, transaction, statement).
 - [`poolSize`](#spec.poolSize-property){: name='spec.poolSize-property'} (integer). Number of connections the pool may create towards the backend server.
-- [`username`](#spec.username-property){: name='spec.username-property'} (string, MaxLength: 64). Name of the service user used to connect to the database.
+- [`username`](#spec.username-property){: name='spec.username-property'} (string, Immutable, MaxLength: 64). Name of the service user used to connect to the database.
 
 ## authSecretRef {: #spec.authSecretRef }
 


### PR DESCRIPTION
Resolves: NEX-2471

Prevent existing `ConnectionPool` resources from changing `spec.databaseName` or `spec.username`.