### PR TITLE
fix(ci): restrict /test command to non-fork PRs

### DIFF
--- a/.github/workflows/pr-test-command.yml
+++ b/.github/workflows/pr-test-command.yml
@@ -41,6 +41,19 @@ jobs:
               pull_number: context.issue.number
             });
 
+            // Refuse /test on fork PRs (head.repo is null when the fork was deleted)
+            const isFork = pr.data.head.repo?.full_name !== pr.data.base.repo.full_name;
+            if (isFork) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: '⛔ `/test` is not allowed on fork PRs'
+              });
+              core.setFailed('Refusing to run /test on a fork PR (untrusted head ref).');
+              return;
+            }
+
             core.setOutput('number', pr.data.number);
             core.setOutput('sha', pr.data.head.sha);
 


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- restrict `/test` command to non-fork PRs to prevent production token exposure
- prevent the issue described in [this PR](https://github.com/aiven/aiven-operator/pull/1212)

Resolves: NEX-2653

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
