### PR TITLE
fix(service_user): ignore empty password

### DIFF
--- a/api/v1alpha1/serviceuser_types.go
+++ b/api/v1alpha1/serviceuser_types.go
@@ -12,12 +12,14 @@ type ServiceUserSpec struct {
 	ServiceDependant `json:",inline"`
 	SecretFields     `json:",inline"`
 
-	// ConnInfoSecretSource allows specifying an existing secret to read credentials from.
-	// The password from this secret will be used to modify the service user credentials.
-	// Password must be 8-256 characters long as per Aiven API requirements.
-	// This can be used to set passwords for new users or modify passwords for existing users (e.g., avnadmin).
-	// The source secret is watched for changes, and reconciliation will be automatically triggered
-	// when the secret data is updated.
+	// ConnInfoSecretSource declares the password the operator should enforce on the user.
+	// Direct password changes in the database will be reverted on the next reconcile cycle.
+	// To rotate, update the source secret.
+	// When unset, the Operator does not manage the password:
+	// the target secret holds whatever password the Aiven API returns.
+	// If the password is later changed directly in the database,
+	// the API returns an empty value and the target secret is emptied on the next reconcile.
+	// Password must be 8-256 characters long.
 	ConnInfoSecretSource *ConnInfoSecretSource `json:"connInfoSecretSource,omitempty"`
 
 	// AccessControl Service type specific access control rules for user.

--- a/charts/aiven-operator-crds/templates/aiven.io_serviceusers.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_serviceusers.yaml
@@ -102,12 +102,14 @@ spec:
                   type: string
                 connInfoSecretSource:
                   description: |-
-                    ConnInfoSecretSource allows specifying an existing secret to read credentials from.
-                    The password from this secret will be used to modify the service user credentials.
-                    Password must be 8-256 characters long as per Aiven API requirements.
-                    This can be used to set passwords for new users or modify passwords for existing users (e.g., avnadmin).
-                    The source secret is watched for changes, and reconciliation will be automatically triggered
-                    when the secret data is updated.
+                    ConnInfoSecretSource declares the password the operator should enforce on the user.
+                    Direct password changes in the database will be reverted on the next reconcile cycle.
+                    To rotate, update the source secret.
+                    When unset, the Operator does not manage the password:
+                    the target secret holds whatever password the Aiven API returns.
+                    If the password is later changed directly in the database,
+                    the API returns an empty value and the target secret is emptied on the next reconcile.
+                    Password must be 8-256 characters long.
                   properties:
                     name:
                       description: |-

--- a/config/crd/bases/aiven.io_serviceusers.yaml
+++ b/config/crd/bases/aiven.io_serviceusers.yaml
@@ -102,12 +102,14 @@ spec:
                   type: string
                 connInfoSecretSource:
                   description: |-
-                    ConnInfoSecretSource allows specifying an existing secret to read credentials from.
-                    The password from this secret will be used to modify the service user credentials.
-                    Password must be 8-256 characters long as per Aiven API requirements.
-                    This can be used to set passwords for new users or modify passwords for existing users (e.g., avnadmin).
-                    The source secret is watched for changes, and reconciliation will be automatically triggered
-                    when the secret data is updated.
+                    ConnInfoSecretSource declares the password the operator should enforce on the user.
+                    Direct password changes in the database will be reverted on the next reconcile cycle.
+                    To rotate, update the source secret.
+                    When unset, the Operator does not manage the password:
+                    the target secret holds whatever password the Aiven API returns.
+                    If the password is later changed directly in the database,
+                    the API returns an empty value and the target secret is emptied on the next reconcile.
+                    Password must be 8-256 characters long.
                   properties:
                     name:
                       description: |-

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -45,7 +45,7 @@ type ServiceUserController struct {
 }
 
 func (r *ServiceUserController) Observe(ctx context.Context, user *v1alpha1.ServiceUser) (Observation, error) {
-	u, details, err := r.fetchUser(ctx, user)
+	u, details, err := r.fetchUser(ctx, user, false)
 	if err != nil {
 		// ServiceUser 404 means "user doesn't exist yet" and should trigger Create.
 		// But service/project 404 is wrapped as errPreconditionNotMet in getServiceIfOperational
@@ -54,6 +54,12 @@ func (r *ServiceUserController) Observe(ctx context.Context, user *v1alpha1.Serv
 			return Observation{ResourceExists: false}, nil
 		}
 		return Observation{}, err
+	}
+
+	// Empty password with a source secret: Update so the declared value gets pushed back to Aiven.
+	// Empty without a source: nothing to enforce, user may change it bypassing the API.
+	if u.Password == "" && user.Spec.ConnInfoSecretSource != nil {
+		return Observation{ResourceExists: true, ResourceUpToDate: false, SecretDetails: details}, nil
 	}
 
 	return Observation{
@@ -82,7 +88,7 @@ func (r *ServiceUserController) Create(ctx context.Context, user *v1alpha1.Servi
 		return CreateResult{}, fmt.Errorf("creating service user: %w", err)
 	}
 
-	if err := r.setAivenPasswordIfProvided(ctx, user, password); err != nil {
+	if _, err := r.setAivenPasswordIfProvided(ctx, user, password); err != nil {
 		return CreateResult{}, err
 	}
 
@@ -93,7 +99,8 @@ func (r *ServiceUserController) Create(ctx context.Context, user *v1alpha1.Servi
 	meta.SetStatusCondition(&user.Status.Conditions, getRunningCondition(metav1.ConditionTrue, "CheckRunning", "Instance is running on Aiven side"))
 	metav1.SetMetaDataAnnotation(&user.ObjectMeta, instanceIsRunningAnnotation, "true")
 
-	_, details, err := r.fetchUser(ctx, user)
+	// Retry to absorb the potential API lag.
+	_, details, err := r.fetchUser(ctx, user, true)
 	if err != nil {
 		return CreateResult{}, fmt.Errorf("building connection details: %w", err)
 	}
@@ -124,14 +131,16 @@ func (r *ServiceUserController) Update(ctx context.Context, user *v1alpha1.Servi
 		logr.FromContextOrDiscard(ctx).V(1).Info("skipping access control update since it isn't provided in the spec")
 	}
 
-	if err := r.setAivenPasswordIfProvided(ctx, user, password); err != nil {
+	wrotePassword, err := r.setAivenPasswordIfProvided(ctx, user, password)
+	if err != nil {
 		return UpdateResult{}, err
 	}
 
 	meta.SetStatusCondition(&user.Status.Conditions, getRunningCondition(metav1.ConditionTrue, "CheckRunning", "Instance is running on Aiven side"))
 	metav1.SetMetaDataAnnotation(&user.ObjectMeta, instanceIsRunningAnnotation, "true")
 
-	_, details, err := r.fetchUser(ctx, user)
+	// Retry empty-password only when a password was actually updated during this cycle.
+	_, details, err := r.fetchUser(ctx, user, wrotePassword)
 	if err != nil {
 		return UpdateResult{}, fmt.Errorf("building connection details: %w", err)
 	}
@@ -154,9 +163,11 @@ func (r *ServiceUserController) Delete(ctx context.Context, user *v1alpha1.Servi
 	return nil
 }
 
-func (r *ServiceUserController) setAivenPasswordIfProvided(ctx context.Context, user *v1alpha1.ServiceUser, password string) error {
+// setAivenPasswordIfProvided pushes the password to Aiven if non-empty.
+// Returns true when the password was actually updated.
+func (r *ServiceUserController) setAivenPasswordIfProvided(ctx context.Context, user *v1alpha1.ServiceUser, password string) (bool, error) {
 	if password == "" {
-		return nil
+		return false, nil
 	}
 
 	if _, err := r.avnGen.ServiceUserCredentialsModify(
@@ -169,28 +180,31 @@ func (r *ServiceUserController) setAivenPasswordIfProvided(ctx context.Context, 
 			Operation:   service.ServiceUserCredentialsModifyOperationTypeResetCredentials,
 		},
 	); err != nil {
-		return fmt.Errorf("modifying service user credentials: %w", err)
+		return false, fmt.Errorf("modifying service user credentials: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
-func (r *ServiceUserController) fetchUser(ctx context.Context, user *v1alpha1.ServiceUser) (*service.ServiceUserGetOut, SecretDetails, error) {
+// fetchUser gets the ServiceUser from Aiven and builds the secret details.
+//
+// retryEmptyPassword absorbs the eventual-consistency window where
+// ServiceUserGet returns an empty password right after the password change.
+func (r *ServiceUserController) fetchUser(
+	ctx context.Context,
+	user *v1alpha1.ServiceUser,
+	retryEmptyPassword bool,
+) (*service.ServiceUserGetOut, SecretDetails, error) {
 	svc, err := getServiceIfOperational(ctx, r.avnGen, user.Spec.Project, user.Spec.ServiceName)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// errEmptyPassword password is not received from the API:
-	// 1. it was changed by TF but the API did not return it
-	// 2. user has changed it in PG directly, so the API does not have it
-	// Wraps errPreconditionNotMet for the soft-requeue.
-	errEmptyPassword := fmt.Errorf("%w: received empty password from the API", errPreconditionNotMet)
 	const (
-		emptyPasswordRetryAttempts = 3
-		emptyPasswordRetryDelay    = 5 * time.Second
-		notFoundRetryAttempts      = 5
-		notFoundRetryDelay         = 1 * time.Second
+		emptyPasswordExtraRetries = 2
+		emptyPasswordRetryDelay   = 5 * time.Second
+		notFoundRetryAttempts     = 5
+		notFoundRetryDelay        = 1 * time.Second
 	)
 
 	running := hasIsRunningAnnotation(user)
@@ -223,30 +237,39 @@ func (r *ServiceUserController) fetchUser(ctx context.Context, user *v1alpha1.Se
 		return u, nil
 	}
 
-	// Retries empty password ≈10s in-reconcile to absorb a brief backend lag.
-	var u *service.ServiceUserGetOut
-	err = retry.Do(
-		func() error {
-			u, err = getUser()
-			if err == nil && u.Password == "" {
-				err = errEmptyPassword
-			}
-			return err
-		},
-		retry.Context(ctx),
-		// Retries errEmptyPassword only.
-		// The rest is retried by the client itself and the outer controller.
-		retry.RetryIf(func(err error) bool {
-			return errors.Is(err, errEmptyPassword)
-		}),
-		retry.Attempts(emptyPasswordRetryAttempts),
-		retry.Delay(emptyPasswordRetryDelay),
-		// retry.Do returns a custom list of errors.
-		// Outer controller must be able to detect error types like "server error".
-		retry.LastErrorOnly(true),
-	)
+	u, err := getUser()
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if retryEmptyPassword && u.Password == "" {
+		errEmptyPassword := errors.New("received empty password from the API")
+		err = retry.Do(
+			func() error {
+				u, err = getUser()
+				if err != nil {
+					return err
+				}
+				if u.Password == "" {
+					return errEmptyPassword
+				}
+				return nil
+			},
+			retry.Context(ctx),
+			retry.RetryIf(func(err error) bool {
+				return errors.Is(err, errEmptyPassword)
+			}),
+			retry.Attempts(emptyPasswordExtraRetries),
+			retry.Delay(emptyPasswordRetryDelay),
+			retry.LastErrorOnly(true),
+		)
+		// Real API errors propagate. Exhausted empty-password retries returns as precondition.
+		switch {
+		case errors.Is(err, errEmptyPassword):
+			return nil, nil, fmt.Errorf("%w: ServiceUser password not yet available from API", errPreconditionNotMet)
+		case err != nil:
+			return nil, nil, err
+		}
 	}
 
 	idx := slices.IndexFunc(svc.Components, func(c service.ComponentOut) bool {

--- a/controllers/serviceuser_controller_test.go
+++ b/controllers/serviceuser_controller_test.go
@@ -669,39 +669,84 @@ func TestServiceUserReconciler(t *testing.T) {
 		})
 	})
 
-	t.Run("Preserves empty password retries for ready ServiceUser", func(t *testing.T) {
-		synctest.Test(t, func(t *testing.T) {
-			user := newObjectFromYAML[v1alpha1.ServiceUser](t, yamlServiceUser)
-			user.Generation = 1
-			user.Annotations = map[string]string{
-				processedGenerationAnnotation: "1",
-				instanceIsRunningAnnotation:   "true",
-			}
+	t.Run("Observe with no source secret publishes whatever the API returns, including empty", func(t *testing.T) {
+		user := newObjectFromYAML[v1alpha1.ServiceUser](t, yamlServiceUser)
+		user.Generation = 1
+		user.Annotations = map[string]string{
+			processedGenerationAnnotation: "1",
+			instanceIsRunningAnnotation:   "true",
+		}
 
-			avn := avngen.NewMockClient(t)
-			avn.EXPECT().
-				ServiceGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, mock.Anything).
-				Return(&service.ServiceGetOut{
-					State:       service.ServiceStateTypeRunning,
-					ServiceType: "kafka",
-					Components:  []service.ComponentOut{{Component: "kafka", Host: "host", Port: 9092}},
-				}, nil).Once()
-			avn.EXPECT().
-				ServiceUserGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, user.Name).
-				Return(&service.ServiceUserGetOut{Username: user.Name, Password: ""}, nil).Times(2)
-			avn.EXPECT().
-				ServiceUserGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, user.Name).
-				Return(&service.ServiceUserGetOut{Username: user.Name, Password: "pw"}, nil).Once()
-			avn.EXPECT().
-				ProjectKmsGetCA(mock.Anything, user.Spec.Project).Return("ca", nil).Once()
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, mock.Anything).
+			Return(&service.ServiceGetOut{
+				State:       service.ServiceStateTypeRunning,
+				ServiceType: "kafka",
+				Components:  []service.ComponentOut{{Component: "kafka", Host: "host", Port: 9092}},
+			}, nil).Once()
+		// Observe path does not retry empty-password — single fetch.
+		avn.EXPECT().
+			ServiceUserGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, user.Name).
+			Return(&service.ServiceUserGetOut{Username: user.Name, Password: ""}, nil).Once()
+		avn.EXPECT().
+			ProjectKmsGetCA(mock.Anything, user.Spec.Project).Return("ca", nil).Once()
 
-			r, res := runScenario(t, user, avn)
-			require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+		r, res := runScenario(t, user, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
 
-			secret := &corev1.Secret{}
-			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, secret))
-			require.Equal(t, []byte("pw"), secret.Data["SERVICEUSER_PASSWORD"])
-		})
+		secret := &corev1.Secret{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, secret))
+		require.Equal(t, []byte(""), secret.Data["SERVICEUSER_PASSWORD"])
+	})
+
+	t.Run("Empty password on Observe with source secret heals via Update", func(t *testing.T) {
+		user := newObjectFromYAML[v1alpha1.ServiceUser](t, yamlServiceUser)
+		user.Generation = 1
+		user.Annotations = map[string]string{
+			processedGenerationAnnotation: "1",
+			instanceIsRunningAnnotation:   "true",
+		}
+		user.Spec.ConnInfoSecretSource = &v1alpha1.ConnInfoSecretSource{Name: "src", PasswordKey: "PASSWORD"}
+
+		srcPassword := "external-secret-password"
+		src := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: user.Namespace},
+			Data:       map[string][]byte{"PASSWORD": []byte(srcPassword)},
+		}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, mock.Anything).
+			Return(&service.ServiceGetOut{
+				State:       service.ServiceStateTypeRunning,
+				ServiceType: "kafka",
+				Components:  []service.ComponentOut{{Component: "kafka", Host: "host", Port: 9092}},
+			}, nil).Twice()
+		// Observe sees empty.
+		avn.EXPECT().
+			ServiceUserGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, user.Name).
+			Return(&service.ServiceUserGetOut{Username: user.Name, Password: ""}, nil).Once()
+		// Update pushes the source-secret password.
+		avn.EXPECT().
+			ServiceUserCredentialsModify(mock.Anything, user.Spec.Project, user.Spec.ServiceName, user.Name, mock.MatchedBy(func(in *service.ServiceUserCredentialsModifyIn) bool {
+				return in.NewPassword != nil && *in.NewPassword == srcPassword &&
+					in.Operation == service.ServiceUserCredentialsModifyOperationTypeResetCredentials
+			})).
+			Return(&service.ServiceUserCredentialsModifyOut{}, nil).Once()
+		// Post-Update fetch sees the populated password.
+		avn.EXPECT().
+			ServiceUserGet(mock.Anything, user.Spec.Project, user.Spec.ServiceName, user.Name).
+			Return(&service.ServiceUserGetOut{Username: user.Name, Password: srcPassword}, nil).Once()
+		avn.EXPECT().
+			ProjectKmsGetCA(mock.Anything, user.Spec.Project).Return("ca", nil).Twice()
+
+		r, res := runScenario(t, user, avn, src)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		secret := &corev1.Secret{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: user.Name, Namespace: user.Namespace}, secret))
+		require.Equal(t, []byte(srcPassword), secret.Data["SERVICEUSER_PASSWORD"])
 	})
 
 	t.Run("Repairs managed Valkey ACL drift during periodic reconcile", func(t *testing.T) {

--- a/docs/docs/guides/serviceuser-password-management.md
+++ b/docs/docs/guides/serviceuser-password-management.md
@@ -1,0 +1,26 @@
+# ServiceUser Password Management
+
+The operator manages ServiceUser passwords in one of two modes, chosen by whether `connInfoSecretSource` is set on the CR.
+
+## Mode 1: Generated (no `connInfoSecretSource`)
+
+Aiven generates the password at creation. The operator publishes it to the target secret and never modifies it again. If something else changes the password (e.g. `ALTER USER` directly in the database), the operator has nothing declared to enforce — the target secret will be updated to reflect what Aiven state, with empty value.
+
+## Mode 2: Declared password (`connInfoSecretSource` set)
+
+```yaml
+apiVersion: aiven.io/v1alpha1
+kind: ServiceUser
+metadata:
+  name: my-user
+spec:
+  project: my-project
+  serviceName: my-service
+  connInfoSecretSource:
+    name: my-user-password
+    passwordKey: PASSWORD
+```
+
+The source secret is the source of truth. On every reconcile the operator reads it and pushes the value to Aiven. **Direct password changes in the database will be reverted on the next reconcile cycle.**
+
+To rotate the password, update the source secret. The operator watches it and reconciles automatically.

--- a/docs/docs/resources/serviceuser.md
+++ b/docs/docs/resources/serviceuser.md
@@ -202,12 +202,14 @@ ServiceUserSpec defines the desired state of ServiceUser.
     When this block is present, the operator manages the full access-control scope it contains. See below for [nested schema](#spec.accessControl).
 - [`authSecretRef`](#spec.authSecretRef-property){: name='spec.authSecretRef-property'} (object). Authentication reference to Aiven token in a secret. See below for [nested schema](#spec.authSecretRef).
 - [`authentication`](#spec.authentication-property){: name='spec.authentication-property'} (string, Enum: `caching_sha2_password`, `mysql_native_password`). Authentication details.
-- [`connInfoSecretSource`](#spec.connInfoSecretSource-property){: name='spec.connInfoSecretSource-property'} (object). ConnInfoSecretSource allows specifying an existing secret to read credentials from.
-    The password from this secret will be used to modify the service user credentials.
-    Password must be 8-256 characters long as per Aiven API requirements.
-    This can be used to set passwords for new users or modify passwords for existing users (e.g., avnadmin).
-    The source secret is watched for changes, and reconciliation will be automatically triggered
-    when the secret data is updated. See below for [nested schema](#spec.connInfoSecretSource).
+- [`connInfoSecretSource`](#spec.connInfoSecretSource-property){: name='spec.connInfoSecretSource-property'} (object). ConnInfoSecretSource declares the password the operator should enforce on the user.
+    Direct password changes in the database will be reverted on the next reconcile cycle.
+    To rotate, update the source secret.
+    When unset, the Operator does not manage the password:
+    the target secret holds whatever password the Aiven API returns.
+    If the password is later changed directly in the database,
+    the API returns an empty value and the target secret is emptied on the next reconcile.
+    Password must be 8-256 characters long. See below for [nested schema](#spec.connInfoSecretSource).
 - [`connInfoSecretTarget`](#spec.connInfoSecretTarget-property){: name='spec.connInfoSecretTarget-property'} (object). Secret configuration. See below for [nested schema](#spec.connInfoSecretTarget).
 - [`connInfoSecretTargetDisabled`](#spec.connInfoSecretTargetDisabled-property){: name='spec.connInfoSecretTargetDisabled-property'} (boolean, Immutable). When true, the secret containing connection information will not be created, defaults to false. This field cannot be changed after resource creation.
 
@@ -240,12 +242,14 @@ Authentication reference to Aiven token in a secret.
 
 _Appears on [`spec`](#spec)._
 
-ConnInfoSecretSource allows specifying an existing secret to read credentials from.
-The password from this secret will be used to modify the service user credentials.
-Password must be 8-256 characters long as per Aiven API requirements.
-This can be used to set passwords for new users or modify passwords for existing users (e.g., avnadmin).
-The source secret is watched for changes, and reconciliation will be automatically triggered
-when the secret data is updated.
+ConnInfoSecretSource declares the password the operator should enforce on the user.
+Direct password changes in the database will be reverted on the next reconcile cycle.
+To rotate, update the source secret.
+When unset, the Operator does not manage the password:
+the target secret holds whatever password the Aiven API returns.
+If the password is later changed directly in the database,
+the API returns an empty value and the target secret is emptied on the next reconcile.
+Password must be 8-256 characters long.
 
 **Required**
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
           - installation/uninstalling.md
           - guides/token-management.md
           - guides/deletion-policy.md
+          - guides/serviceuser-password-management.md
           - controllers/reconciler.md
           - controllers/clickhouseuser.md
       - Resources: &crds


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
ServiceUser CRs whose password was changed directly in the database (e.g. `ALTER USER`) got stuck, Aiven's API returns `password: ""` indefinitely, the operator wrapped that as `errPreconditionNotMet`, and the target K8s secret kept serving a stale value.

- `Observe` no longer treats empty password as an error. With `connInfoSecretSource` set, the declared value is pushed back via `Update` → `ResetCredentials` (heals in one cycle). Without a source, the empty value is published as-is.

Resolves: NEX-2559

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
