### PR TITLE
feat(database): migrate to new reconciler

### DIFF
--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -10,145 +10,128 @@ import (
 	"github.com/aiven/go-client-codegen/handler/service"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
 
-// DatabaseReconciler reconciles a Database object
-type DatabaseReconciler struct {
-	Controller
-}
-
-func newDatabaseReconciler(c Controller) reconcilerType {
-	return &DatabaseReconciler{Controller: c}
-}
-
-// DatabaseHandler handles an Aiven Database
-type DatabaseHandler struct{}
-
 //+kubebuilder:rbac:groups=aiven.io,resources=databases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=aiven.io,resources=databases/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=aiven.io,resources=databases/finalizers,verbs=get;create;update
 
-func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.reconcileInstance(ctx, req, DatabaseHandler{}, &v1alpha1.Database{})
+// DatabaseController reconciles a Database object.
+type DatabaseController struct {
+	client.Client
+	avnGen avngen.Client
 }
 
-func (r *DatabaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.Database{}).
-		Complete(r)
+func newDatabaseReconciler(c Controller) reconcilerType {
+	return newManagedReconciler(
+		c,
+		func(c Controller, avnGen avngen.Client) AivenController[*v1alpha1.Database] {
+			return &DatabaseController{Client: c.Client, avnGen: avnGen}
+		},
+		nil,
+	)
 }
 
-func (h DatabaseHandler) createOrUpdate(ctx context.Context, avnGen avngen.Client, obj client.Object, _ []client.Object) error {
-	db, err := h.convert(obj)
-	if err != nil {
-		return err
+func (r *DatabaseController) Observe(ctx context.Context, db *v1alpha1.Database) (Observation, error) {
+	if _, err := getServiceIfOperational(ctx, r.avnGen, db.Spec.Project, db.Spec.ServiceName); err != nil {
+		return Observation{}, err
 	}
 
-	exists, err := h.exists(ctx, avnGen, db)
-	if err != nil {
-		return err
+	_, err := GetDatabaseByName(ctx, r.avnGen, db.Spec.Project, db.Spec.ServiceName, db.GetDatabaseName())
+	switch {
+	case isNotFound(err):
+		return Observation{ResourceExists: false}, nil
+	case err != nil:
+		return Observation{}, fmt.Errorf("describing database: %w", err)
 	}
 
-	if !exists {
-		err = avnGen.ServiceDatabaseCreate(ctx, db.Spec.Project, db.Spec.ServiceName, &service.ServiceDatabaseCreateIn{
-			Database:  db.GetDatabaseName(),
-			LcCollate: NilIfZero(db.Spec.LcCollate),
-			LcCtype:   NilIfZero(db.Spec.LcCtype),
-		})
-		if err != nil {
-			return fmt.Errorf("cannot create database on Aiven side: %w", err)
+	markInstanceRunning(db)
+
+	return Observation{
+		ResourceExists:   true,
+		ResourceUpToDate: hasLatestGeneration(db),
+	}, nil
+}
+
+func (r *DatabaseController) Create(ctx context.Context, db *v1alpha1.Database) (CreateResult, error) {
+	delete(db.GetAnnotations(), instanceIsRunningAnnotation)
+
+	req := service.ServiceDatabaseCreateIn{
+		Database:  db.GetDatabaseName(),
+		LcCollate: NilIfZero(db.Spec.LcCollate),
+		LcCtype:   NilIfZero(db.Spec.LcCtype),
+	}
+	if err := r.avnGen.ServiceDatabaseCreate(ctx, db.Spec.Project, db.Spec.ServiceName, &req); err != nil {
+		// The service can report RUNNING via ServiceGet while it is not ready
+		// to accept database creation yet, returning a transient 5xx.
+		if isServerError(err) {
+			return CreateResult{}, fmt.Errorf("%w: %w", errPreconditionNotMet, err)
 		}
+		return CreateResult{}, fmt.Errorf("cannot create database on Aiven side: %w", err)
 	}
 
-	return nil
+	const reason = "Created"
+	meta.SetStatusCondition(&db.Status.Conditions, getInitializedCondition(reason, "Successfully created the instance in Aiven"))
+	meta.SetStatusCondition(&db.Status.Conditions, getRunningCondition(metav1.ConditionUnknown, reason, "Successfully created the instance in Aiven, status remains unknown"))
+
+	return CreateResult{}, nil
 }
 
-func (h DatabaseHandler) delete(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {
-	db, err := h.convert(obj)
-	if err != nil {
-		return false, err
-	}
+func (r *DatabaseController) Update(_ context.Context, _ *v1alpha1.Database) (UpdateResult, error) {
+	// Databases have no mutable fields.
+	return UpdateResult{}, nil
+}
 
+func (r *DatabaseController) Delete(ctx context.Context, db *v1alpha1.Database) error {
 	if fromAnyPointer(db.Spec.TerminationProtection) {
-		return false, errTerminationProtectionOn
+		return errTerminationProtectionOn
 	}
 
-	err = avnGen.ServiceDatabaseDelete(
-		ctx,
-		db.Spec.Project,
-		db.Spec.ServiceName,
-		db.GetDatabaseName())
+	err := r.avnGen.ServiceDatabaseDelete(ctx, db.Spec.Project, db.Spec.ServiceName, db.GetDatabaseName())
 	if err != nil && !isNotFound(err) {
-		return false, err
-	}
-
-	return true, nil
-}
-
-func (h DatabaseHandler) exists(ctx context.Context, avnGen avngen.Client, db *v1alpha1.Database) (bool, error) {
-	d, err := GetDatabaseByName(ctx, avnGen, db.Spec.Project, db.Spec.ServiceName, db.GetDatabaseName())
-	if isNotFound(err) {
-		return false, nil
-	}
-
-	return d != nil, nil
-}
-
-func (h DatabaseHandler) observe(ctx context.Context, avnGen avngen.Client, obj v1alpha1.AivenManagedObject) error {
-	db, err := h.convert(obj)
-	if err != nil {
 		return err
 	}
-
-	_, err = GetDatabaseByName(ctx, avnGen, db.Spec.Project, db.Spec.ServiceName, db.GetDatabaseName())
-	if err != nil {
-		return err
-	}
-
-	meta.SetStatusCondition(&db.Status.Conditions,
-		getRunningCondition(metav1.ConditionTrue, "CheckRunning",
-			"Instance is running on Aiven side"))
-
-	metav1.SetMetaDataAnnotation(&db.ObjectMeta, instanceIsRunningAnnotation, "true")
-
 	return nil
 }
 
-func (h DatabaseHandler) checkPreconditions(ctx context.Context, avnGen avngen.Client, obj client.Object) (bool, error) {
-	db, err := h.convert(obj)
-	if err != nil {
-		return false, err
-	}
+// maxDatabaseListPages is an upper bound on the number of pages GetDatabaseByName will fetch.
+const maxDatabaseListPages = 100
 
-	meta.SetStatusCondition(&db.Status.Conditions,
-		getInitializedCondition("Preconditions", "Checking preconditions"))
-
-	return checkServiceIsOperational(ctx, avnGen, db.Spec.Project, db.Spec.ServiceName)
-}
-
-func (h DatabaseHandler) convert(i client.Object) (*v1alpha1.Database, error) {
-	db, ok := i.(*v1alpha1.Database)
-	if !ok {
-		return nil, fmt.Errorf("cannot convert object to Database")
-	}
-
-	return db, nil
-}
-
-func GetDatabaseByName(ctx context.Context, avnGen avngen.Client, projectName, serviceName, dbName string) (*service.DatabaseOut, error) {
-	list, err := avnGen.ServiceDatabaseList(ctx, projectName, serviceName)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, db := range list.Databases {
-		if db.DatabaseName == dbName {
-			return &db, nil
+func GetDatabaseByName(
+	ctx context.Context,
+	avnGen avngen.Client,
+	projectName, serviceName, dbName string,
+) (*service.DatabaseOut, error) {
+	var after string
+	for page := 0; page < maxDatabaseListPages; page++ {
+		var query [][2]string
+		if after != "" {
+			query = append(query, service.ServiceDatabaseListAfter(after))
 		}
+
+		list, err := avnGen.ServiceDatabaseList(ctx, projectName, serviceName, query...)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range list.Databases {
+			if list.Databases[i].DatabaseName == dbName {
+				return &list.Databases[i], nil
+			}
+		}
+
+		if list.Next == nil || *list.Next == "" {
+			return nil, NewNotFound(fmt.Sprintf("Database with name %q not found", dbName))
+		}
+		after = *list.Next
 	}
-	return nil, NewNotFound(fmt.Sprintf("Database with name %q not found", dbName))
+
+	return nil, fmt.Errorf(
+		"GetDatabaseByName: exceeded %d pages searching for database %q",
+		maxDatabaseListPages,
+		dbName,
+	)
 }

--- a/controllers/database_controller_test.go
+++ b/controllers/database_controller_test.go
@@ -1,0 +1,308 @@
+package controllers
+
+import (
+	"fmt"
+	"testing"
+
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/service"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aiven/aiven-operator/api/v1alpha1"
+)
+
+func TestDatabaseReconciler(t *testing.T) {
+	t.Parallel()
+
+	newDatabase := func(t *testing.T) *v1alpha1.Database {
+		t.Helper()
+		db := newObjectFromExampleYAML[v1alpha1.Database](t, "database")
+		db.Namespace = "default"
+		return db
+	}
+
+	runScenarioErr := func(t *testing.T, db *v1alpha1.Database, avn avngen.Client) (*Reconciler[*v1alpha1.Database], ctrlruntime.Result, error) {
+		t.Helper()
+
+		scheme := runtime.NewScheme()
+		require.NoError(t, clientgoscheme.AddToScheme(scheme))
+		require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+		r := newDatabaseReconciler(Controller{
+			Client: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&v1alpha1.Database{}).
+				WithObjects([]client.Object{db}...).
+				Build(),
+			Scheme:       scheme,
+			Recorder:     record.NewFakeRecorder(10),
+			DefaultToken: "test-token",
+			PollInterval: testPollInterval,
+		}).(*Reconciler[*v1alpha1.Database])
+		r.newAivenGeneratedClient = func(_, _, _ string) (avngen.Client, error) {
+			return avn, nil
+		}
+
+		res, err := r.Reconcile(t.Context(), ctrlruntime.Request{
+			NamespacedName: types.NamespacedName{Name: db.Name, Namespace: db.Namespace},
+		})
+		return r, res, err
+	}
+
+	runScenario := func(t *testing.T, db *v1alpha1.Database, avn avngen.Client) (*Reconciler[*v1alpha1.Database], ctrlruntime.Result) {
+		t.Helper()
+
+		r, res, err := runScenarioErr(t, db, avn)
+		require.NoError(t, err)
+		return r, res
+	}
+
+	expectServiceRunning := func(avn *avngen.MockClient, db *v1alpha1.Database, times int) {
+		avn.EXPECT().
+			ServiceGet(mock.Anything, db.Spec.Project, db.Spec.ServiceName, mock.Anything).
+			Return(&service.ServiceGetOut{State: service.ServiceStateTypeRunning}, nil).
+			Times(times)
+	}
+
+	t.Run("Requeues when service preconditions aren't met", func(t *testing.T) {
+		db := newDatabase(t)
+		db.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, db.Spec.Project, db.Spec.ServiceName, mock.Anything).
+			Return(nil, newAivenError(404, "service not found")).Once()
+
+		r, res := runScenario(t, db, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.Database{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, got))
+		require.Contains(t, got.Finalizers, instanceDeletionFinalizer)
+	})
+
+	t.Run("Creates database on Aiven when it doesn't exist", func(t *testing.T) {
+		db := newDatabase(t)
+		db.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		expectServiceRunning(avn, db, 1)
+		avn.EXPECT().
+			ServiceDatabaseList(mock.Anything, db.Spec.Project, db.Spec.ServiceName).
+			Return(&service.ServiceDatabaseListOut{}, nil).Once()
+		avn.EXPECT().
+			ServiceDatabaseCreate(mock.Anything, db.Spec.Project, db.Spec.ServiceName, mock.MatchedBy(func(in *service.ServiceDatabaseCreateIn) bool {
+				return in.Database == db.GetDatabaseName()
+			})).
+			Return(nil).Once()
+
+		r, res := runScenario(t, db, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.Database{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, got))
+		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
+		require.Contains(t, got.Finalizers, instanceDeletionFinalizer)
+	})
+
+	t.Run("Requeues without hard error on transient server error during create", func(t *testing.T) {
+		db := newDatabase(t)
+		db.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		expectServiceRunning(avn, db, 1)
+		avn.EXPECT().
+			ServiceDatabaseList(mock.Anything, db.Spec.Project, db.Spec.ServiceName).
+			Return(&service.ServiceDatabaseListOut{}, nil).Once()
+		avn.EXPECT().
+			ServiceDatabaseCreate(mock.Anything, db.Spec.Project, db.Spec.ServiceName, mock.Anything).
+			Return(newAivenError(501, "Not Implemented")).Once()
+
+		r, res, err := runScenarioErr(t, db, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := &v1alpha1.Database{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, got))
+		require.NotEqual(t, "1", got.Annotations[processedGenerationAnnotation])
+		require.Contains(t, got.Finalizers, instanceDeletionFinalizer)
+	})
+
+	t.Run("Marks running and requeues when database already exists", func(t *testing.T) {
+		db := newDatabase(t)
+		db.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		expectServiceRunning(avn, db, 1)
+		avn.EXPECT().
+			ServiceDatabaseList(mock.Anything, db.Spec.Project, db.Spec.ServiceName).
+			Return(&service.ServiceDatabaseListOut{Databases: []service.DatabaseOut{{DatabaseName: db.GetDatabaseName()}}}, nil).Once()
+
+		r, res := runScenario(t, db, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.Database{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, got))
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
+	})
+
+	t.Run("Deletes database and removes finalizer on deletion", func(t *testing.T) {
+		db := newDatabase(t)
+		db.Generation = 1
+		db.Finalizers = []string{instanceDeletionFinalizer}
+		now := metav1.Now()
+		db.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceDatabaseDelete(mock.Anything, db.Spec.Project, db.Spec.ServiceName, db.GetDatabaseName()).
+			Return(nil).Once()
+
+		r, res := runScenario(t, db, avn)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		got := &v1alpha1.Database{}
+		err := r.Get(t.Context(), types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+
+	t.Run("Ignores not found on deletion", func(t *testing.T) {
+		db := newDatabase(t)
+		db.Generation = 1
+		db.Finalizers = []string{instanceDeletionFinalizer}
+		now := metav1.Now()
+		db.DeletionTimestamp = &now
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceDatabaseDelete(mock.Anything, db.Spec.Project, db.Spec.ServiceName, db.GetDatabaseName()).
+			Return(newAivenError(404, "not found")).Once()
+
+		r, res := runScenario(t, db, avn)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		got := &v1alpha1.Database{}
+		err := r.Get(t.Context(), types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+
+	t.Run("Blocks deletion when termination protection is enabled", func(t *testing.T) {
+		db := newDatabase(t)
+		db.Generation = 1
+		db.Finalizers = []string{instanceDeletionFinalizer}
+		enabled := true
+		db.Spec.TerminationProtection = &enabled
+		now := metav1.Now()
+		db.DeletionTimestamp = &now
+
+		// No ServiceDatabaseDelete call is expected: termination protection short-circuits deletion.
+		avn := avngen.NewMockClient(t)
+
+		r, _, err := runScenarioErr(t, db, avn)
+		require.Error(t, err)
+
+		// The finalizer must remain so deletion is retried once protection is lifted.
+		got := &v1alpha1.Database{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: db.Name, Namespace: db.Namespace}, got))
+		require.Contains(t, got.Finalizers, instanceDeletionFinalizer)
+	})
+}
+
+func TestGetDatabaseByName(t *testing.T) {
+	t.Parallel()
+
+	const (
+		project = "test-project"
+		svc     = "test-service"
+	)
+
+	t.Run("Finds database on a later page by following the Next cursor", func(t *testing.T) {
+		avn := avngen.NewMockClient(t)
+		// First page: does not contain the target, but advertises a next page.
+		avn.EXPECT().
+			ServiceDatabaseList(mock.Anything, project, svc).
+			Return(&service.ServiceDatabaseListOut{
+				Databases: []service.DatabaseOut{{DatabaseName: "other-a"}, {DatabaseName: "other-b"}},
+				Next:      toOptionalStringPointer("cursor-1"),
+			}, nil).Once()
+		// Second page: fetched using the cursor from the first page, contains the target.
+		avn.EXPECT().
+			ServiceDatabaseList(mock.Anything, project, svc, [][2]string{service.ServiceDatabaseListAfter("cursor-1")}).
+			Return(&service.ServiceDatabaseListOut{
+				Databases: []service.DatabaseOut{{DatabaseName: "target"}},
+			}, nil).Once()
+
+		got, err := GetDatabaseByName(t.Context(), avn, project, svc, "target")
+		require.NoError(t, err)
+		require.Equal(t, "target", got.DatabaseName)
+	})
+
+	t.Run("Stops paging as soon as the database is found", func(t *testing.T) {
+		avn := avngen.NewMockClient(t)
+		// The first page contains the target. Even though Next is set, no second page must be requested.
+		avn.EXPECT().
+			ServiceDatabaseList(mock.Anything, project, svc).
+			Return(&service.ServiceDatabaseListOut{
+				Databases: []service.DatabaseOut{{DatabaseName: "target"}},
+				Next:      toOptionalStringPointer("cursor-1"),
+			}, nil).Once()
+
+		got, err := GetDatabaseByName(t.Context(), avn, project, svc, "target")
+		require.NoError(t, err)
+		require.Equal(t, "target", got.DatabaseName)
+	})
+
+	t.Run("Returns not found after exhausting all pages", func(t *testing.T) {
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceDatabaseList(mock.Anything, project, svc).
+			Return(&service.ServiceDatabaseListOut{
+				Databases: []service.DatabaseOut{{DatabaseName: "other-a"}},
+				Next:      toOptionalStringPointer("cursor-1"),
+			}, nil).Once()
+		avn.EXPECT().
+			ServiceDatabaseList(mock.Anything, project, svc, [][2]string{service.ServiceDatabaseListAfter("cursor-1")}).
+			Return(&service.ServiceDatabaseListOut{
+				Databases: []service.DatabaseOut{{DatabaseName: "other-b"}},
+			}, nil).Once()
+
+		_, err := GetDatabaseByName(t.Context(), avn, project, svc, "target")
+		require.True(t, isNotFound(err))
+	})
+
+	t.Run("Returns error after exceeding the page cap", func(t *testing.T) {
+		avn := avngen.NewMockClient(t)
+		// Each page reports a Next cursor so the loop never terminates naturally.
+		// The cap must kick in after maxDatabaseListPages iterations.
+		out := func(i int) *service.ServiceDatabaseListOut {
+			return &service.ServiceDatabaseListOut{
+				Databases: []service.DatabaseOut{{DatabaseName: "other"}},
+				Next:      toOptionalStringPointer(fmt.Sprintf("cursor-%d", i+1)),
+			}
+		}
+		avn.EXPECT().
+			ServiceDatabaseList(mock.Anything, project, svc).
+			Return(out(0), nil).Once()
+		for i := 1; i < maxDatabaseListPages; i++ {
+			avn.EXPECT().
+				ServiceDatabaseList(mock.Anything, project, svc, [][2]string{service.ServiceDatabaseListAfter(fmt.Sprintf("cursor-%d", i))}).
+				Return(out(i), nil).Once()
+		}
+
+		_, err := GetDatabaseByName(t.Context(), avn, project, svc, "target")
+		require.Error(t, err)
+		require.False(t, isNotFound(err))
+		require.ErrorContains(t, err, "exceeded")
+	})
+}

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -3,10 +3,14 @@
 package tests
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 	"github.com/aiven/aiven-operator/controllers"
@@ -170,4 +174,95 @@ func TestDatabase_databaseName(t *testing.T) {
 			}))
 		})
 	}
+
+	t.Run("immutable fields are rejected by the API server", func(t *testing.T) {
+		dbName := randName("database-immutable")
+
+		yml, err := loadExampleYaml("database.yaml", map[string]string{
+			"metadata.name":     dbName,
+			"spec.project":      cfg.Project,
+			"spec.serviceName":  pgName,
+			"spec.databaseName": "REMOVE",
+		})
+		require.NoError(t, err)
+		require.NoError(t, s.Apply(yml))
+
+		db := new(v1alpha1.Database)
+		require.NoError(t, s.GetRunning(db, dbName))
+
+		ymlUpdate, err := loadExampleYaml("database.yaml", map[string]string{
+			"metadata.name":     dbName,
+			"spec.project":      cfg.Project,
+			"spec.serviceName":  pgName,
+			"spec.databaseName": "REMOVE",
+			"spec.lcCtype":      "C",
+		})
+		require.NoError(t, err)
+
+		require.ErrorContains(t, s.Apply(ymlUpdate), "Value is immutable")
+	})
+}
+
+// TestDatabase_terminationProtection verifies that a Database with
+// spec.terminationProtection=true is not deleted on Aiven while protection is on.
+func TestDatabase_terminationProtection(t *testing.T) {
+	t.Parallel()
+	defer recoverPanic(t)
+
+	ctx, cancel := testCtx()
+	defer cancel()
+
+	pg, release, err := sharedResources.AcquirePostgreSQL(ctx)
+	require.NoError(t, err)
+	defer release()
+
+	s := NewSession(ctx, k8sClient)
+	defer s.Destroy(t)
+
+	pgName := pg.GetName()
+	dbName := randName("database-tp")
+
+	dbYaml := func(terminationProtection bool) string {
+		return fmt.Sprintf(`
+apiVersion: aiven.io/v1alpha1
+kind: Database
+metadata:
+  name: %[3]s
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+  project: %[1]s
+  serviceName: %[2]s
+  terminationProtection: %[4]t
+`, cfg.Project, pgName, dbName, terminationProtection)
+	}
+
+	// GIVEN a running database with termination protection enabled.
+	require.NoError(t, s.Apply(dbYaml(true)))
+
+	db := new(v1alpha1.Database)
+	require.NoError(t, s.GetRunning(db, dbName))
+
+	// WHEN we attempt to delete the Kubernetes resource.
+	// THEN the admission webhook rejects the request immediately.
+	err = k8sClient.Delete(ctx, db)
+	require.ErrorContains(t, err, "termination protection")
+
+	// AND the database still exists on Aiven.
+	_, err = controllers.GetDatabaseByName(ctx, avnGen, cfg.Project, pgName, dbName)
+	require.NoError(t, err)
+
+	// WHEN termination protection is disabled.
+	require.NoError(t, s.Apply(dbYaml(false)))
+
+	// Fetch the updated object so the delete call carries the current resourceVersion.
+	require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Namespace: defaultNamespace, Name: dbName}, db))
+
+	// THEN deletion is accepted and the database is gone from Aiven.
+	require.NoError(t, k8sClient.Delete(ctx, db))
+	require.Eventually(t, func() bool {
+		_, err := controllers.GetDatabaseByName(ctx, avnGen, cfg.Project, pgName, dbName)
+		return avngen.IsNotFound(err)
+	}, 2*time.Minute, 5*time.Second, "database %s should be deleted from Aiven", dbName)
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Migrated the `Database` controller to the `Reconciler[T]`
- `GetDatabaseByName` now **paginates** via the `Next` cursor instead of reading only the first page

Resolves: NEX-2663

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
