### PR TITLE
feat(charts): add extraEnvs to operator deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add kind: `OrganizationProject` to manage Aiven projects that belong to an organization or organizational unit.
 - Fix `KafkaACL`, `KafkaQuota`, and `KafkaSchemaRegistryACL` to reach the `ReadyToUse`
   state in a single reconcile cycle after creation or update.
+- Add `extraEnvs` option to Helm chart, to set additional environment variables on the operator deployment.
 
 ## v0.43.0 - 2026-07-24
 

--- a/charts/aiven-operator/ci/test-values.yaml
+++ b/charts/aiven-operator/ci/test-values.yaml
@@ -1,2 +1,8 @@
 webhooks:
   enabled: false
+
+# Renders the extraEnvs block without affecting the operator's runtime behaviour;
+# proxy variables would break `ct install` against the kind cluster.
+extraEnvs:
+  - name: AIVEN_OPERATOR_CI_EXTRA_ENV
+    value: chart-testing

--- a/charts/aiven-operator/templates/deployment.yaml
+++ b/charts/aiven-operator/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
             - name: WATCHED_NAMESPACES
               value: {{ . | uniq | join "," | quote }}
             {{- end }}
+            {{- with .Values.extraEnvs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           command:
             - /manager
           args:

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -10,6 +10,12 @@ metricsBindAddress: ""
 healthProbeBindAddress: ""
 leaderElect: true
 
+# Extra environment variables for the operator container.
+# extraEnvs:
+#   - name: example_name
+#     value: "example_value"
+extraEnvs: []
+
 # Default Aiven Token Secret
 # Configure a single Aiven API token that can be used by all resources.
 # This eliminates the need to create token secrets in every namespace.


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Adds an `extraEnvs` value to the `aiven-operator` Helm chart, rendering additional environment variables into the container. Defaults to `[]`, so rendered output is unchanged for existing users.

Carried over from [aiven/aiven-charts#92](https://github.com/aiven/aiven-charts/pull/92).

Resolves: NEX-2790

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
