### PR TITLE
feat(clickhouse_grant): migrated to new reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Change `ClickhouseGrant` reconciliation to the managed reconciler: the resource now registers a
+  finalizer, periodically re-reconciles, and reports `Running` status conditions
 - Add Kafka SASL and Schema Registry endpoint keys to `ServiceUser` connection secrets for Kafka services.
 - Change `ServiceIntegrationEndpoint` reconciliation to the managed reconciler: the resource now adopts a
   pre-existing endpoint matching its `endpointName` and `endpointType`.

--- a/controllers/clickhousegrant_controller.go
+++ b/controllers/clickhousegrant_controller.go
@@ -10,8 +10,6 @@ import (
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
@@ -19,145 +17,106 @@ import (
 	chUtils "github.com/aiven/aiven-operator/utils/clickhouse"
 )
 
-// ClickhouseGrantReconciler reconciles a ClickhouseGrant object
-type ClickhouseGrantReconciler struct {
-	Controller
-}
-
-func newClickhouseGrantReconciler(c Controller) reconcilerType {
-	return &ClickhouseGrantReconciler{Controller: c}
-}
-
-// ClickhouseGrantHandler handles an Aiven ClickhouseGrant
-type ClickhouseGrantHandler struct{}
-
 //+kubebuilder:rbac:groups=aiven.io,resources=clickhousegrants,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=aiven.io,resources=clickhousegrants/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=aiven.io,resources=clickhousegrants/finalizers,verbs=get;create;update
 
-func (r *ClickhouseGrantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.reconcileInstance(ctx, req, &ClickhouseGrantHandler{}, &v1alpha1.ClickhouseGrant{})
+// ClickhouseGrantController reconciles a ClickhouseGrant object.
+type ClickhouseGrantController struct {
+	client.Client
+	avnGen avngen.Client
 }
 
-func (r *ClickhouseGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.ClickhouseGrant{}).
-		Complete(r)
+func newClickhouseGrantReconciler(c Controller) reconcilerType {
+	return newManagedReconciler(
+		c,
+		func(c Controller, avnGen avngen.Client) AivenController[*v1alpha1.ClickhouseGrant] {
+			return &ClickhouseGrantController{Client: c.Client, avnGen: avnGen}
+		},
+		nil,
+	)
 }
 
-func (h *ClickhouseGrantHandler) createOrUpdate(ctx context.Context, avnGen avngen.Client, obj client.Object, _ []client.Object) error {
-	g, err := h.convert(obj)
-	if err != nil {
-		return err
+func (r *ClickhouseGrantController) Observe(ctx context.Context, g *v1alpha1.ClickhouseGrant) (Observation, error) {
+	if _, err := getServiceIfOperational(ctx, r.avnGen, g.Spec.Project, g.Spec.ServiceName); err != nil {
+		return Observation{}, err
 	}
+
+	exists := wasEverApplied(g)
+	if exists && hasLatestGeneration(g) {
+		markInstanceRunning(g)
+		return Observation{ResourceExists: true, ResourceUpToDate: true}, nil
+	}
+
+	if err := r.checkPreconditions(ctx, g); err != nil {
+		return Observation{}, err
+	}
+
+	return Observation{ResourceExists: exists, ResourceUpToDate: false}, nil
+}
+
+func (r *ClickhouseGrantController) Create(ctx context.Context, g *v1alpha1.ClickhouseGrant) (CreateResult, error) {
+	return CreateResult{}, r.applyGrants(ctx, g)
+}
+
+func (r *ClickhouseGrantController) Update(ctx context.Context, g *v1alpha1.ClickhouseGrant) (UpdateResult, error) {
+	return UpdateResult{}, r.applyGrants(ctx, g)
+}
+
+func (r *ClickhouseGrantController) Delete(ctx context.Context, g *v1alpha1.ClickhouseGrant) error {
+	// Revokes the latest grants from the spec.
+	return revokeGrants(ctx, r.avnGen, g, &g.Spec.Grants)
+}
+
+// applyGrants revokes the previously applied grants (if any), then grants declared privileges in the spec.
+func (r *ClickhouseGrantController) applyGrants(ctx context.Context, g *v1alpha1.ClickhouseGrant) error {
+	delete(g.GetAnnotations(), instanceIsRunningAnnotation)
 
 	// Revokes previous grants
 	if g.Status.State != nil {
-		err = revokeGrants(ctx, avnGen, g, g.Status.State)
-		if err != nil {
+		if err := revokeGrants(ctx, r.avnGen, g, g.Status.State); err != nil {
 			return err
 		}
 	}
 
 	// Grants new privileges
-	return grantSpecGrants(ctx, avnGen, g)
-}
-
-func (h *ClickhouseGrantHandler) delete(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {
-	g, err := h.convert(obj)
-	if err != nil {
-		return false, err
-	}
-
-	// Revokes latest grants.
-	// Doesn't revoke previous grants (state) here.
-	// If the object hasn't been committed yet, it might have an empty state.
-	// Must revoke from the spec.
-	err = revokeGrants(ctx, avnGen, g, &g.Spec.Grants)
-	return err == nil, err
-}
-
-func (h *ClickhouseGrantHandler) observe(_ context.Context, _ avngen.Client, obj v1alpha1.AivenManagedObject) error {
-	g, err := h.convert(obj)
-	if err != nil {
+	if err := grantSpecGrants(ctx, r.avnGen, g); err != nil {
 		return err
 	}
 
-	// Stores previous state
+	// Stores the applied grants so the next reconciliation can revoke them before re-granting.
 	g.Status.State = g.Spec.Grants.DeepCopy()
-
-	meta.SetStatusCondition(&g.Status.Conditions,
-		getRunningCondition(metav1.ConditionTrue, "CheckRunning",
-			"Instance is running on Aiven side"))
-
-	metav1.SetMetaDataAnnotation(&g.ObjectMeta, instanceIsRunningAnnotation, "true")
+	markInstanceRunning(g)
 	return nil
 }
 
-func (h *ClickhouseGrantHandler) checkPreconditions(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {
-	/** Preconditions for ClickhouseGrant:
-	 *
-	 * 1. The service is running
-	 * 2. All users and roles specified in spec exist
-	 * 3. All databases specified in spec exist
-	 */
-
-	g, err := h.convert(obj)
-	if err != nil {
-		return false, err
+// checkPreconditions verifies that all users, roles and databases referenced in the spec already exist in ClickHouse.
+// Missing references are reported as errPreconditionNotMet.
+func (r *ClickhouseGrantController) checkPreconditions(ctx context.Context, g *v1alpha1.ClickhouseGrant) error {
+	if err := checkPrecondition(ctx, g, r.avnGen, g.Spec.CollectGrantees, chUtils.QueryGrantees, "missing users or roles defined in spec: %v"); err != nil {
+		return err
 	}
 
-	meta.SetStatusCondition(&g.Status.Conditions,
-		getInitializedCondition("Preconditions", "Checking preconditions"))
-
-	isOperational, err := checkServiceIsOperational(ctx, avnGen, g.Spec.Project, g.Spec.ServiceName)
-	if !isOperational || err != nil {
-		return false, err
+	if err := checkPrecondition(ctx, g, r.avnGen, g.Spec.CollectDatabases, chUtils.QueryDatabases, "missing databases defined in spec: %v"); err != nil {
+		return err
 	}
 
-	// Service is running, check users and roles specified in spec exist
-	_, err = checkPrecondition(ctx, g, avnGen, g.Spec.CollectGrantees, chUtils.QueryGrantees, "missing users or roles defined in spec: %v")
-	if err != nil {
-		return false, err
-	}
-
-	// Check that databases specified in spec exist
-	_, err = checkPrecondition(ctx, g, avnGen, g.Spec.CollectDatabases, chUtils.QueryDatabases, "missing databases defined in spec: %v")
-	if err != nil {
-		return false, err
-	}
-
-	// Remove previous error conditions
-	meta.RemoveStatusCondition(&g.Status.Conditions, "Error")
-
-	meta.SetStatusCondition(&g.Status.Conditions,
-		getInitializedCondition("Preconditions", "Preconditions met"))
-
-	return true, nil
+	return nil
 }
 
-func checkPrecondition[T comparable](ctx context.Context, g *v1alpha1.ClickhouseGrant, avnGen avngen.Client, collectFunc func() []T, queryFunc func(context.Context, avngen.Client, string, string) ([]T, error), errorMsgFormat string) (bool, error) {
+func checkPrecondition[T comparable](ctx context.Context, g *v1alpha1.ClickhouseGrant, avnGen avngen.Client, collectFunc func() []T, queryFunc func(context.Context, avngen.Client, string, string) ([]T, error), errorMsgFormat string) error {
 	itemsInSpec := collectFunc()
 	itemsInDB, err := queryFunc(ctx, avnGen, g.Spec.Project, g.Spec.ServiceName)
 	if err != nil {
-		return false, err
+		return err
 	}
 	missingItems := utils.CheckSliceContainment(itemsInSpec, itemsInDB)
 	if len(missingItems) > 0 {
 		err = fmt.Errorf(errorMsgFormat, missingItems)
 		meta.SetStatusCondition(&g.Status.Conditions, getErrorCondition(errConditionPreconditions, err))
-		return false, err
+		return fmt.Errorf("%w: %w", errPreconditionNotMet, err)
 	}
-	return true, nil
-}
-
-func (h *ClickhouseGrantHandler) convert(i client.Object) (*v1alpha1.ClickhouseGrant, error) {
-	g, ok := i.(*v1alpha1.ClickhouseGrant)
-	if !ok {
-		return nil, fmt.Errorf("cannot convert object to ClickhouseGrant")
-	}
-
-	return g, nil
+	return nil
 }
 
 func executeStatements(

--- a/controllers/clickhousegrant_controller_test.go
+++ b/controllers/clickhousegrant_controller_test.go
@@ -1,0 +1,348 @@
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/clickhouse"
+	"github.com/aiven/go-client-codegen/handler/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aiven/aiven-operator/api/v1alpha1"
+)
+
+const yamlClickhouseGrant = `
+apiVersion: aiven.io/v1alpha1
+kind: ClickhouseGrant
+metadata:
+  name: test-grant
+  namespace: default
+spec:
+  project: test-project
+  serviceName: test-service
+  privilegeGrants:
+    - grantees:
+        - user: test-user
+      privileges:
+        - SELECT
+      database: test-db
+  roleGrants:
+    - grantees:
+        - user: test-user
+      roles:
+        - test-role
+`
+
+func newRunningService() *service.ServiceGetOut {
+	return &service.ServiceGetOut{State: service.ServiceStateTypeRunning}
+}
+
+func Test_newClickhouseGrantReconciler(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := newClickhouseGrantReconciler(Controller{Client: k8sClient})
+
+	rec, ok := r.(*Reconciler[*v1alpha1.ClickhouseGrant])
+	require.True(t, ok)
+
+	require.IsType(t, &v1alpha1.ClickhouseGrant{}, rec.newObj())
+
+	ctrl, ok := rec.newController(nil).(*ClickhouseGrantController)
+	require.True(t, ok)
+	require.Equal(t, k8sClient, ctrl.Client)
+}
+
+func TestClickhouseGrantController_Observe(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Returns error when service is not operational", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			Return(nil, newAivenError(404, "service not found")).
+			Once()
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		_, err := ctrl.Observe(t.Context(), grant)
+		require.EqualError(t, err, "preconditions are not met: [404 ]: service not found")
+	})
+
+	t.Run("Marks up to date without precondition queries when already applied", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+		grant.SetGeneration(1)
+		grant.Annotations = map[string]string{processedGenerationAnnotation: "1"}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			Return(newRunningService(), nil).
+			Once()
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		obs, err := ctrl.Observe(t.Context(), grant)
+		require.NoError(t, err)
+		require.Equal(t, Observation{ResourceExists: true, ResourceUpToDate: true}, obs)
+		// The running condition/marker is refreshed on the up-to-date path.
+		require.Equal(t, "true", grant.Annotations[instanceIsRunningAnnotation])
+	})
+
+	t.Run("Reports resource missing when preconditions are met and never applied", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+
+		router := &chQueryRouter{users: []string{"test-user"}, databases: []string{"test-db"}}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			Return(newRunningService(), nil).
+			Once()
+		avn.EXPECT().
+			ServiceClickHouseQuery(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			RunAndReturn(router.handle)
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		obs, err := ctrl.Observe(t.Context(), grant)
+		require.NoError(t, err)
+		require.Equal(t, Observation{ResourceExists: false, ResourceUpToDate: false}, obs)
+	})
+
+	t.Run("Returns errPreconditionNotMet when a grantee is missing", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+
+		// No users/roles -> the spec's grantee "test-user" is missing.
+		router := &chQueryRouter{databases: []string{"test-db"}}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			Return(newRunningService(), nil).
+			Once()
+		avn.EXPECT().
+			ServiceClickHouseQuery(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			RunAndReturn(router.handle)
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		_, err := ctrl.Observe(t.Context(), grant)
+		require.ErrorIs(t, err, errPreconditionNotMet)
+		require.Contains(t, err.Error(), "missing users or roles defined in spec: [test-user]")
+	})
+
+	t.Run("Returns errPreconditionNotMet when a database is missing", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+
+		// Grantee exists but the referenced database does not.
+		router := &chQueryRouter{users: []string{"test-user"}}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			Return(newRunningService(), nil).
+			Once()
+		avn.EXPECT().
+			ServiceClickHouseQuery(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			RunAndReturn(router.handle)
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		_, err := ctrl.Observe(t.Context(), grant)
+		require.ErrorIs(t, err, errPreconditionNotMet)
+		require.Contains(t, err.Error(), "missing databases defined in spec: [test-db]")
+	})
+}
+
+func TestClickhouseGrantController_Create(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Grants spec privileges and records state without prior revoke", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+
+		router := &chQueryRouter{}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceClickHouseQuery(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			RunAndReturn(router.handle)
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		_, err := ctrl.Create(t.Context(), grant)
+		require.NoError(t, err)
+
+		// No prior state, so only GRANT statements are executed.
+		require.Len(t, router.executed, 2)
+		for _, stmt := range router.executed {
+			require.True(t, strings.HasPrefix(stmt, "GRANT "), "expected only GRANT statements, got %q", stmt)
+		}
+
+		// State is recorded so the next reconcile can revoke it, and the running marker is set.
+		require.NotNil(t, grant.Status.State)
+		require.Equal(t, grant.Spec.Grants, *grant.Status.State)
+		require.Equal(t, "true", grant.Annotations[instanceIsRunningAnnotation])
+	})
+
+	t.Run("Wraps error from a GRANT statement", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+		// Stale running marker from a previous reconcile must be cleared on failure.
+		grant.Annotations = map[string]string{instanceIsRunningAnnotation: "true"}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceClickHouseQuery(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			Return(nil, assert.AnError)
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		_, err := ctrl.Create(t.Context(), grant)
+		require.ErrorIs(t, err, assert.AnError)
+		// State must not advance when granting fails.
+		require.Nil(t, grant.Status.State)
+		// The resource must not keep advertising itself as running after a failed apply.
+		require.NotContains(t, grant.Annotations, instanceIsRunningAnnotation)
+	})
+}
+
+func TestClickhouseGrantController_Update(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Revokes previous state before granting spec privileges", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+		// A previously applied state that must be revoked first.
+		grant.Status.State = &v1alpha1.Grants{
+			PrivilegeGrants: []v1alpha1.PrivilegeGrant{
+				{
+					Grantees:   []v1alpha1.Grantee{{User: "test-user"}},
+					Privileges: []string{"INSERT"},
+					Database:   "old-db",
+				},
+			},
+		}
+
+		router := &chQueryRouter{}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceClickHouseQuery(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			RunAndReturn(router.handle)
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		_, err := ctrl.Update(t.Context(), grant)
+		require.NoError(t, err)
+
+		// 1 REVOKE (old state) followed by 2 GRANTs (spec privilege + role grant).
+		require.Len(t, router.executed, 3)
+		require.True(t, strings.HasPrefix(router.executed[0], "REVOKE "), "first statement must revoke previous state, got %q", router.executed[0])
+		require.True(t, strings.HasPrefix(router.executed[1], "GRANT "))
+		require.True(t, strings.HasPrefix(router.executed[2], "GRANT "))
+
+		require.Equal(t, grant.Spec.Grants, *grant.Status.State)
+		require.Equal(t, "true", grant.Annotations[instanceIsRunningAnnotation])
+	})
+}
+
+func TestClickhouseGrantController_Delete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Revokes spec grants", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+
+		router := &chQueryRouter{}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceClickHouseQuery(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			RunAndReturn(router.handle)
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		require.NoError(t, ctrl.Delete(t.Context(), grant))
+
+		require.Len(t, router.executed, 2)
+		for _, stmt := range router.executed {
+			require.True(t, strings.HasPrefix(stmt, "REVOKE "), "expected only REVOKE statements, got %q", stmt)
+		}
+	})
+
+	t.Run("Tolerates 400 and 404 errors during revoke", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceClickHouseQuery(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			Return(nil, newAivenError(404, "there is no role")).
+			Twice()
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		require.NoError(t, ctrl.Delete(t.Context(), grant))
+	})
+
+	t.Run("Propagates unexpected revoke errors", func(t *testing.T) {
+		grant := newObjectFromYAML[v1alpha1.ClickhouseGrant](t, yamlClickhouseGrant)
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceClickHouseQuery(mock.Anything, grant.Spec.Project, grant.Spec.ServiceName, mock.Anything).
+			Return(nil, newAivenError(500, "boom"))
+
+		ctrl := &ClickhouseGrantController{avnGen: avn}
+
+		err := ctrl.Delete(t.Context(), grant)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "boom")
+	})
+}
+
+// chQueryRouter dispatches ServiceClickHouseQuery calls.
+// Precondition queries, GRANT/REVOKE statements are recorded in order.
+type chQueryRouter struct {
+	users     []string
+	roles     []string
+	databases []string
+
+	executed []string
+}
+
+func (r *chQueryRouter) handle(_ context.Context, _, _ string, in *clickhouse.ServiceClickHouseQueryIn) (*clickhouse.ServiceClickHouseQueryOut, error) {
+	q := in.Query
+	switch {
+	case strings.HasPrefix(q, "GRANT "), strings.HasPrefix(q, "REVOKE "):
+		r.executed = append(r.executed, q)
+		return &clickhouse.ServiceClickHouseQueryOut{}, nil
+	case strings.Contains(q, "system.users"):
+		return &clickhouse.ServiceClickHouseQueryOut{Data: toRows(r.users)}, nil
+	case strings.Contains(q, "system.roles"):
+		return &clickhouse.ServiceClickHouseQueryOut{Data: toRows(r.roles)}, nil
+	case strings.Contains(q, "system.databases"):
+		return &clickhouse.ServiceClickHouseQueryOut{Data: toRows(r.databases)}, nil
+	default:
+		return &clickhouse.ServiceClickHouseQueryOut{}, nil
+	}
+}
+
+func toRows(values []string) [][]any {
+	rows := make([][]any, 0, len(values))
+	for _, v := range values {
+		rows = append(rows, []any{v})
+	}
+	return rows
+}

--- a/tests/clickhousegrant_test.go
+++ b/tests/clickhousegrant_test.go
@@ -225,6 +225,72 @@ func TestClickhouseGrant(t *testing.T) {
 		},
 	}
 	assert.ElementsMatch(t, roleGrantResults, expectedRoleGrants)
+
+	// Updating the spec must revoke the previously applied privileges before granting the new ones.
+	t.Run("Update revokes previously applied privileges", func(t *testing.T) {
+		// Drops INSERT, keeping only SELECT for both grantees.
+		updatedYml := getClickhouseGrantUpdatedYaml(cfg.Project, chName, dbName, userName, roleName)
+		require.NoError(t, s.Apply(updatedYml))
+
+		// GetRunning blocks until the new generation is processed, i.e. the update has been applied.
+		require.NoError(t, s.GetRunning(grant, roleName+"-grant"))
+
+		results, err := queryAndCollectResults[ClickhouseGrant](ctx, conn, chUtils.QueryNonAivenPrivileges)
+		require.NoError(t, err)
+
+		filtered := filterPrivilegeGrantResults(results, userName, roleName)
+		// Only SELECT for the user and SELECT for the role remain; both INSERT grants must be revoked.
+		assert.Len(t, filtered, 2)
+		for _, r := range filtered {
+			assert.Equal(t, "SELECT", r.AccessType, "INSERT should have been revoked by the update")
+		}
+	})
+
+	// Deleting the grant must revoke all privileges from ClickHouse.
+	t.Run("Delete revokes all granted privileges", func(t *testing.T) {
+		require.NoError(t, s.Delete(grant, func() error { return nil }))
+
+		results, err := queryAndCollectResults[ClickhouseGrant](ctx, conn, chUtils.QueryNonAivenPrivileges)
+		require.NoError(t, err)
+		assert.Empty(t, filterPrivilegeGrantResults(results, userName, roleName),
+			"all privileges for the user and role must be revoked after deletion")
+	})
+}
+
+// getClickhouseGrantUpdatedYaml returns a ClickhouseGrant manifest with removed INSERT.
+func getClickhouseGrantUpdatedYaml(project, chName, dbName, userName, roleName string) string {
+	return fmt.Sprintf(`
+apiVersion: aiven.io/v1alpha1
+kind: ClickhouseGrant
+metadata:
+  name: %[5]s-grant
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: %[1]s
+  serviceName: %[2]s
+
+  privilegeGrants:
+    - grantees:
+        - user: %[4]s
+        - role: %[5]s
+      privileges:
+        - SELECT
+      database: %[3]s
+      table: example-table
+      columns:
+        - col1
+      withGrantOption: true
+
+  roleGrants:
+    - roles:
+        - %[5]s
+      grantees:
+        - user: %[4]s
+      withAdminOption: true
+`, project, chName, dbName, userName, roleName)
 }
 
 func queryAndCollectResults[T any](ctx context.Context, conn clickhouse.Conn, query string) ([]T, error) {


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- migrated `ClickHouseGrant` to the new reconciler
- this is a pure lift-and-shift onto the new reconciler - behavior is intentionally unchanged

Resolves: NEX-2664

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
