### PR TITLE
fix(kafkaacl,kafkaquota,kafkaschemaregistryacl): reach IsReadyToUse in a single reconcile cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - Add kind: `OrganizationProject` to manage Aiven projects that belong to an organization or organizational unit.
+- Fix `KafkaACL`, `KafkaQuota`, and `KafkaSchemaRegistryACL` to reach the `ReadyToUse`
+  state in a single reconcile cycle after creation or update.
 
 ## v0.43.0 - 2026-07-24
 

--- a/controllers/kafkaacl_controller.go
+++ b/controllers/kafkaacl_controller.go
@@ -62,6 +62,7 @@ func (r *KafkaACLController) Create(ctx context.Context, acl *v1alpha1.KafkaACL)
 	if err := r.applyACL(ctx, acl); err != nil {
 		return CreateResult{}, err
 	}
+	markInstanceRunning(acl)
 	return CreateResult{}, nil
 }
 
@@ -69,6 +70,7 @@ func (r *KafkaACLController) Update(ctx context.Context, acl *v1alpha1.KafkaACL)
 	if err := r.applyACL(ctx, acl); err != nil {
 		return UpdateResult{}, err
 	}
+	markInstanceRunning(acl)
 	return UpdateResult{}, nil
 }
 

--- a/controllers/kafkaacl_controller_test.go
+++ b/controllers/kafkaacl_controller_test.go
@@ -123,13 +123,13 @@ func TestKafkaACLReconciler(t *testing.T) {
 
 		r, res, err := runKafkaACLScenario(t, acl, avn)
 		require.NoError(t, err)
-		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
 
 		got := &v1alpha1.KafkaACL{}
 		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got))
 		require.Equal(t, "acl-id", got.Status.ID)
 		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
-		require.NotContains(t, got.Annotations, instanceIsRunningAnnotation)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
 	})
 
 	t.Run("Marks KafkaACL running when it already exists", func(t *testing.T) {
@@ -283,11 +283,12 @@ func TestKafkaACLReconciler(t *testing.T) {
 
 		r, res, err := runKafkaACLScenario(t, acl, avn)
 		require.NoError(t, err)
-		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
 
 		got := &v1alpha1.KafkaACL{}
 		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got))
 		require.Equal(t, "new-id", got.Status.ID)
 		require.Equal(t, "2", got.Annotations[processedGenerationAnnotation])
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
 	})
 }

--- a/controllers/kafkaquota_controller.go
+++ b/controllers/kafkaquota_controller.go
@@ -72,7 +72,7 @@ func (r *KafkaQuotaController) Create(ctx context.Context, q *v1alpha1.KafkaQuot
 
 	const reason = "CreatedOrUpdated"
 	meta.SetStatusCondition(&q.Status.Conditions, getInitializedCondition(reason, "Successfully created or updated the instance in Aiven"))
-	meta.SetStatusCondition(&q.Status.Conditions, getRunningCondition(metav1.ConditionUnknown, reason, "Successfully created or updated the instance in Aiven, status remains unknown"))
+	markInstanceRunning(q)
 
 	return CreateResult{}, nil
 }
@@ -85,7 +85,7 @@ func (r *KafkaQuotaController) Update(ctx context.Context, q *v1alpha1.KafkaQuot
 
 	const reason = "CreatedOrUpdated"
 	meta.SetStatusCondition(&q.Status.Conditions, getInitializedCondition(reason, "Successfully created or updated the instance in Aiven"))
-	meta.SetStatusCondition(&q.Status.Conditions, getRunningCondition(metav1.ConditionUnknown, reason, "Successfully created or updated the instance in Aiven, status remains unknown"))
+	markInstanceRunning(q)
 
 	return UpdateResult{}, nil
 }

--- a/controllers/kafkaquota_controller_test.go
+++ b/controllers/kafkaquota_controller_test.go
@@ -234,12 +234,12 @@ func TestKafkaQuotaReconciler(t *testing.T) {
 
 		r, res, err := runKafkaQuotaScenario(t, quota, avn)
 		require.NoError(t, err)
-		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
 
 		got := &v1alpha1.KafkaQuota{}
 		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: quota.Name, Namespace: quota.Namespace}, got))
 		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
