### PR TITLE
test(clickhouse): pin the clickhouse version in the tests

### DIFF
--- a/docs/docs/resources/clickhouse.md
+++ b/docs/docs/resources/clickhouse.md
@@ -48,6 +48,7 @@ spec:
     instance: foo
 
   userConfig:
+    clickhouse_version: "25.3"
     ip_filter:
       - network: 0.0.0.0/0
         description: bar

--- a/docs/docs/resources/clickhousegrant.md
+++ b/docs/docs/resources/clickhousegrant.md
@@ -111,6 +111,9 @@ This resource uses the following API operations, and for each operation, _any_ o
       cloudName: google-europe-west1
       plan: startup-16
     
+      userConfig:
+        clickhouse_version: "25.3"
+    
     ---
     
     apiVersion: aiven.io/v1alpha1

--- a/docs/docs/resources/examples/clickhouse.yaml
+++ b/docs/docs/resources/examples/clickhouse.yaml
@@ -19,6 +19,7 @@ spec:
     instance: foo
 
   userConfig:
+    clickhouse_version: "25.3"
     ip_filter:
       - network: 0.0.0.0/0
         description: bar

--- a/docs/docs/resources/examples/clickhousegrant.yaml
+++ b/docs/docs/resources/examples/clickhousegrant.yaml
@@ -40,6 +40,9 @@ spec:
   cloudName: google-europe-west1
   plan: startup-16
 
+  userConfig:
+    clickhouse_version: "25.3"
+
 ---
 
 apiVersion: aiven.io/v1alpha1

--- a/docs/docs/resources/examples/serviceintegration.clickhouse_postgresql.yaml
+++ b/docs/docs/resources/examples/serviceintegration.clickhouse_postgresql.yaml
@@ -34,6 +34,9 @@ spec:
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00
 
+  userConfig:
+    clickhouse_version: "25.3"
+
 ---
 
 apiVersion: aiven.io/v1alpha1

--- a/docs/docs/resources/serviceintegration.md
+++ b/docs/docs/resources/serviceintegration.md
@@ -117,6 +117,9 @@ This resource uses the following API operations, and for each operation, _any_ o
       maintenanceWindowDow: friday
       maintenanceWindowTime: 23:00:00
     
+      userConfig:
+        clickhouse_version: "25.3"
+    
     ---
     
     apiVersion: aiven.io/v1alpha1

--- a/test/e2e/clickhouse/clickhouse-simple-cluster/01-clickhouse.yaml
+++ b/test/e2e/clickhouse/clickhouse-simple-cluster/01-clickhouse.yaml
@@ -17,3 +17,6 @@ spec:
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00
+
+  userConfig:
+    clickhouse_version: "25.3"

--- a/test/e2e/clickhouse/clickhouseuser-builtin-avnadmin/01-clickhouse.yaml
+++ b/test/e2e/clickhouse/clickhouseuser-builtin-avnadmin/01-clickhouse.yaml
@@ -16,3 +16,6 @@ spec:
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00
+
+  userConfig:
+    clickhouse_version: "25.3"

--- a/test/e2e/clickhouse/clickhouseuser-with-password/01-clickhouse.yaml
+++ b/test/e2e/clickhouse/clickhouseuser-with-password/01-clickhouse.yaml
@@ -17,3 +17,6 @@ spec:
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00
+
+  userConfig:
+    clickhouse_version: "25.3"

--- a/test/e2e/service-integration/clickhouse-postgresql/01-clickhouse.yaml
+++ b/test/e2e/service-integration/clickhouse-postgresql/01-clickhouse.yaml
@@ -17,3 +17,6 @@ spec:
 
   maintenanceWindowDow: friday
   maintenanceWindowTime: 23:00:00
+
+  userConfig:
+    clickhouse_version: "25.3"

--- a/tests/clickhouseuser_test.go
+++ b/tests/clickhouseuser_test.go
@@ -565,6 +565,9 @@ spec:
   project: %s
   cloudName: %s
   plan: startup-v2-16
+
+  userConfig:
+    clickhouse_version: "25.3"
 `, chName, chName, cfg.Project, cfg.PrimaryCloudName)
 
 	s := NewSession(ctx, k8sClient)

--- a/tests/suite_shared_resources.go
+++ b/tests/suite_shared_resources.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
+	clickhouseuserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/clickhouse"
 	kafkauserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/kafka"
 )
 
@@ -60,6 +61,9 @@ func (s *sharedResourcesImpl) AcquireClickhouse(ctx context.Context) (*v1alpha1.
 	obj.Spec.Plan = "startup-16"
 	obj.Spec.Project = cfg.Project
 	obj.Spec.CloudName = cfg.PrimaryCloudName
+	obj.Spec.UserConfig = &clickhouseuserconfig.ClickhouseUserConfig{
+		ClickhouseVersion: anyPointer("25.3"),
+	}
 	return acquire(ctx, s, "Clickhouse", obj)
 }
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Pin `aiven_clickhouse` in `TestAccAivenClickhouseGrant` to `clickhouse_version = "25.3"`
- Unblocks the acceptance pipeline, which has been red

Contributes to: NEX-2506

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
