### PR TITLE
chore(kafka_schema): fix transient errors

### DIFF
--- a/controllers/kafkaschema_controller.go
+++ b/controllers/kafkaschema_controller.go
@@ -278,7 +278,11 @@ func (r *KafkaSchemaController) lookupVersionForID(
 		schema.Spec.ServiceName,
 		schema.Spec.SubjectName,
 	)
-	if err != nil {
+	switch {
+	case isNotFound(err):
+		// soft-requeue and retry
+		return 0, fmt.Errorf("%w: subject not visible in registry yet", errPreconditionNotMet)
+	case err != nil:
 		return 0, fmt.Errorf("listing Kafka Schema versions: %w", err)
 	}
 
@@ -291,7 +295,10 @@ func (r *KafkaSchemaController) lookupVersionForID(
 			schema.Spec.SubjectName,
 			v,
 		)
-		if err != nil {
+		switch {
+		case isNotFound(err):
+			return 0, fmt.Errorf("%w: schema version %d not visible in registry yet", errPreconditionNotMet, v)
+		case err != nil:
 			return 0, fmt.Errorf("getting Kafka Schema version %d: %w", v, err)
 		}
 		if got.Id == id {

--- a/controllers/main_test.go
+++ b/controllers/main_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+
+package controllers
+
+import (
+	"os"
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestMain(m *testing.M) {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	os.Exit(m.Run())
+}

--- a/controllers/secret_watch_controller_test.go
+++ b/controllers/secret_watch_controller_test.go
@@ -17,15 +17,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
 func TestSecretWatchController_secretDataChanged(t *testing.T) {
 	t.Parallel()
-
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	scheme := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
@@ -85,8 +82,6 @@ func TestSecretWatchController_secretDataChanged(t *testing.T) {
 
 func TestSecretWatchController_getResourcesWithSecretSource(t *testing.T) {
 	t.Parallel()
-
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	scheme := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
@@ -294,8 +289,6 @@ func TestSecretWatchController_resourceMatchesSecret(t *testing.T) {
 func TestSecretWatchController_triggerReconciliation(t *testing.T) {
 	t.Parallel()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-
 	scheme := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	require.NoError(t, v1alpha1.AddToScheme(scheme))
@@ -379,8 +372,6 @@ func TestSecretWatchController_triggerReconciliation(t *testing.T) {
 // TestAnnotationHandling tests annotation management scenarios
 func TestAnnotationHandling(t *testing.T) {
 	t.Parallel()
-
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	scheme := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- `lookupVersionForID`, classify `404s` as `errPreconditionNotMet` instead of hard errors, producing a soft-requeue with no error condition written to the object

Resolves: NEX-2589


<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
