### PR TITLE
fix(serviceuser): requeue empty-password as precondition

### DIFF
--- a/controllers/reconciler.go
+++ b/controllers/reconciler.go
@@ -144,6 +144,12 @@ func (r *Reconciler[T]) ensureFinalizer(ctx context.Context, obj client.Object) 
 }
 
 func (r *Reconciler[T]) handleObserveError(ctx context.Context, obj T, err error) (ctrl.Result, error) {
+	// context.Canceled almost always means the manager is shutting down.
+	if errors.Is(err, context.Canceled) {
+		logr.FromContextOrDiscard(ctx).V(1).Info("reconcile context canceled, will retry", "error", err)
+		return ctrl.Result{RequeueAfter: requeueTimeout}, nil
+	}
+
 	if errors.Is(err, errServicePoweredOff) {
 		r.Recorder.Event(obj, corev1.EventTypeWarning, eventUnableToWaitForPreconditions, err.Error())
 		meta.SetStatusCondition(obj.Conditions(), getErrorCondition(errConditionPreconditions, err))

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -184,9 +184,10 @@ func (r *ServiceUserController) fetchUser(ctx context.Context, user *v1alpha1.Se
 	// errEmptyPassword password is not received from the API:
 	// 1. it was changed by TF but the API did not return it
 	// 2. user has changed it in PG directly, so the API does not have it
-	errEmptyPassword := errors.New("received empty password from the API")
+	// Wraps errPreconditionNotMet for the soft-requeue.
+	errEmptyPassword := fmt.Errorf("%w: received empty password from the API", errPreconditionNotMet)
 	const (
-		emptyPasswordRetryAttempts = 10
+		emptyPasswordRetryAttempts = 3
 		emptyPasswordRetryDelay    = 5 * time.Second
 		notFoundRetryAttempts      = 5
 		notFoundRetryDelay         = 1 * time.Second
@@ -222,10 +223,7 @@ func (r *ServiceUserController) fetchUser(ctx context.Context, user *v1alpha1.Se
 		return u, nil
 	}
 
-	// Retries empty password up to ~1m.
-	// It should be enough to get the backend to a consistent state.
-	// Though if user has changed the password in PG directly,
-	// the API will never return the password.
+	// Retries empty password ≈10s in-reconcile to absorb a brief backend lag.
 	var u *service.ServiceUserGetOut
 	err = retry.Do(
 		func() error {
@@ -241,7 +239,6 @@ func (r *ServiceUserController) fetchUser(ctx context.Context, user *v1alpha1.Se
 		retry.RetryIf(func(err error) bool {
 			return errors.Is(err, errEmptyPassword)
 		}),
-		// ≈1m total wait time
 		retry.Attempts(emptyPasswordRetryAttempts),
 		retry.Delay(emptyPasswordRetryDelay),
 		// retry.Do returns a custom list of errors.


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- `errEmptyPassword` wraps `errPreconditionNotMet` → 10s requeue instead of workqueue backoff
- in-reconcile retry: 10×5s → 3×5s
- `context.Canceled` in `handleObserveError` → soft-requeue + log, to avoid `Reconciler error` on pod shutdown

Contributes to: NEX-2559

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
