### PR TITLE
feat(connection_pool): migrated to new reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Change `ServiceIntegrationEndpoint` field `datadog.site`: enum add `us2.ddog-gov.com`
 - Add new 'KafkaQuota' resource to manage quotas for Aiven for Apache Kafka® services.
+- `ConnectionPool` reconciliation: changes to `poolMode` and `poolSize` are now detected and applied on
+  update, and the connection info secret is kept in sync on every reconcile
 
 ## v0.40.0 - 2026-06-05
 

--- a/controllers/connectionpool_controller.go
+++ b/controllers/connectionpool_controller.go
@@ -11,267 +11,212 @@ import (
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/postgresql"
 	"github.com/aiven/go-client-codegen/handler/service"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-// ConnectionPoolReconciler reconciles a ConnectionPool object
-type ConnectionPoolReconciler struct {
-	Controller
-}
-
-func newConnectionPoolReconciler(c Controller) reconcilerType {
-	return &ConnectionPoolReconciler{Controller: c}
-}
-
-// ConnectionPoolHandler handles an Aiven ConnectionPool
-type ConnectionPoolHandler struct{}
-
 //+kubebuilder:rbac:groups=aiven.io,resources=connectionpools,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=aiven.io,resources=connectionpools/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=aiven.io,resources=connectionpools/finalizers,verbs=get;create;update
 
-func (r *ConnectionPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.reconcileInstance(ctx, req, ConnectionPoolHandler{}, &v1alpha1.ConnectionPool{})
+// ConnectionPoolController reconciles a ConnectionPool object.
+type ConnectionPoolController struct {
+	client.Client
+	avnGen avngen.Client
 }
 
-func (r *ConnectionPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.ConnectionPool{}).
-		Owns(&corev1.Secret{}).
-		Complete(r)
+func newConnectionPoolReconciler(c Controller) reconcilerType {
+	return newManagedReconciler(
+		c,
+		func(c Controller, avnGen avngen.Client) AivenController[*v1alpha1.ConnectionPool] {
+			return &ConnectionPoolController{Client: c.Client, avnGen: avnGen}
+		},
+		nil,
+	)
 }
 
-func (h ConnectionPoolHandler) createOrUpdate(ctx context.Context, avnGen avngen.Client, obj client.Object, _ []client.Object) error {
-	connPool, err := h.convert(obj)
+func (r *ConnectionPoolController) Observe(ctx context.Context, cp *v1alpha1.ConnectionPool) (Observation, error) {
+	svc, err := getServiceIfOperational(ctx, r.avnGen, cp.Spec.Project, cp.Spec.ServiceName)
 	if err != nil {
+		return Observation{}, err
+	}
+
+	if !slices.Contains(svc.Databases, cp.Spec.DatabaseName) {
+		return Observation{}, fmt.Errorf("%w: database %q not found", errPreconditionNotMet, cp.Spec.DatabaseName)
+	}
+
+	var poolUser *service.ServiceUserGetOut
+	if cp.Spec.Username != "" {
+		u, err := r.avnGen.ServiceUserGet(ctx, cp.Spec.Project, cp.Spec.ServiceName, cp.Spec.Username)
+		if isNotFound(err) {
+			return Observation{}, fmt.Errorf("%w: service user %q not found", errPreconditionNotMet, cp.Spec.Username)
+		}
+		if err != nil {
+			return Observation{}, fmt.Errorf("cannot get user: %w", err)
+		}
+		poolUser = u
+	}
+
+	pool := findConnectionPool(svc, cp.Name)
+	if pool == nil {
+		return Observation{ResourceExists: false}, nil
+	}
+
+	if !hasLatestGeneration(cp) || !poolMatchesSpec(pool, cp) {
+		return Observation{ResourceExists: true, ResourceUpToDate: false}, nil
+	}
+
+	details, err := r.buildSecretDetails(ctx, cp, svc, pool, poolUser)
+	if err != nil {
+		return Observation{}, err
+	}
+
+	markInstanceRunning(cp)
+
+	return Observation{
+		ResourceExists:   true,
+		ResourceUpToDate: true,
+		SecretDetails:    details,
+	}, nil
+}
+
+func (r *ConnectionPoolController) Create(ctx context.Context, cp *v1alpha1.ConnectionPool) (CreateResult, error) {
+	delete(cp.GetAnnotations(), instanceIsRunningAnnotation)
+
+	req := postgresql.ServicePGBouncerCreateIn{
+		Database: cp.Spec.DatabaseName,
+		PoolMode: cp.Spec.PoolMode,
+		PoolName: cp.Name,
+		PoolSize: NilIfZero(cp.Spec.PoolSize),
+		Username: NilIfZero(cp.Spec.Username),
+	}
+	if err := r.avnGen.ServicePGBouncerCreate(ctx, cp.Spec.Project, cp.Spec.ServiceName, &req); err != nil && !isAlreadyExists(err) {
+		return CreateResult{}, fmt.Errorf("cannot create connection pool: %w", err)
+	}
+
+	details, err := r.connectionDetails(ctx, cp)
+	if err != nil {
+		return CreateResult{}, err
+	}
+
+	markInstanceRunning(cp)
+
+	return CreateResult{SecretDetails: details}, nil
+}
+
+func (r *ConnectionPoolController) Update(ctx context.Context, cp *v1alpha1.ConnectionPool) (UpdateResult, error) {
+	delete(cp.GetAnnotations(), instanceIsRunningAnnotation)
+
+	req := postgresql.ServicePGBouncerUpdateIn{
+		Database: NilIfZero(cp.Spec.DatabaseName),
+		PoolMode: cp.Spec.PoolMode,
+		PoolSize: NilIfZero(cp.Spec.PoolSize),
+		Username: NilIfZero(cp.Spec.Username),
+	}
+	if err := r.avnGen.ServicePGBouncerUpdate(ctx, cp.Spec.Project, cp.Spec.ServiceName, cp.Name, &req); err != nil {
+		return UpdateResult{}, fmt.Errorf("cannot update connection pool: %w", err)
+	}
+
+	details, err := r.connectionDetails(ctx, cp)
+	if err != nil {
+		return UpdateResult{}, err
+	}
+
+	markInstanceRunning(cp)
+
+	return UpdateResult{SecretDetails: details}, nil
+}
+
+func (r *ConnectionPoolController) Delete(ctx context.Context, cp *v1alpha1.ConnectionPool) error {
+	if err := r.avnGen.ServicePGBouncerDelete(ctx, cp.Spec.Project, cp.Spec.ServiceName, cp.Name); err != nil && !isNotFound(err) {
 		return err
 	}
+	return nil
+}
 
-	// check if the connection pool already exists
-	s, err := avnGen.ServiceGet(ctx, connPool.Spec.Project, connPool.Spec.ServiceName)
+// connectionDetails fetches the service and builds the connection secret for the pool.
+func (r *ConnectionPoolController) connectionDetails(ctx context.Context, cp *v1alpha1.ConnectionPool) (SecretDetails, error) {
+	svc, err := getServiceIfOperational(ctx, r.avnGen, cp.Spec.Project, cp.Spec.ServiceName)
 	if err != nil {
-		return fmt.Errorf("cannot get service: %w", err)
+		return nil, err
 	}
 
-	var exists bool
-	for _, connP := range s.ConnectionPools {
-		if connP.PoolName == connPool.Name {
-			exists = true
-			break
-		}
+	pool := findConnectionPool(svc, cp.Name)
+	if pool == nil {
+		return nil, fmt.Errorf("%w: connection pool %q not yet available", errPreconditionNotMet, cp.Name)
 	}
 
-	if !exists {
-		req := postgresql.ServicePGBouncerCreateIn{
-			Database: connPool.Spec.DatabaseName,
-			PoolMode: connPool.Spec.PoolMode,
-			PoolName: connPool.Name,
-			PoolSize: NilIfZero(connPool.Spec.PoolSize),
-			Username: NilIfZero(connPool.Spec.Username),
+	var poolUser *service.ServiceUserGetOut
+	if cp.Spec.Username != "" {
+		u, err := r.avnGen.ServiceUserGet(ctx, cp.Spec.Project, cp.Spec.ServiceName, cp.Spec.Username)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get user: %w", err)
 		}
+		poolUser = u
+	}
 
-		if err = avnGen.ServicePGBouncerCreate(ctx, connPool.Spec.Project, connPool.Spec.ServiceName, &req); err != nil && !isAlreadyExists(err) {
-			return fmt.Errorf("cannot create connection pool: %w", err)
-		}
-	} else {
-		req := postgresql.ServicePGBouncerUpdateIn{
-			Database: NilIfZero(connPool.Spec.DatabaseName),
-			PoolMode: connPool.Spec.PoolMode,
-			PoolSize: NilIfZero(connPool.Spec.PoolSize),
-			Username: NilIfZero(connPool.Spec.Username),
-		}
+	return r.buildSecretDetails(ctx, cp, svc, pool, poolUser)
+}
 
-		if err = avnGen.ServicePGBouncerUpdate(ctx, connPool.Spec.Project, connPool.Spec.ServiceName, connPool.Name, &req); err != nil {
-			return fmt.Errorf("cannot update connection pool: %w", err)
+// buildSecretDetails assembles the connection secret. poolUser must be non-nil when spec.Username is set.
+func (r *ConnectionPoolController) buildSecretDetails(ctx context.Context, cp *v1alpha1.ConnectionPool, svc *service.ServiceGetOut, pool *service.ConnectionPoolOut, poolUser *service.ServiceUserGetOut) (SecretDetails, error) {
+	cert, err := r.avnGen.ProjectKmsGetCA(ctx, cp.Spec.Project)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve project CA certificate: %w", err)
+	}
+
+	// The pool comes with its own port.
+	poolURI, err := url.Parse(pool.ConnectionUri)
+	if err != nil {
+		return nil, fmt.Errorf("can't parse ConnectionPool URI: %w", err)
+	}
+
+	user := svc.ServiceUriParams["user"]
+	password := svc.ServiceUriParams["password"]
+	if cp.Spec.Username != "" && poolUser != nil {
+		user = fromAnyPointer(pool.Username)
+		password = poolUser.Password
+	}
+
+	prefix := getSecretPrefix(cp)
+	return SecretDetails{
+		prefix + "NAME":         cp.Name,
+		prefix + "HOST":         svc.ServiceUriParams["host"],
+		prefix + "PORT":         poolURI.Port(),
+		prefix + "DATABASE":     pool.Database,
+		prefix + "USER":         user,
+		prefix + "PASSWORD":     password,
+		prefix + "SSLMODE":      svc.ServiceUriParams["sslmode"],
+		prefix + "DATABASE_URI": pool.ConnectionUri,
+		prefix + "CA_CERT":      cert,
+		// todo: remove in future releases
+		"PGHOST":       svc.ServiceUriParams["host"],
+		"PGPORT":       poolURI.Port(),
+		"PGDATABASE":   pool.Database,
+		"PGUSER":       user,
+		"PGPASSWORD":   password,
+		"PGSSLMODE":    svc.ServiceUriParams["sslmode"],
+		"DATABASE_URI": pool.ConnectionUri,
+	}, nil
+}
+
+func findConnectionPool(svc *service.ServiceGetOut, name string) *service.ConnectionPoolOut {
+	for i := range svc.ConnectionPools {
+		if svc.ConnectionPools[i].PoolName == name {
+			return &svc.ConnectionPools[i]
 		}
 	}
 	return nil
 }
 
-func (h ConnectionPoolHandler) delete(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {
-	cp, err := h.convert(obj)
-	if err != nil {
-		return false, err
+// poolMatchesSpec reports whether the remote pool matches the mutable spec fields.
+func poolMatchesSpec(remote *service.ConnectionPoolOut, cp *v1alpha1.ConnectionPool) bool {
+	if cp.Spec.PoolMode != "" && string(remote.PoolMode) != string(cp.Spec.PoolMode) {
+		return false
 	}
-
-	if err = avnGen.ServicePGBouncerDelete(ctx, cp.Spec.Project, cp.Spec.ServiceName, cp.Name); err != nil && !isNotFound(err) {
-		return false, err
+	if cp.Spec.PoolSize != 0 && remote.PoolSize != cp.Spec.PoolSize {
+		return false
 	}
-
-	return true, nil
-}
-
-func (h ConnectionPoolHandler) get(ctx context.Context, avnGen avngen.Client, obj client.Object) (*corev1.Secret, error) {
-	connPool, err := h.convert(obj)
-	if err != nil {
-		return nil, err
-	}
-
-	// Search the connection pool
-	var cp *service.ConnectionPoolOut
-	serviceList, err := avnGen.ServiceGet(ctx, connPool.Spec.Project, connPool.Spec.ServiceName)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get service: %w", err)
-	}
-
-	for _, connP := range serviceList.ConnectionPools {
-		if connP.PoolName == connPool.Name {
-			cp = &connP
-		}
-	}
-
-	if cp == nil {
-		return nil, fmt.Errorf("connection pool %q not found", connPool.Name)
-	}
-
-	cert, err := avnGen.ProjectKmsGetCA(ctx, connPool.Spec.Project)
-	if err != nil {
-		return nil, fmt.Errorf("cannot retrieve project CA certificate: %w", err)
-	}
-
-	// The pool comes with its own port
-	poolURI, err := url.Parse(cp.ConnectionUri)
-	if err != nil {
-		return nil, fmt.Errorf("can't parse ConnectionPool URI: %w", err)
-	}
-
-	s, err := avnGen.ServiceGet(ctx, connPool.Spec.Project, connPool.Spec.ServiceName, service.ServiceGetIncludeSecrets(true))
-	if err != nil {
-		return nil, fmt.Errorf("cannot get service: %w", err)
-	}
-
-	metav1.SetMetaDataAnnotation(&connPool.ObjectMeta, instanceIsRunningAnnotation, "true")
-
-	meta.SetStatusCondition(&connPool.Status.Conditions,
-		getRunningCondition(metav1.ConditionTrue, "CheckRunning",
-			"Instance is running on Aiven side"))
-
-	if len(connPool.Spec.Username) == 0 {
-		prefix := getSecretPrefix(connPool)
-		stringData := map[string]string{
-			prefix + "NAME":         connPool.Name,
-			prefix + "HOST":         s.ServiceUriParams["host"],
-			prefix + "PORT":         poolURI.Port(),
-			prefix + "DATABASE":     cp.Database,
-			prefix + "USER":         s.ServiceUriParams["user"],
-			prefix + "PASSWORD":     s.ServiceUriParams["password"],
-			prefix + "SSLMODE":      s.ServiceUriParams["sslmode"],
-			prefix + "DATABASE_URI": cp.ConnectionUri,
-			prefix + "CA_CERT":      cert,
-			// todo: remove in future releases
-			"PGHOST":       s.ServiceUriParams["host"],
-			"PGPORT":       poolURI.Port(),
-			"PGDATABASE":   cp.Database,
-			"PGUSER":       s.ServiceUriParams["user"],
-			"PGPASSWORD":   s.ServiceUriParams["password"],
-			"PGSSLMODE":    s.ServiceUriParams["sslmode"],
-			"DATABASE_URI": cp.ConnectionUri,
-		}
-
-		return newSecret(connPool, stringData, false), nil
-	}
-
-	u, err := avnGen.ServiceUserGet(ctx, connPool.Spec.Project, connPool.Spec.ServiceName, connPool.Spec.Username)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get user: %w", err)
-	}
-
-	prefix := getSecretPrefix(connPool)
-	stringData := map[string]string{
-		prefix + "NAME":     connPool.Name,
-		prefix + "HOST":     s.ServiceUriParams["host"],
-		prefix + "PORT":     poolURI.Port(),
-		prefix + "DATABASE": cp.Database,
-		prefix + "USER": func() string {
-			if cp.Username != nil {
-				return *cp.Username
-			}
-
-			// this should never happen, but we have to handle this case anyway
-			// this behaviour compatible with the previous implementation with aiven.Client
-			return ""
-		}(),
-		prefix + "PASSWORD":     u.Password,
-		prefix + "SSLMODE":      s.ServiceUriParams["sslmode"],
-		prefix + "DATABASE_URI": cp.ConnectionUri,
-		prefix + "CA_CERT":      cert,
-		// todo: remove in future releases
-		"PGHOST":     s.ServiceUriParams["host"],
-		"PGPORT":     poolURI.Port(),
-		"PGDATABASE": cp.Database,
-		"PGUSER": func() string {
-			if cp.Username != nil {
-				return *cp.Username
-			}
-
-			// this should never happen, but we have to handle this case anyway
-			// this behaviour compatible with the previous implementation with aiven.Client
-			return ""
-		}(),
-		"PGPASSWORD":   u.Password,
-		"PGSSLMODE":    s.ServiceUriParams["sslmode"],
-		"DATABASE_URI": cp.ConnectionUri,
-	}
-	return newSecret(connPool, stringData, false), nil
-}
-
-func (h ConnectionPoolHandler) checkPreconditions(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {
-	cp, err := h.convert(obj)
-	if err != nil {
-		return false, err
-	}
-
-	meta.SetStatusCondition(&cp.Status.Conditions,
-		getInitializedCondition("Preconditions", "Checking preconditions"))
-
-	isRunning, err := checkServiceIsOperational(ctx, avnGen, cp.Spec.Project, cp.Spec.ServiceName)
-	if err != nil {
-		return false, err
-	}
-
-	if !isRunning {
-		return false, nil
-	}
-
-	// check if the database exists
-	var exists bool
-	dbList, err := avnGen.ServiceGet(ctx, cp.Spec.Project, cp.Spec.ServiceName)
-	if err != nil {
-		return false, err
-	}
-
-	if slices.Contains(dbList.Databases, cp.Spec.DatabaseName) {
-		exists = true
-	}
-
-	if !exists {
-		return false, nil
-	}
-
-	if cp.Spec.Username != "" {
-		_, err = avnGen.ServiceUserGet(ctx, cp.Spec.Project, cp.Spec.ServiceName, cp.Spec.Username)
-		if isNotFound(err) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-	}
-
-	return true, nil
-}
-
-func (h ConnectionPoolHandler) convert(i client.Object) (*v1alpha1.ConnectionPool, error) {
-	cp, ok := i.(*v1alpha1.ConnectionPool)
-	if !ok {
-		return nil, fmt.Errorf("cannot convert object to ConnectionPool")
-	}
-
-	return cp, nil
+	return true
 }

--- a/controllers/connectionpool_controller_test.go
+++ b/controllers/connectionpool_controller_test.go
@@ -1,0 +1,407 @@
+package controllers
+
+import (
+	"testing"
+
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/postgresql"
+	"github.com/aiven/go-client-codegen/handler/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aiven/aiven-operator/api/v1alpha1"
+)
+
+const yamlConnectionPool = `
+apiVersion: aiven.io/v1alpha1
+kind: ConnectionPool
+metadata:
+  name: test-pool
+  namespace: default
+spec:
+  project: test-project
+  serviceName: test-service
+  databaseName: test-db
+  poolMode: transaction
+  poolSize: 25
+`
+
+func TestConnectionPoolReconciler(t *testing.T) {
+	t.Parallel()
+
+	runScenarioErr := func(t *testing.T, cp *v1alpha1.ConnectionPool, avn avngen.Client) (*Reconciler[*v1alpha1.ConnectionPool], ctrlruntime.Result, error) {
+		t.Helper()
+
+		scheme := runtime.NewScheme()
+		require.NoError(t, clientgoscheme.AddToScheme(scheme))
+		require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+		r := newConnectionPoolReconciler(Controller{
+			Client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&v1alpha1.ConnectionPool{}).
+				WithObjects([]client.Object{cp}...).
+				Build(),
+			Scheme:       scheme,
+			Recorder:     record.NewFakeRecorder(10),
+			DefaultToken: "test-token",
+			PollInterval: testPollInterval,
+		}).(*Reconciler[*v1alpha1.ConnectionPool])
+		r.newAivenGeneratedClient = func(_, _, _ string) (avngen.Client, error) {
+			return avn, nil
+		}
+
+		res, err := r.Reconcile(t.Context(), ctrlruntime.Request{
+			NamespacedName: types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace},
+		})
+		return r, res, err
+	}
+
+	runScenario := func(t *testing.T, cp *v1alpha1.ConnectionPool, avn avngen.Client) (*Reconciler[*v1alpha1.ConnectionPool], ctrlruntime.Result) {
+		t.Helper()
+
+		r, res, err := runScenarioErr(t, cp, avn)
+		require.NoError(t, err)
+		return r, res
+	}
+
+	// serviceGetOut returns a running PG service exposing the db and (optionally) the pool.
+	serviceGetOut := func(cp *v1alpha1.ConnectionPool, pools ...service.ConnectionPoolOut) *service.ServiceGetOut {
+		return &service.ServiceGetOut{
+			State:     service.ServiceStateTypeRunning,
+			Databases: []string{cp.Spec.DatabaseName},
+			ServiceUriParams: map[string]string{
+				"host":     "pg.example.com",
+				"user":     "avnadmin",
+				"password": "svc-pass",
+				"sslmode":  "require",
+			},
+			ConnectionPools: pools,
+		}
+	}
+
+	t.Run("Requeues when service preconditions aren't met", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(nil, newAivenError(404, "service not found")).Once()
+
+		r, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.ConnectionPool{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, got))
+		require.Contains(t, got.Finalizers, instanceDeletionFinalizer)
+	})
+
+	t.Run("Requeues when target database isn't present yet", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(&service.ServiceGetOut{State: service.ServiceStateTypeRunning}, nil).Once()
+
+		_, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+	})
+
+	t.Run("Creates connection pool and publishes secret", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+
+		pool := service.ConnectionPoolOut{
+			PoolName:      cp.Name,
+			Database:      cp.Spec.DatabaseName,
+			PoolMode:      service.PoolModeType(cp.Spec.PoolMode),
+			PoolSize:      cp.Spec.PoolSize,
+			ConnectionUri: "postgres://avnadmin:svc-pass@pg.example.com:24655/test-db?sslmode=require",
+		}
+
+		avn := avngen.NewMockClient(t)
+		// Observe: pool doesn't exist yet -> Create.
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(serviceGetOut(cp), nil).Once()
+		avn.EXPECT().
+			ServicePGBouncerCreate(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.MatchedBy(func(in *postgresql.ServicePGBouncerCreateIn) bool {
+				return in.PoolName == cp.Name &&
+					in.Database == cp.Spec.DatabaseName &&
+					in.PoolSize != nil && *in.PoolSize == cp.Spec.PoolSize &&
+					string(in.PoolMode) == string(cp.Spec.PoolMode)
+			})).
+			Return(nil).Once()
+		// Create re-fetches the service to build connection details, now the pool is present.
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(serviceGetOut(cp, pool), nil).Once()
+		avn.EXPECT().
+			ProjectKmsGetCA(mock.Anything, cp.Spec.Project).Return("ca-cert", nil).Once()
+
+		r, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.ConnectionPool{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, got))
+		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+		require.Contains(t, got.Finalizers, instanceDeletionFinalizer)
+
+		// Secret is published in the same reconcile as create, not deferred to a later pass.
+		secret := &corev1.Secret{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, secret))
+		require.Equal(t, []byte("pg.example.com"), secret.Data["CONNECTIONPOOL_HOST"])
+		require.Equal(t, []byte("svc-pass"), secret.Data["CONNECTIONPOOL_PASSWORD"])
+		require.Equal(t, []byte("ca-cert"), secret.Data["CONNECTIONPOOL_CA_CERT"])
+	})
+
+	t.Run("Publishes secret and marks running when pool is up to date", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+		cp.Annotations = map[string]string{
+			processedGenerationAnnotation: "1",
+			instanceIsRunningAnnotation:   "true",
+		}
+
+		pool := service.ConnectionPoolOut{
+			PoolName:      cp.Name,
+			Database:      cp.Spec.DatabaseName,
+			PoolMode:      service.PoolModeType(cp.Spec.PoolMode),
+			PoolSize:      cp.Spec.PoolSize,
+			ConnectionUri: "postgres://avnadmin:svc-pass@pg.example.com:24655/test-db?sslmode=require",
+		}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(serviceGetOut(cp, pool), nil).Once()
+		avn.EXPECT().
+			ProjectKmsGetCA(mock.Anything, cp.Spec.Project).Return("ca-cert", nil).Once()
+
+		r, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.ConnectionPool{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, got))
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
+
+		secret := &corev1.Secret{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, secret))
+		require.Equal(t, []byte("pg.example.com"), secret.Data["CONNECTIONPOOL_HOST"])
+		require.Equal(t, []byte("24655"), secret.Data["CONNECTIONPOOL_PORT"])
+		require.Equal(t, []byte("test-db"), secret.Data["CONNECTIONPOOL_DATABASE"])
+		require.Equal(t, []byte("svc-pass"), secret.Data["CONNECTIONPOOL_PASSWORD"])
+		require.Equal(t, []byte("ca-cert"), secret.Data["CONNECTIONPOOL_CA_CERT"])
+		// Legacy unprefixed keys remain for backwards compatibility.
+		require.Equal(t, []byte("pg.example.com"), secret.Data["PGHOST"])
+	})
+
+	t.Run("Publishes pool user credentials when spec sets a username", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+		cp.Spec.Username = "pool-user"
+		cp.Annotations = map[string]string{
+			processedGenerationAnnotation: "1",
+			instanceIsRunningAnnotation:   "true",
+		}
+
+		poolUser := "pool-user"
+		pool := service.ConnectionPoolOut{
+			PoolName:      cp.Name,
+			Database:      cp.Spec.DatabaseName,
+			PoolMode:      service.PoolModeType(cp.Spec.PoolMode),
+			PoolSize:      cp.Spec.PoolSize,
+			Username:      &poolUser,
+			ConnectionUri: "postgres://pool-user:user-pass@pg.example.com:24655/test-db?sslmode=require",
+		}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(serviceGetOut(cp, pool), nil).Once()
+		// Observe fetches the user once and threads it through to buildSecretDetails.
+		avn.EXPECT().
+			ServiceUserGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, cp.Spec.Username).
+			Return(&service.ServiceUserGetOut{Username: poolUser, Password: "user-pass"}, nil).Once()
+		avn.EXPECT().
+			ProjectKmsGetCA(mock.Anything, cp.Spec.Project).Return("ca-cert", nil).Once()
+
+		r, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		secret := &corev1.Secret{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, secret))
+		// USER comes from the pool's username, PASSWORD from the service user lookup.
+		require.Equal(t, []byte("pool-user"), secret.Data["CONNECTIONPOOL_USER"])
+		require.Equal(t, []byte("user-pass"), secret.Data["CONNECTIONPOOL_PASSWORD"])
+		require.Equal(t, []byte("pool-user"), secret.Data["PGUSER"])
+		require.Equal(t, []byte("user-pass"), secret.Data["PGPASSWORD"])
+		require.Equal(t, []byte("ca-cert"), secret.Data["CONNECTIONPOOL_CA_CERT"])
+	})
+
+	t.Run("Updates connection pool when spec drifts", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+		cp.Annotations = map[string]string{
+			processedGenerationAnnotation: "1",
+			instanceIsRunningAnnotation:   "true",
+		}
+
+		// Remote pool has a different size than the spec, so Observe returns not-up-to-date.
+		pool := service.ConnectionPoolOut{
+			PoolName:      cp.Name,
+			Database:      cp.Spec.DatabaseName,
+			PoolMode:      service.PoolModeType(cp.Spec.PoolMode),
+			PoolSize:      10,
+			ConnectionUri: "postgres://avnadmin:svc-pass@pg.example.com:24655/test-db?sslmode=require",
+		}
+
+		// Pool with the spec's size, returned after the update so connection details can be built.
+		updatedPool := pool
+		updatedPool.PoolSize = cp.Spec.PoolSize
+
+		avn := avngen.NewMockClient(t)
+		// Observe sees drift (PoolSize 10 != 25) -> Update. No CA fetch on this branch.
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(serviceGetOut(cp, pool), nil).Once()
+		avn.EXPECT().
+			ServicePGBouncerUpdate(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, cp.Name, mock.MatchedBy(func(in *postgresql.ServicePGBouncerUpdateIn) bool {
+				return in.PoolSize != nil && *in.PoolSize == cp.Spec.PoolSize
+			})).
+			Return(nil).Once()
+		// Update re-fetches the service to build connection details.
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(serviceGetOut(cp, updatedPool), nil).Once()
+		avn.EXPECT().
+			ProjectKmsGetCA(mock.Anything, cp.Spec.Project).Return("ca-cert", nil).Once()
+
+		r, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		secret := &corev1.Secret{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, secret))
+		require.Equal(t, []byte("ca-cert"), secret.Data["CONNECTIONPOOL_CA_CERT"])
+	})
+
+	t.Run("Updates connection pool when pool mode drifts", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+		cp.Annotations = map[string]string{
+			processedGenerationAnnotation: "1",
+			instanceIsRunningAnnotation:   "true",
+		}
+
+		// Remote pool has a different mode than the spec, so Observe returns not-up-to-date.
+		pool := service.ConnectionPoolOut{
+			PoolName:      cp.Name,
+			Database:      cp.Spec.DatabaseName,
+			PoolMode:      service.PoolModeTypeSession,
+			PoolSize:      cp.Spec.PoolSize,
+			ConnectionUri: "postgres://avnadmin:svc-pass@pg.example.com:24655/test-db?sslmode=require",
+		}
+
+		// Pool with the spec's mode, returned after the update so connection details can be built.
+		updatedPool := pool
+		updatedPool.PoolMode = service.PoolModeType(cp.Spec.PoolMode)
+
+		avn := avngen.NewMockClient(t)
+		// Observe sees drift (session != transaction) -> Update. No CA fetch on this branch.
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(serviceGetOut(cp, pool), nil).Once()
+		avn.EXPECT().
+			ServicePGBouncerUpdate(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, cp.Name, mock.MatchedBy(func(in *postgresql.ServicePGBouncerUpdateIn) bool {
+				return string(in.PoolMode) == string(cp.Spec.PoolMode)
+			})).
+			Return(nil).Once()
+		// Update re-fetches the service to build connection details.
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(serviceGetOut(cp, updatedPool), nil).Once()
+		avn.EXPECT().
+			ProjectKmsGetCA(mock.Anything, cp.Spec.Project).Return("ca-cert", nil).Once()
+
+		r, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		secret := &corev1.Secret{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, secret))
+		require.Equal(t, []byte("ca-cert"), secret.Data["CONNECTIONPOOL_CA_CERT"])
+	})
+
+	t.Run("Deletes connection pool and removes finalizer on deletion", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+		cp.Finalizers = []string{instanceDeletionFinalizer}
+		now := metav1.Now()
+		cp.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServicePGBouncerDelete(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, cp.Name).
+			Return(nil).Once()
+
+		r, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		got := &v1alpha1.ConnectionPool{}
+		err := r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+
+	t.Run("Requeues when the pool's service user isn't present yet", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+		cp.Spec.Username = "pool-user"
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, mock.Anything).
+			Return(serviceGetOut(cp), nil).Once()
+		// The referenced service user doesn't exist yet -> soft requeue, not a hard error.
+		avn.EXPECT().
+			ServiceUserGet(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, cp.Spec.Username).
+			Return(nil, newAivenError(404, "user not found")).Once()
+
+		_, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+	})
+
+	t.Run("Removes finalizer when the pool is already gone at Aiven", func(t *testing.T) {
+		cp := newObjectFromYAML[v1alpha1.ConnectionPool](t, yamlConnectionPool)
+		cp.Generation = 1
+		cp.Finalizers = []string{instanceDeletionFinalizer}
+		now := metav1.Now()
+		cp.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		// Delete tolerates a 404 from Aiven (pool already deleted) and still removes the finalizer.
+		avn.EXPECT().
+			ServicePGBouncerDelete(mock.Anything, cp.Spec.Project, cp.Spec.ServiceName, cp.Name).
+			Return(newAivenError(404, "pool not found")).Once()
+
+		r, res := runScenario(t, cp, avn)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		got := &v1alpha1.ConnectionPool{}
+		err := r.Get(t.Context(), types.NamespacedName{Name: cp.Name, Namespace: cp.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+}


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- migrated `connection_pool` controller to the new reconciler

Resolves: NEX-2611

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
