### PR TITLE
feat(serviceintegration): migrate to new reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Change `ServiceIntegrationEndpoint` reconciliation to the managed reconciler: the resource now adopts a
+  pre-existing endpoint matching its `endpointName` and `endpointType`.
 - Change `ServiceIntegrationEndpoint` field `datadog.site`: enum add `us2.ddog-gov.com`
 - Add new 'KafkaQuota' resource to manage quotas for Aiven for Apache Kafka® services.
 - Change `ClickhouseDatabase` reconciliation to the managed reconciler: the resource now registers a

--- a/controllers/serviceintegrationendpoint_controller.go
+++ b/controllers/serviceintegrationendpoint_controller.go
@@ -9,153 +9,174 @@ import (
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/service"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-// ServiceIntegrationEndpointReconciler reconciles a ServiceIntegrationEndpoint object
-type ServiceIntegrationEndpointReconciler struct {
-	Controller
-}
-
 func newServiceIntegrationEndpointReconciler(c Controller) reconcilerType {
-	return &ServiceIntegrationEndpointReconciler{Controller: c}
+	return newManagedReconciler(
+		c,
+		func(c Controller, avnGen avngen.Client) AivenController[*v1alpha1.ServiceIntegrationEndpoint] {
+			return &ServiceIntegrationEndpointController{
+				Client: c.Client,
+				avnGen: avnGen,
+			}
+		},
+		nil,
+	)
 }
 
 //+kubebuilder:rbac:groups=aiven.io,resources=serviceintegrationendpoints,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=aiven.io,resources=serviceintegrationendpoints/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=aiven.io,resources=serviceintegrationendpoints/finalizers,verbs=get;create;update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-func (r *ServiceIntegrationEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.reconcileInstance(ctx, req, ServiceIntegrationEndpointHandler{}, &v1alpha1.ServiceIntegrationEndpoint{})
+// ServiceIntegrationEndpointController reconciles a ServiceIntegrationEndpoint object
+type ServiceIntegrationEndpointController struct {
+	client.Client
+	avnGen avngen.Client
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *ServiceIntegrationEndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.ServiceIntegrationEndpoint{}).
-		Complete(r)
-}
+func (r *ServiceIntegrationEndpointController) Observe(ctx context.Context, si *v1alpha1.ServiceIntegrationEndpoint) (Observation, error) {
+	if si.Status.ID == "" {
+		// Status.ID may be empty because the endpoint was never created, or a prior Create status write was lost.
+		existing, err := r.findEndpoint(ctx, si)
+		if err != nil {
+			return Observation{}, err
+		}
+		if existing == nil {
+			return Observation{ResourceExists: false}, nil
+		}
 
-type ServiceIntegrationEndpointHandler struct{}
+		// adoption
+		si.Status.ID = existing.EndpointId
+		return Observation{
+			ResourceExists:   true,
+			ResourceUpToDate: false,
+		}, nil
+	}
 
-func (h ServiceIntegrationEndpointHandler) createOrUpdate(ctx context.Context, avnGen avngen.Client, obj client.Object, _ []client.Object) error {
-	si, err := h.convert(obj)
+	_, err := r.avnGen.ServiceIntegrationEndpointGet(ctx, si.Spec.Project, si.Status.ID)
 	if err != nil {
-		return err
+		if isNotFound(err) {
+			si.Status.ID = ""
+			return Observation{ResourceExists: false}, nil
+		}
+		return Observation{}, fmt.Errorf("getting service integration endpoint: %w", err)
+	}
+
+	markInstanceRunning(si)
+
+	return Observation{
+		ResourceExists:   true,
+		ResourceUpToDate: IsReadyToUse(si),
+	}, nil
+}
+
+func (r *ServiceIntegrationEndpointController) Create(ctx context.Context, si *v1alpha1.ServiceIntegrationEndpoint) (CreateResult, error) {
+	delete(si.GetAnnotations(), instanceIsRunningAnnotation)
+
+	userConfig, err := si.GetUserConfig()
+	if err != nil {
+		return CreateResult{}, err
+	}
+
+	userConfigMap, err := CreateUserConfiguration(userConfig)
+	if err != nil {
+		return CreateResult{}, err
+	}
+
+	endpoint, err := r.avnGen.ServiceIntegrationEndpointCreate(
+		ctx,
+		si.Spec.Project,
+		&service.ServiceIntegrationEndpointCreateIn{
+			EndpointName: si.Spec.EndpointName,
+			EndpointType: service.EndpointType(si.Spec.EndpointType),
+			UserConfig:   userConfigMap,
+		},
+	)
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("creating service integration endpoint: %w", err)
+	}
+
+	si.Status.ID = endpoint.EndpointId
+	markInstanceRunning(si)
+
+	return CreateResult{}, nil
+}
+
+func (r *ServiceIntegrationEndpointController) Update(ctx context.Context, si *v1alpha1.ServiceIntegrationEndpoint) (UpdateResult, error) {
+	delete(si.GetAnnotations(), instanceIsRunningAnnotation)
+
+	if !si.HasUserConfig() {
+		markInstanceRunning(si)
+		return UpdateResult{}, nil
 	}
 
 	userConfig, err := si.GetUserConfig()
 	if err != nil {
-		return err
+		return UpdateResult{}, err
 	}
 
-	if si.Status.ID == "" {
-		userConfigMap, err := CreateUserConfiguration(userConfig)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := avnGen.ServiceIntegrationEndpointCreate(
-			ctx,
-			si.Spec.Project,
-			&service.ServiceIntegrationEndpointCreateIn{
-				EndpointName: si.Spec.EndpointName,
-				EndpointType: service.EndpointType(si.Spec.EndpointType),
-				UserConfig:   userConfigMap,
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("cannot createOrUpdate service integration: %w", err)
-		}
-
-		si.Status.ID = endpoint.EndpointId
-	} else {
-		if !si.HasUserConfig() {
-			return nil
-		}
-
-		userConfigMap, err := UpdateUserConfiguration(userConfig)
-		if err != nil {
-			return err
-		}
-
-		updatedIntegration, err := avnGen.ServiceIntegrationEndpointUpdate(
-			ctx,
-			si.Spec.Project,
-			si.Status.ID,
-			&service.ServiceIntegrationEndpointUpdateIn{
-				UserConfig: userConfigMap,
-			},
-		)
-		if err != nil {
-			if strings.Contains(strings.ToLower(err.Error()), "user config not changed") {
-				return nil
-			}
-			return err
-		}
-		si.Status.ID = updatedIntegration.EndpointId
+	userConfigMap, err := UpdateUserConfiguration(userConfig)
+	if err != nil {
+		return UpdateResult{}, err
 	}
 
-	return nil
+	updatedEndpoint, err := r.avnGen.ServiceIntegrationEndpointUpdate(
+		ctx,
+		si.Spec.Project,
+		si.Status.ID,
+		&service.ServiceIntegrationEndpointUpdateIn{
+			UserConfig: userConfigMap,
+		},
+	)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "user config not changed") {
+			markInstanceRunning(si)
+			return UpdateResult{}, nil
+		}
+		return UpdateResult{}, err
+	}
+
+	if updatedEndpoint != nil && updatedEndpoint.EndpointId != "" {
+		si.Status.ID = updatedEndpoint.EndpointId
+	}
+	markInstanceRunning(si)
+
+	return UpdateResult{}, nil
 }
 
