### PR TITLE
chore(deps): pin all k8s.io modules in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,19 +18,11 @@ updates:
     schedule:
       interval: weekly
     ignore:
-      - dependency-name: k8s.io/api
+      - dependency-name: k8s.io/*
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
-      - dependency-name: k8s.io/apimachinery
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
-      - dependency-name: k8s.io/client-go
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
-      - dependency-name: sigs.k8s.io/controller-runtime
+      - dependency-name: sigs.k8s.io/*
         update-types:
           - version-update:semver-major
           - version-update:semver-minor


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Replace named entries with `k8s.io/*` and `sigs.k8s.io/*` wildcards
- Patch updates still allowed

Resolves: NEX-2616

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
