### PR TITLE
fix(ci): use full check-mode for trunk in workflow_call

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,6 +75,9 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: trunk-io/trunk-action@v1
+        with:
+          # fall back to a full check when invoked via workflow_call
+          check-mode: ${{ inputs.ref != '' && 'all' || '' }}
   codeql_analysis:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
  - The `trunk` job in `.github/workflows/lint.yml` was failing on PRs that produce auto-generated commits (e.g. dependabot bumps that touch `userconfigs/`), with `fatal: ambiguous argument 'HEAD^2'`.
  - `generate.yml` re-invokes `lint.yml` via `workflow_call` with the SHA of the freshly auto-committed change. That commit has only one parent, so `trunk-action`'s autodetected `pull_request` mode blows up

Resolves: NEX-2570

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
