### PR TITLE
feat(project_vpc): ignore deleted vpcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add `extraEnvs` option to Helm chart, to set additional environment variables on the operator deployment.
 - Add `logging.encoder` option to Helm chart, to log in `json` or `console` format.
 - Add `Valkey` field `userConfig.valkey_activedefrag`, type `boolean`: Enable active memory defragmentation
+- Fix `ProjectVPC` adopting a VPC that Aiven is already tearing down. Re-creating a `ProjectVPC` with the
+  same `cloudName` and `networkCidr` shortly after deleting one left the resource waiting forever for an
+  `ACTIVE` state. It now waits for the old VPC to disappear and then creates a replacement.
 
 ## v0.43.0 - 2026-07-24
 

--- a/controllers/projectvpc_controller.go
+++ b/controllers/projectvpc_controller.go
@@ -47,13 +47,25 @@ func (r *ProjectVPCController) Observe(ctx context.Context, projectVPC *v1alpha1
 			return Observation{}, fmt.Errorf("cannot list project VPCs: %w", err)
 		}
 
-		for _, v := range vpcs {
-			// cloudName + networkCidr uniquely identify a VPC within a project, and both are
-			// immutable on the spec, so a match is unambiguously our resource.
-			if v.CloudName == projectVPC.Spec.CloudName && v.NetworkCidr == projectVPC.Spec.NetworkCidr {
-				projectVPC.Status.ID = v.ProjectVpcId
-				return r.observeState(projectVPC, v.State), nil
+		var pending *vpc.VpcOut
+		for i, v := range vpcs {
+			if !vpcMatchesSpec(v, projectVPC.Spec) {
+				continue
 			}
+
+			// A VPC still being torn down can be neither adopted nor replaced.
+			if isVPCGone(v.State) {
+				pending = &vpcs[i]
+				continue
+			}
+
+			projectVPC.Status.ID = v.ProjectVpcId
+			return r.observeState(projectVPC, v.State), nil
+		}
+
+		if pending != nil {
+			return Observation{}, fmt.Errorf("%w: vpc %s with the same cloudName and networkCidr is %s, waiting for it to be removed before creating a replacement",
+				errPreconditionNotMet, pending.ProjectVpcId, pending.State)
 		}
 
 		// No matching VPC exists yet; let the reconciler create one.
@@ -70,6 +82,17 @@ func (r *ProjectVPCController) Observe(ctx context.Context, projectVPC *v1alpha1
 	}
 
 	return r.observeState(projectVPC, avnVpc.State), nil
+}
+
+// vpcMatchesSpec reports whether the remote VPC is the one this resource describes.
+// cloudName and networkCidr uniquely identify a VPC within a project.
+func vpcMatchesSpec(v vpc.VpcOut, spec v1alpha1.ProjectVPCSpec) bool {
+	return v.CloudName == spec.CloudName && v.NetworkCidr == spec.NetworkCidr
+}
+
+// isVPCGone reports whether Aiven has already torn the VPC down.
+func isVPCGone(state vpc.VpcStateType) bool {
+	return state == vpc.VpcStateTypeDeleting || state == vpc.VpcStateTypeDeleted
 }
 
 // observeState records the observed VPC state on the status and reports whether the resource
@@ -129,9 +152,8 @@ func (r *ProjectVPCController) Delete(ctx context.Context, projectVPC *v1alpha1.
 		return err
 	}
 
-	switch avnVpc.State {
-	case vpc.VpcStateTypeDeleting, vpc.VpcStateTypeDeleted:
-		// Deletion already confirmed on Aiven side; remove the finalizer.
+	// Deletion already confirmed on Aiven side; remove the finalizer.
+	if isVPCGone(avnVpc.State) {
 		return nil
 	}
 

--- a/controllers/projectvpc_controller_test.go
+++ b/controllers/projectvpc_controller_test.go
@@ -138,6 +138,84 @@ func TestProjectVPCReconciler(t *testing.T) {
 		require.Equal(t, "1", got.Annotations[processedGenerationAnnotation])
 	})
 
+	for _, tc := range []struct {
+		name  string
+		state vpc.VpcStateType
+	}{
+		{"DELETING", vpc.VpcStateTypeDeleting},
+		{"DELETED", vpc.VpcStateTypeDeleted},
+	} {
+		t.Run("Waits instead of adopting or replacing a "+tc.name+" VPC matching the spec", func(t *testing.T) {
+			vpcObj := newProjectVPC(t)
+			vpcObj.Generation = 1
+
+			avn := avngen.NewMockClient(t)
+			avn.EXPECT().
+				VpcList(mock.Anything, vpcObj.Spec.Project).
+				Return([]vpc.VpcOut{
+					// Matches the spec, but is being torn down. Adopting it would wait for an
+					// ACTIVE state that never comes; creating a replacement cannot work while it
+					// still holds the cloudName + networkCidr key.
+					{ProjectVpcId: "gone-id", CloudName: vpcObj.Spec.CloudName, NetworkCidr: vpcObj.Spec.NetworkCidr, State: tc.state},
+				}, nil).Once()
+			// Neither VpcCreate nor any other call: the precondition is simply not met yet.
+
+			r, res := runScenario(t, vpcObj, avn)
+			require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+			got := getVPC(t, r, vpcObj)
+			require.Empty(t, got.Status.ID, "must not adopt the VPC being torn down")
+			// A precondition wait is not an error state, so no Error condition is recorded.
+			require.Nil(t, meta.FindStatusCondition(got.Status.Conditions, ConditionTypeError))
+		})
+	}
+
+	t.Run("A torn-down VPC with a different key does not block creation", func(t *testing.T) {
+		vpcObj := newProjectVPC(t)
+		vpcObj.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			VpcList(mock.Anything, vpcObj.Spec.Project).
+			Return([]vpc.VpcOut{
+				// Being torn down, but holds a different CIDR, so it occupies no key of ours.
+				{ProjectVpcId: "gone-id", CloudName: vpcObj.Spec.CloudName, NetworkCidr: "10.99.0.0/24", State: vpc.VpcStateTypeDeleting},
+			}, nil).Once()
+		avn.EXPECT().
+			VpcCreate(mock.Anything, vpcObj.Spec.Project, mock.Anything).
+			Return(&vpc.VpcCreateOut{ProjectVpcId: "new-vpc-id", State: vpc.VpcStateTypeApproved}, nil).Once()
+
+		r, res := runScenario(t, vpcObj, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: requeueTimeout}, res)
+
+		got := getVPC(t, r, vpcObj)
+		require.Equal(t, "new-vpc-id", got.Status.ID)
+	})
+
+	t.Run("Adopts the live VPC when a torn-down one with the same key is listed first", func(t *testing.T) {
+		vpcObj := newProjectVPC(t)
+		vpcObj.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			VpcList(mock.Anything, vpcObj.Spec.Project).
+			Return([]vpc.VpcOut{
+				// A previous VPC with the same cloud and CIDR, already deleted. It must not
+				// shadow the live one that follows it.
+				{ProjectVpcId: "gone-id", CloudName: vpcObj.Spec.CloudName, NetworkCidr: vpcObj.Spec.NetworkCidr, State: vpc.VpcStateTypeDeleted},
+				{ProjectVpcId: "adopted-id", CloudName: vpcObj.Spec.CloudName, NetworkCidr: vpcObj.Spec.NetworkCidr, State: vpc.VpcStateTypeActive},
+			}, nil).Once()
+		// VpcCreate must NOT be called: the live VPC is adopted.
+
+		r, res := runScenario(t, vpcObj, avn)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := getVPC(t, r, vpcObj)
+		require.Equal(t, "adopted-id", got.Status.ID)
+		require.Equal(t, vpc.VpcStateTypeActive, got.Status.State)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+	})
+
 	t.Run("APPROVED state does not mark running and soft-requeues", func(t *testing.T) {
 		vpcObj := newProjectVPC(t)
 		vpcObj.Generation = 1


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- `ProjectVPC.Observe` adopts a pre-existing VPC by matching `cloudName` + `networkCidr`, but did not check the VPC's state. A VPC that Aiven was already tearing down would be adopted, and since `observeState` only marks the resource running on `ACTIVE`, the CR requeued forever waiting for a state that never arrives — and never created the replacement VPC.

- Adoption now skips `DELETING`/`DELETED` VPCs.

Resolves: NEX-2793

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