-func (h ServiceIntegrationEndpointHandler) delete(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {
-	si, err := h.convert(obj)
-	if err != nil {
-		return false, err
-	}
-
+func (r *ServiceIntegrationEndpointController) Delete(ctx context.Context, si *v1alpha1.ServiceIntegrationEndpoint) error {
 	if si.Status.ID == "" {
-		return true, nil
+		return nil
 	}
 
-	err = avnGen.ServiceIntegrationEndpointDelete(ctx, si.Spec.Project, si.Status.ID)
+	err := r.avnGen.ServiceIntegrationEndpointDelete(ctx, si.Spec.Project, si.Status.ID)
 	if err != nil && !isNotFound(err) {
-		return false, fmt.Errorf("aiven client delete service integration endpoint error: %w", err)
+		return fmt.Errorf("deleting service integration endpoint: %w", err)
 	}
-
-	return true, nil
-}
-
-func (h ServiceIntegrationEndpointHandler) observe(_ context.Context, _ avngen.Client, obj v1alpha1.AivenManagedObject) error {
-	si, err := h.convert(obj)
-	if err != nil {
-		return err
-	}
-
-	meta.SetStatusCondition(&si.Status.Conditions,
-		getRunningCondition(metav1.ConditionTrue, "CheckRunning",
-			"Instance is running on Aiven side"))
-
-	metav1.SetMetaDataAnnotation(&si.ObjectMeta, instanceIsRunningAnnotation, "true")
 
 	return nil
 }
 
-func (h ServiceIntegrationEndpointHandler) checkPreconditions(_ context.Context, _ avngen.Client, obj client.Object) (bool, error) {
-	si, err := h.convert(obj)
+// findEndpoint looks up an endpoint matching the desired spec.
+// Aiven guarantees uniqueness on (project, endpoint_name, endpoint_type).
+func (r *ServiceIntegrationEndpointController) findEndpoint(
+	ctx context.Context,
+	si *v1alpha1.ServiceIntegrationEndpoint,
+) (*service.ServiceIntegrationEndpointOut, error) {
+	endpoints, err := r.avnGen.ServiceIntegrationEndpointList(ctx, si.Spec.Project)
 	if err != nil {
-		return false, err
+		return nil, fmt.Errorf("listing service integration endpoints: %w", err)
 	}
 
-	meta.SetStatusCondition(&si.Status.Conditions,
-		getInitializedCondition("Preconditions", "Checking preconditions"))
-
-	return true, nil
-}
-
-func (h ServiceIntegrationEndpointHandler) convert(i client.Object) (*v1alpha1.ServiceIntegrationEndpoint, error) {
-	si, ok := i.(*v1alpha1.ServiceIntegrationEndpoint)
-	if !ok {
-		return nil, fmt.Errorf("cannot convert object to ServiceIntegrationEndpoint")
+	for i := range endpoints {
+		e := &endpoints[i]
+		if e.EndpointName == si.Spec.EndpointName && e.EndpointType == service.EndpointType(si.Spec.EndpointType) {
+			return e, nil
+		}
 	}
 
-	return si, nil
+	return nil, nil
 }

--- a/controllers/serviceintegrationendpoint_controller_test.go
+++ b/controllers/serviceintegrationendpoint_controller_test.go
@@ -1,0 +1,328 @@
+package controllers
+
+import (
+	"errors"
+	"testing"
+
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aiven/aiven-operator/api/v1alpha1"
+	prometheususerconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/integrationendpoints/prometheus"
+)
+
+const yamlServiceIntegrationEndpointDatadog = `
+apiVersion: aiven.io/v1alpha1
+kind: ServiceIntegrationEndpoint
+metadata:
+  name: test-sie
+  namespace: default
+spec:
+  project: test-project
+  endpointName: my-endpoint
+  endpointType: datadog
+  datadog:
+    datadog_api_key: AAAAAAAAAAAAAAAA
+    site: datadoghq.com
+`
+
+func runServiceIntegrationEndpointScenario(
+	t *testing.T,
+	si *v1alpha1.ServiceIntegrationEndpoint,
+	avn avngen.Client,
+	additionalObjects ...client.Object,
+) (*Reconciler[*v1alpha1.ServiceIntegrationEndpoint], ctrlruntime.Result, error) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	objects := append([]client.Object{si}, additionalObjects...)
+
+	r := newServiceIntegrationEndpointReconciler(Controller{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&v1alpha1.ServiceIntegrationEndpoint{}).
+			WithObjects(objects...).
+			Build(),
+		Scheme:       scheme,
+		Recorder:     record.NewFakeRecorder(10),
+		DefaultToken: "test-token",
+		PollInterval: testPollInterval,
+	}).(*Reconciler[*v1alpha1.ServiceIntegrationEndpoint])
+	r.newAivenGeneratedClient = func(_, _, _ string) (avngen.Client, error) {
+		return avn, nil
+	}
+
+	res, err := r.Reconcile(t.Context(), ctrlruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      si.Name,
+			Namespace: si.Namespace,
+		},
+	})
+	return r, res, err
+}
+
+func TestServiceIntegrationEndpointReconciler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Creates ServiceIntegrationEndpoint on Aiven when it doesn't exist", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		// Observe: no Status.ID yet, so it lists to look for an adoptable endpoint and finds none.
+		avn.EXPECT().
+			ServiceIntegrationEndpointList(mock.Anything, si.Spec.Project).
+			Return(nil, nil).Once()
+		avn.EXPECT().
+			ServiceIntegrationEndpointCreate(mock.Anything, si.Spec.Project, mock.MatchedBy(func(in *service.ServiceIntegrationEndpointCreateIn) bool {
+				return in.EndpointName == si.Spec.EndpointName &&
+					in.EndpointType == service.EndpointType(si.Spec.EndpointType) &&
+					len(in.UserConfig) > 0
+			})).
+			Return(&service.ServiceIntegrationEndpointCreateOut{EndpointId: "endpoint-123"}, nil).Once()
+
+		r, res, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.ServiceIntegrationEndpoint{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got))
+		require.Equal(t, "endpoint-123", got.Status.ID)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
+		require.Contains(t, got.Finalizers, instanceDeletionFinalizer)
+	})
+
+	t.Run("Adopts existing endpoint by name+type when Status.ID is empty", func(t *testing.T) {
+		// Simulates a lost status write
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceIntegrationEndpointList(mock.Anything, si.Spec.Project).
+			Return([]service.ServiceIntegrationEndpointOut{
+				{EndpointId: "other-id", EndpointName: "different-name", EndpointType: service.EndpointType(si.Spec.EndpointType)},
+				{EndpointId: "adopted-id", EndpointName: si.Spec.EndpointName, EndpointType: service.EndpointType(si.Spec.EndpointType)},
+			}, nil).Once()
+		// No Create is expected. Adoption marks the resource as not up-to-date, so Update runs.
+		avn.EXPECT().
+			ServiceIntegrationEndpointUpdate(mock.Anything, si.Spec.Project, "adopted-id", mock.Anything).
+			Return(&service.ServiceIntegrationEndpointUpdateOut{EndpointId: "adopted-id"}, nil).Once()
+
+		r, res, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.ServiceIntegrationEndpoint{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got))
+		require.Equal(t, "adopted-id", got.Status.ID)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
+	})
+
+	t.Run("Marks running and requeues when endpoint already exists and is up to date", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+		si.Status.ID = "endpoint-123"
+		si.Annotations = map[string]string{
+			processedGenerationAnnotation: "1",
+			instanceIsRunningAnnotation:   "true",
+		}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceIntegrationEndpointGet(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(&service.ServiceIntegrationEndpointGetOut{EndpointId: si.Status.ID}, nil).Once()
+
+		r, res, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.ServiceIntegrationEndpoint{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got))
+		require.Equal(t, "endpoint-123", got.Status.ID)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+	})
+
+	t.Run("Updates endpoint user config and tolerates \"user config not changed\"", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+		si.Status.ID = "endpoint-123"
+
+		avn := avngen.NewMockClient(t)
+		// Observe: endpoint exists but not up to date (no processed-generation annotation yet).
+		avn.EXPECT().
+			ServiceIntegrationEndpointGet(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(&service.ServiceIntegrationEndpointGetOut{EndpointId: si.Status.ID}, nil).Once()
+		avn.EXPECT().
+			ServiceIntegrationEndpointUpdate(mock.Anything, si.Spec.Project, si.Status.ID, mock.MatchedBy(func(in *service.ServiceIntegrationEndpointUpdateIn) bool {
+				return len(in.UserConfig) > 0
+			})).
+			Return(nil, errors.New("User config not changed")).Once()
+
+		r, res, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.ServiceIntegrationEndpoint{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got))
+		require.Equal(t, "endpoint-123", got.Status.ID)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
+	})
+
+	t.Run("Updates endpoint user config and stores ID returned by API", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+		si.Status.ID = "endpoint-123"
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceIntegrationEndpointGet(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(&service.ServiceIntegrationEndpointGetOut{EndpointId: si.Status.ID}, nil).Once()
+		avn.EXPECT().
+			ServiceIntegrationEndpointUpdate(mock.Anything, si.Spec.Project, si.Status.ID, mock.Anything).
+			Return(&service.ServiceIntegrationEndpointUpdateOut{EndpointId: "endpoint-456"}, nil).Once()
+
+		r, res, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.ServiceIntegrationEndpoint{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got))
+		require.Equal(t, "endpoint-456", got.Status.ID)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+	})
+
+	t.Run("Returns error when Get fails with a non-retryable error", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+		si.Status.ID = "endpoint-123"
+
+		avn := avngen.NewMockClient(t)
+		// 400 is not retryable, so the reconciler surfaces it as an error rather than requeueing.
+		avn.EXPECT().
+			ServiceIntegrationEndpointGet(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(nil, newAivenError(400, "bad request")).Once()
+
+		_, _, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.Error(t, err)
+	})
+
+	t.Run("Returns error when Update fails with a non-tolerated error", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+		si.Status.ID = "endpoint-123"
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceIntegrationEndpointGet(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(&service.ServiceIntegrationEndpointGetOut{EndpointId: si.Status.ID}, nil).Once()
+		avn.EXPECT().
+			ServiceIntegrationEndpointUpdate(mock.Anything, si.Spec.Project, si.Status.ID, mock.Anything).
+			Return(nil, errors.New("some other failure")).Once()
+
+		_, _, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.Error(t, err)
+	})
+
+	t.Run("Returns error when more than one endpoint config is set", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+		// datadog is set via YAML; add a conflicting second config block.
+		si.Spec.Prometheus = &prometheususerconfig.PrometheusUserConfig{}
+
+		avn := avngen.NewMockClient(t)
+		// Observe lists for adoption and finds nothing; Create must then fail in GetUserConfig
+		// before any ServiceIntegrationEndpointCreate call is made.
+		avn.EXPECT().
+			ServiceIntegrationEndpointList(mock.Anything, si.Spec.Project).
+			Return(nil, nil).Once()
+
+		_, _, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.Error(t, err)
+	})
+
+	t.Run("Resets Status.ID and recreates when Get returns NotFound", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+		si.Status.ID = "stale-id"
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceIntegrationEndpointGet(mock.Anything, si.Spec.Project, "stale-id").
+			Return(nil, newAivenError(404, "not found")).Once()
+		avn.EXPECT().
+			ServiceIntegrationEndpointCreate(mock.Anything, si.Spec.Project, mock.MatchedBy(func(in *service.ServiceIntegrationEndpointCreateIn) bool {
+				return in.EndpointType == service.EndpointType(si.Spec.EndpointType)
+			})).
+			Return(&service.ServiceIntegrationEndpointCreateOut{EndpointId: "endpoint-789"}, nil).Once()
+
+		r, res, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.ServiceIntegrationEndpoint{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got))
+		require.Equal(t, "endpoint-789", got.Status.ID)
+	})
+
+	t.Run("Deletes endpoint and removes finalizer on deletion", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+		si.Status.ID = "endpoint-123"
+		si.Finalizers = []string{instanceDeletionFinalizer}
+		now := metav1.Now()
+		si.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceIntegrationEndpointDelete(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(nil).Once()
+
+		r, res, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		got := &v1alpha1.ServiceIntegrationEndpoint{}
+		err = r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+
+	t.Run("Treats NotFound on delete as already deleted", func(t *testing.T) {
+		si := newObjectFromYAML[v1alpha1.ServiceIntegrationEndpoint](t, yamlServiceIntegrationEndpointDatadog)
+		si.Generation = 1
+		si.Status.ID = "endpoint-123"
+		si.Finalizers = []string{instanceDeletionFinalizer}
+		now := metav1.Now()
+		si.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceIntegrationEndpointDelete(mock.Anything, si.Spec.Project, si.Status.ID).
+			Return(newAivenError(404, "not found")).Once()
+
+		r, res, err := runServiceIntegrationEndpointScenario(t, si, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		got := &v1alpha1.ServiceIntegrationEndpoint{}
+		err = r.Get(t.Context(), types.NamespacedName{Name: si.Name, Namespace: si.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+}

--- a/tests/serviceintegrationendpoint_test.go
+++ b/tests/serviceintegrationendpoint_test.go
@@ -16,43 +16,106 @@ func TestServiceIntegrationEndpointExternalPostgres(t *testing.T) {
 	t.Parallel()
 	defer recoverPanic(t)
 
-	// GIVEN
-	ctx, cancel := testCtx()
-	defer cancel()
+	t.Run("creates and reconciles a new endpoint", func(t *testing.T) {
+		t.Parallel()
+		defer recoverPanic(t)
 
-	endpointPgName := randName("postgresql")
+		// GIVEN
+		ctx, cancel := testCtx()
+		defer cancel()
 
-	yml, err := loadExampleYaml("serviceintegrationendpoint.external_postgresql.yaml", map[string]string{
-		"metadata.name": endpointPgName,
-		"spec.project":  cfg.Project,
+		endpointPgName := randName("postgresql")
+
+		yml, err := loadExampleYaml("serviceintegrationendpoint.external_postgresql.yaml", map[string]string{
+			"metadata.name": endpointPgName,
+			"spec.project":  cfg.Project,
+		})
+		require.NoError(t, err)
+		s := NewSession(ctx, k8sClient)
+
+		// Cleans test afterward
+		defer s.Destroy(t)
+
+		// WHEN
+		// Applies given manifest
+		require.NoError(t, s.Apply(yml))
+
+		// THEN
+
+		// Validates ServiceIntegrationEndpoint externalPostgresql
+		endpointPg := new(v1alpha1.ServiceIntegrationEndpoint)
+		require.NoError(t, s.GetRunning(endpointPg, endpointPgName))
+		endpointPgAvn, err := avnGen.ServiceIntegrationEndpointGet(ctx, cfg.Project, endpointPg.Status.ID, service.ServiceIntegrationEndpointGetIncludeSecrets(true))
+		require.NoError(t, err)
+		assert.Equal(t, "external_postgresql", string(endpointPgAvn.EndpointType))
+		assert.Equal(t, "username", endpointPg.Spec.ExternalPostgresql.Username)
+		assert.Equal(t, "password", *endpointPg.Spec.ExternalPostgresql.Password)
+		assert.Equal(t, "example.example", endpointPg.Spec.ExternalPostgresql.Host)
+		assert.Equal(t, 5432, endpointPg.Spec.ExternalPostgresql.Port)
+		assert.EqualValues(t, endpointPgAvn.EndpointType, endpointPg.Spec.EndpointType)
+		assert.EqualValues(t, endpointPgAvn.UserConfig["username"], endpointPg.Spec.ExternalPostgresql.Username)
+		assert.EqualValues(t, endpointPgAvn.UserConfig["password"], *endpointPg.Spec.ExternalPostgresql.Password)
+		assert.EqualValues(t, endpointPgAvn.UserConfig["host"], endpointPg.Spec.ExternalPostgresql.Host)
+		assert.EqualValues(t, endpointPgAvn.UserConfig["port"], endpointPg.Spec.ExternalPostgresql.Port)
 	})
-	require.NoError(t, err)
-	s := NewSession(ctx, k8sClient)
 
-	// Cleans test afterward
-	defer s.Destroy(t)
+	// Verifies that the controller adopts a pre-existing Aiven endpoint that matches the
+	// manifest's name+type instead of trying to create a duplicate.
+	t.Run("adopts a pre-existing endpoint with the same name and type", func(t *testing.T) {
+		t.Parallel()
+		defer recoverPanic(t)
 
-	// WHEN
-	// Applies given manifest
-	require.NoError(t, s.Apply(yml))
+		// GIVEN
+		ctx, cancel := testCtx()
+		defer cancel()
 
-	// THEN
+		endpointName := randName("adoption")
 
-	// Validates ServiceIntegrationEndpoint externalPostgresql
-	endpointPg := new(v1alpha1.ServiceIntegrationEndpoint)
-	require.NoError(t, s.GetRunning(endpointPg, endpointPgName))
-	endpointPgAvn, err := avnGen.ServiceIntegrationEndpointGet(ctx, cfg.Project, endpointPg.Status.ID, service.ServiceIntegrationEndpointGetIncludeSecrets(true))
-	require.NoError(t, err)
-	assert.Equal(t, "external_postgresql", string(endpointPgAvn.EndpointType))
-	assert.Equal(t, "username", endpointPg.Spec.ExternalPostgresql.Username)
-	assert.Equal(t, "password", *endpointPg.Spec.ExternalPostgresql.Password)
-	assert.Equal(t, "example.example", endpointPg.Spec.ExternalPostgresql.Host)
-	assert.Equal(t, 5432, endpointPg.Spec.ExternalPostgresql.Port)
-	assert.EqualValues(t, endpointPgAvn.EndpointType, endpointPg.Spec.EndpointType)
-	assert.EqualValues(t, endpointPgAvn.UserConfig["username"], endpointPg.Spec.ExternalPostgresql.Username)
-	assert.EqualValues(t, endpointPgAvn.UserConfig["password"], *endpointPg.Spec.ExternalPostgresql.Password)
-	assert.EqualValues(t, endpointPgAvn.UserConfig["host"], endpointPg.Spec.ExternalPostgresql.Host)
-	assert.EqualValues(t, endpointPgAvn.UserConfig["port"], endpointPg.Spec.ExternalPostgresql.Port)
+		// Pre-create the endpoint directly via the Aiven API, simulating an endpoint that exists.
+		preCreated, err := avnGen.ServiceIntegrationEndpointCreate(ctx, cfg.Project, &service.ServiceIntegrationEndpointCreateIn{
+			EndpointName: endpointName,
+			EndpointType: service.EndpointTypeExternalPostgresql,
+			UserConfig: map[string]any{
+				"username": "username",
+				"password": "password",
+				"host":     "example.example",
+				"port":     5432,
+				"ssl_mode": "require",
+			},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, preCreated.EndpointId)
+
+		yml, err := loadExampleYaml("serviceintegrationendpoint.external_postgresql.yaml", map[string]string{
+			"metadata.name":     endpointName,
+			"spec.project":      cfg.Project,
+			"spec.endpointName": endpointName,
+		})
+		require.NoError(t, err)
+		s := NewSession(ctx, k8sClient)
+
+		defer s.Destroy(t)
+
+		// WHEN
+		require.NoError(t, s.Apply(yml))
+
+		// THEN
+		// The controller must adopt the pre-existing endpoint.
+		endpoint := new(v1alpha1.ServiceIntegrationEndpoint)
+		require.NoError(t, s.GetRunning(endpoint, endpointName))
+		assert.Equal(t, preCreated.EndpointId, endpoint.Status.ID, "controller should adopt the existing endpoint, not create a new one")
+
+		// And exactly one endpoint with this name+type exists on Aiven.
+		list, err := avnGen.ServiceIntegrationEndpointList(ctx, cfg.Project)
+		require.NoError(t, err)
+		var matching int
+		for i := range list {
+			if list[i].EndpointName == endpointName && list[i].EndpointType == service.EndpointTypeExternalPostgresql {
+				matching++
+			}
+		}
+		assert.Equal(t, 1, matching, "expected exactly one endpoint with this name+type after adoption")
+	})
 }
 
 func TestServiceIntegrationEndpoint(t *testing.T) {


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Migrate `ServiceIntegrationEndpoint` to the managed reconciler

- migrated `ServiceIntegrationEndpoint` to the new reconciler
- added endpoint adoption: when `Status.ID` is empty

Resolves: NEX-2645

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