-		require.NotContains(t, got.Annotations, instanceIsRunningAnnotation)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
 	})
 
 	t.Run("Marks KafkaQuota running when remote quota matches spec", func(t *testing.T) {
@@ -303,12 +303,12 @@ func TestKafkaQuotaReconciler(t *testing.T) {
 
 		r, res, err := runKafkaQuotaScenario(t, quota, avn)
 		require.NoError(t, err)
-		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
 
 		got := &v1alpha1.KafkaQuota{}
 		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: quota.Name, Namespace: quota.Namespace}, got))
 		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
-		require.NotContains(t, got.Annotations, instanceIsRunningAnnotation)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
 	})
 
 	t.Run("Deletes KafkaQuota and removes finalizer on deletion", func(t *testing.T) {

--- a/controllers/kafkaschemaregistryacl_controller.go
+++ b/controllers/kafkaschemaregistryacl_controller.go
@@ -68,6 +68,8 @@ func (r *KafkaSchemaRegistryACLController) Create(ctx context.Context, acl *v1al
 	if err := r.addACL(ctx, acl); err != nil {
 		return CreateResult{}, err
 	}
+
+	markInstanceRunning(acl)
 	return CreateResult{}, nil
 }
 

--- a/controllers/kafkaschemaregistryacl_controller_test.go
+++ b/controllers/kafkaschemaregistryacl_controller_test.go
@@ -112,13 +112,13 @@ func TestKafkaSchemaRegistryACLReconciler(t *testing.T) {
 
 		r, res, err := runKafkaSchemaRegistryACLScenario(t, acl, avn)
 		require.NoError(t, err)
-		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
 
 		got := &v1alpha1.KafkaSchemaRegistryACL{}
 		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got))
 		require.Equal(t, "acl-id", got.Status.ACLId)
 		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
-		require.NotContains(t, got.Annotations, instanceIsRunningAnnotation)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
 	})
 
 	t.Run("Fails when the created ACL is absent from the Aiven response", func(t *testing.T) {
@@ -209,12 +209,12 @@ func TestKafkaSchemaRegistryACLReconciler(t *testing.T) {
 
 		r, res, err := runKafkaSchemaRegistryACLScenario(t, acl, avn)
 		require.NoError(t, err)
-		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
 
 		got := &v1alpha1.KafkaSchemaRegistryACL{}
 		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got))
 		require.Equal(t, "new-id", got.Status.ACLId)
-		require.NotContains(t, got.Annotations, instanceIsRunningAnnotation)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
 	})
 
 	t.Run("Deletes KafkaSchemaRegistryACL and removes finalizer on deletion", func(t *testing.T) {


### PR DESCRIPTION
## About this change—what it does

`IsReadyToUse` requires the `instance-is-running` annotation and the processed-generation annotation. The reconciler writes processed-generation in `completeReconcileSuccess`, but the running annotation is the controller's job, and `Create` and `Update` never set it here. So the first cycle finished not ready and requeued after `requeueTimeout` (10 s), and only the next cycle's `Observe` marked it running. Anything gating on readiness through `GetRefs` waited that extra cycle.

All three now call `markInstanceRunning` before returning:

- `KafkaACL`: `Create` and `Update`.
- `KafkaQuota`: `Create` and `Update`, replacing the `Running=Unknown` write that the running state now contradicts.
- `KafkaSchemaRegistryACL`: `Create` only, leaving its adoption behaviour alone. `Update` is unreachable, because `Observe` never reports an existing ACL as out of date.

`KafkaNativeACL`, `ConnectionPool` and `UpgradePipelineStep` already did this.

## Why this way

For these kinds `Observe` already sets the running condition on nothing more than the resource being present on Aiven, so `Create` asserts what the next cycle would. Unlike `KafkaTopic` there is no provisioning state to wait on.
