### PR TITLE
fix(kafkanativeacl,kafkaschemaregistryacl): decide ACL existence by spec match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
   present on Aiven instead of trying to create a second one. Existence is decided by matching
   every identifying field against the ACL list. This
   covers an ACLs created outside the operator as well. Note
-  that an adopted ACL is deleted together with the custom resource unless `deletionPolicy: Orphan`
-  is set.
+  that an adopted ACL is deleted together with the custom resource unless the
+  `controllers.aiven.io/deletion-policy: Orphan` annotation is set.
 - Fix `KafkaSchema` never converging when `schema` and `compatibilityLevel` change in the same apply:
   the compatibility level is now set before the new schema version is registered. Behavior change: a
   rejected schema leaves the new level applied, and tightening the level alongside a schema that violates it now fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - `ServiceUser`: increased the amount of concurrent reconcilers up to 10
+- Fix `KafkaNativeACL` and `KafkaSchemaRegistryACL` to adopt the matching ACL that is already
+  present on Aiven instead of trying to create a second one. Existence is decided by matching
+  every identifying field against the ACL list. This
+  covers an ACLs created outside the operator as well. Note
+  that an adopted ACL is deleted together with the custom resource unless `deletionPolicy: Orphan`
+  is set.
 - Fix `KafkaSchema` never converging when `schema` and `compatibilityLevel` change in the same apply:
   the compatibility level is now set before the new schema version is registered. Behavior change: a
   rejected schema leaves the new level applied, and tightening the level alongside a schema that violates it now fails.
@@ -36,10 +42,6 @@
 ## v0.44.0 - 2026-08-11
 
 - Add kind: `OrganizationProject` to manage Aiven projects that belong to an organization or organizational unit.
-- Fix `KafkaNativeACL` and `KafkaSchemaRegistryACL` to adopt an existing matching ACL when
-  the custom resource is created while the ACL is already present on Aiven, for example
-  after an `Orphan` deletion. Previously `KafkaNativeACL` failed with a 409 conflict and
-  `KafkaSchemaRegistryACL` created a duplicate entry.
 - Fix `KafkaACL`, `KafkaQuota`, and `KafkaSchemaRegistryACL` to reach the `ReadyToUse`
   state in a single reconcile cycle after creation or update.
 - Add `extraEnvs` option to Helm chart, to set additional environment variables on the operator deployment.

--- a/controllers/kafkanativeacl_controller.go
+++ b/controllers/kafkanativeacl_controller.go
@@ -8,6 +8,7 @@ import (
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafka"
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
@@ -38,37 +39,30 @@ func (r *KafkaNativeACLController) Observe(ctx context.Context, acl *v1alpha1.Ka
 		return Observation{}, err
 	}
 
-	if acl.Status.ID == "" {
-		// No stored ID — the ACL may already exist on Aiven, e.g. the CR was recreated after a
-		// deletionPolicy:Orphan deletion, or the ACL was created outside the operator. Check the
-		// live list before creating.
-		list, err := r.avnGen.ServiceKafkaNativeAclList(ctx, acl.Spec.Project, acl.Spec.ServiceName)
-		if err != nil {
-			return Observation{}, fmt.Errorf("list Kafka-native ACLs error: %w", err)
-		}
-		for _, existing := range list.KafkaAcl {
-			if nativeSpecMatches(acl.Spec, existing) {
-				acl.Status.ID = existing.Id
-				markInstanceRunning(acl)
-				// The spec is immutable, so an adopted ACL is always up to date.
-				return Observation{ResourceExists: true, ResourceUpToDate: true}, nil
-			}
-		}
-		return Observation{ResourceExists: false}, nil
+	list, err := r.avnGen.ServiceKafkaNativeAclList(ctx, acl.Spec.Project, acl.Spec.ServiceName)
+	if err != nil {
+		return Observation{}, fmt.Errorf("list Kafka-native ACLs error: %w", err)
 	}
 
-	_, err := r.avnGen.ServiceKafkaNativeAclGet(ctx, acl.Spec.Project, acl.Spec.ServiceName, acl.Status.ID)
-	switch {
-	case isNotFound(err):
-		return Observation{ResourceExists: false}, nil
-	case err != nil:
-		return Observation{}, fmt.Errorf("get Kafka-native ACL error: %w", err)
+	for _, existing := range list.KafkaAcl {
+		if !nativeSpecMatches(acl.Spec, existing) {
+			continue
+		}
+
+		if acl.Status.ID != existing.Id {
+			// Adopting an entry this CR did not create.
+			logr.FromContextOrDiscard(ctx).Info("adopting existing Kafka-native ACL",
+				"aclID", existing.Id, "cachedID", acl.Status.ID)
+			acl.Status.ID = existing.Id
+		}
+
+		markInstanceRunning(acl)
+
+		// The spec is immutable, so an existing ACL is always up to date.
+		return Observation{ResourceExists: true, ResourceUpToDate: true}, nil
 	}
 
-	markInstanceRunning(acl)
-
-	// The spec is immutable, so an existing ACL is always up to date.
-	return Observation{ResourceExists: true, ResourceUpToDate: true}, nil
+	return Observation{ResourceExists: false}, nil
 }
 
 func (r *KafkaNativeACLController) Create(ctx context.Context, acl *v1alpha1.KafkaNativeACL) (CreateResult, error) {
@@ -102,6 +96,10 @@ func (r *KafkaNativeACLController) Update(_ context.Context, acl *v1alpha1.Kafka
 }
 
 func (r *KafkaNativeACLController) Delete(ctx context.Context, acl *v1alpha1.KafkaNativeACL) error {
+	if acl.Status.ID == "" {
+		return nil
+	}
+
 	err := r.avnGen.ServiceKafkaNativeAclDelete(ctx, acl.Spec.Project, acl.Spec.ServiceName, acl.Status.ID)
 	if err != nil && !isNotFound(err) {
 		return fmt.Errorf("delete Kafka-native ACL error: %w", err)
@@ -112,11 +110,19 @@ func (r *KafkaNativeACLController) Delete(ctx context.Context, acl *v1alpha1.Kaf
 // nativeSpecMatches reports whether an existing Kafka-native ACL from Aiven matches the CR
 // spec. All immutable identifying fields are compared.
 func nativeSpecMatches(spec v1alpha1.KafkaNativeACLSpec, existing kafka.KafkaAclOut) bool {
-	return spec.Host == existing.Host &&
+	return normalizeACLHost(spec.Host) == normalizeACLHost(existing.Host) &&
 		spec.Principal == existing.Principal &&
 		spec.ResourceName == existing.ResourceName &&
 		spec.Operation == existing.Operation &&
 		spec.PatternType == existing.PatternType &&
 		string(spec.PermissionType) == string(existing.PermissionType) &&
 		spec.ResourceType == existing.ResourceType
+}
+
+// normalizeACLHost resolves an empty host to the wildcard the spec defaults to.
+func normalizeACLHost(host string) string {
+	if host == "" {
+		return "*"
+	}
+	return host
 }

--- a/controllers/kafkanativeacl_controller_test.go
+++ b/controllers/kafkanativeacl_controller_test.go
@@ -38,6 +38,23 @@ spec:
   resourceType: Topic
 `
 
+// nativeACLListWith returns a list response holding one remote entry that matches the CR spec
+// under the given ID.
+func nativeACLListWith(acl *v1alpha1.KafkaNativeACL, id string) *kafka.ServiceKafkaNativeAclListOut {
+	return &kafka.ServiceKafkaNativeAclListOut{
+		KafkaAcl: []kafka.KafkaAclOut{{
+			Id:             id,
+			Host:           acl.Spec.Host,
+			Operation:      acl.Spec.Operation,
+			PatternType:    acl.Spec.PatternType,
+			PermissionType: kafka.KafkaAclPermissionType(acl.Spec.PermissionType),
+			Principal:      acl.Spec.Principal,
+			ResourceName:   acl.Spec.ResourceName,
+			ResourceType:   acl.Spec.ResourceType,
+		}},
+	}
+}
+
 func runKafkaNativeACLScenario(
 	t *testing.T,
 	acl *v1alpha1.KafkaNativeACL,
@@ -106,7 +123,7 @@ func TestKafkaNativeACLReconciler(t *testing.T) {
 		avn.EXPECT().
 			ServiceGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
 			Return(runningService(), nil).Once()
-		// New path: list is checked first; empty list means no orphan to adopt.
+		// Existence comes from the live list; an empty list means there is nothing to adopt.
 		avn.EXPECT().
 			ServiceKafkaNativeAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
 			Return(&kafka.ServiceKafkaNativeAclListOut{KafkaAcl: nil}, nil).Once()
@@ -146,8 +163,8 @@ func TestKafkaNativeACLReconciler(t *testing.T) {
 			ServiceGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
 			Return(runningService(), nil).Once()
 		avn.EXPECT().
-			ServiceKafkaNativeAclGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, "acl-123").
-			Return(&kafka.ServiceKafkaNativeAclGetOut{Id: "acl-123"}, nil).Once()
+			ServiceKafkaNativeAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
+			Return(nativeACLListWith(acl, "acl-123"), nil).Once()
 
 		r, res, err := runKafkaNativeACLScenario(t, acl, avn)
 		require.NoError(t, err)
@@ -155,22 +172,27 @@ func TestKafkaNativeACLReconciler(t *testing.T) {
 
 		got := &v1alpha1.KafkaNativeACL{}
 		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got))
+		require.Equal(t, "acl-123", got.Status.ID)
 		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
 	})
 
-	t.Run("Recreates KafkaNativeACL when status ID is stale (404 on get)", func(t *testing.T) {
+	t.Run("Recreates KafkaNativeACL when no remote entry matches the spec", func(t *testing.T) {
 		acl := newObjectFromYAML[v1alpha1.KafkaNativeACL](t, yamlKafkaNativeACL)
 		acl.Generation = 1
 		acl.Status.ID = "stale-id"
 		acl.Annotations = map[string]string{processedGenerationAnnotation: "1"}
+
+		// An unrelated entry on the same service must not be mistaken for this one.
+		other := nativeACLListWith(acl, "other-acl-id")
+		other.KafkaAcl[0].Principal = "User:bob"
 
 		avn := avngen.NewMockClient(t)
 		avn.EXPECT().
 			ServiceGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
 			Return(runningService(), nil).Once()
 		avn.EXPECT().
-			ServiceKafkaNativeAclGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, "stale-id").
-			Return(nil, newAivenError(404, "not found")).Once()
+			ServiceKafkaNativeAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
+			Return(other, nil).Once()
 		avn.EXPECT().
 			ServiceKafkaNativeAclAdd(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
 			Return(&kafka.ServiceKafkaNativeAclAddOut{Id: "acl-456"}, nil).Once()
@@ -182,6 +204,76 @@ func TestKafkaNativeACLReconciler(t *testing.T) {
 		got := &v1alpha1.KafkaNativeACL{}
 		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got))
 		require.Equal(t, "acl-456", got.Status.ID)
+	})
+
+	t.Run("Re-adopts KafkaNativeACL when the entry was recreated under a new ID", func(t *testing.T) {
+		// Aiven assigns a fresh ID whenever an entry is recreated, so a cached ID can point at
+		// nothing while an identical entry exists. Creating again would 409 forever.
+		acl := newObjectFromYAML[v1alpha1.KafkaNativeACL](t, yamlKafkaNativeACL)
+		acl.Generation = 1
+		acl.Status.ID = "stale-id"
+		acl.Annotations = map[string]string{processedGenerationAnnotation: "1"}
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceKafkaNativeAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
+			Return(nativeACLListWith(acl, "recreated-acl-id"), nil).Once()
+		// ServiceKafkaNativeAclAdd must NOT be called.
+
+		r, res, err := runKafkaNativeACLScenario(t, acl, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.KafkaNativeACL{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got))
+		require.Equal(t, "recreated-acl-id", got.Status.ID)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+	})
+
+	t.Run("Adopts KafkaNativeACL when Aiven reports an empty host", func(t *testing.T) {
+		// Aiven only substitutes "*" for a missing host key, so an entry created elsewhere
+		// with an explicit empty host still means all hosts.
+		acl := newObjectFromYAML[v1alpha1.KafkaNativeACL](t, yamlKafkaNativeACL)
+		acl.Generation = 1
+		require.Equal(t, "*", acl.Spec.Host)
+
+		emptyHost := nativeACLListWith(acl, "empty-host-acl-id")
+		emptyHost.KafkaAcl[0].Host = ""
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceKafkaNativeAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
+			Return(emptyHost, nil).Once()
+
+		r, res, err := runKafkaNativeACLScenario(t, acl, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.KafkaNativeACL{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got))
+		require.Equal(t, "empty-host-acl-id", got.Status.ID)
+	})
+
+	t.Run("Fails reconcile when the KafkaNativeACL list call fails", func(t *testing.T) {
+		acl := newObjectFromYAML[v1alpha1.KafkaNativeACL](t, yamlKafkaNativeACL)
+		acl.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceKafkaNativeAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
+			Return(nil, newAivenError(400, "bad request")).Once()
+
+		_, _, err := runKafkaNativeACLScenario(t, acl, avn)
+		require.ErrorContains(t, err, "list Kafka-native ACLs error")
 	})
 
 	t.Run("Deletes KafkaNativeACL and removes finalizer on deletion", func(t *testing.T) {
@@ -228,6 +320,25 @@ func TestKafkaNativeACLReconciler(t *testing.T) {
 		require.True(t, apierrors.IsNotFound(err))
 	})
 
+	t.Run("Skips the Aiven delete when no KafkaNativeACL ID was ever recorded", func(t *testing.T) {
+		acl := newObjectFromYAML[v1alpha1.KafkaNativeACL](t, yamlKafkaNativeACL)
+		acl.Generation = 1
+		acl.Finalizers = []string{instanceDeletionFinalizer}
+		now := metav1.Now()
+		acl.DeletionTimestamp = &now
+
+		// No Aiven call is expected: there is nothing to address without an ID.
+		avn := avngen.NewMockClient(t)
+
+		r, res, err := runKafkaNativeACLScenario(t, acl, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{}, res)
+
+		got := &v1alpha1.KafkaNativeACL{}
+		err = r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got)
+		require.True(t, apierrors.IsNotFound(err))
+	})
+
 	t.Run("Adopts orphaned KafkaNativeACL when status ID is empty but spec matches existing entry", func(t *testing.T) {
 		// Simulates: CR deleted with deletionPolicy:Orphan, then re-applied.
 		// The operator must adopt the existing ACL instead of trying to create a duplicate.
@@ -241,20 +352,7 @@ func TestKafkaNativeACLReconciler(t *testing.T) {
 			Return(runningService(), nil).Once()
 		avn.EXPECT().
 			ServiceKafkaNativeAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
-			Return(&kafka.ServiceKafkaNativeAclListOut{
-				KafkaAcl: []kafka.KafkaAclOut{
-					{
-						Id:             "orphaned-acl-id",
-						Principal:      acl.Spec.Principal,
-						ResourceName:   acl.Spec.ResourceName,
-						Operation:      acl.Spec.Operation,
-						PatternType:    acl.Spec.PatternType,
-						PermissionType: kafka.KafkaAclPermissionType(acl.Spec.PermissionType),
-						ResourceType:   acl.Spec.ResourceType,
-						Host:           acl.Spec.Host,
-					},
-				},
-			}, nil).Once()
+			Return(nativeACLListWith(acl, "orphaned-acl-id"), nil).Once()
 		// ServiceKafkaNativeAclAdd must NOT be called — adoption avoids the 409.
 
 		r, res, err := runKafkaNativeACLScenario(t, acl, avn)
@@ -284,6 +382,12 @@ func TestNativeSpecMatches(t *testing.T) {
 		ResourceType:   spec.ResourceType,
 	}
 	require.True(t, nativeSpecMatches(spec, remote))
+
+	// Aiven stores an explicitly empty host verbatim, but it means the same as the "*" the
+	// spec defaults to.
+	emptyHost := remote
+	emptyHost.Host = ""
+	require.True(t, nativeSpecMatches(spec, emptyHost))
 
 	// Every field below is part of the Kafka ACL identity tuple, so a difference in any
 	// single one of them must prevent adoption.

--- a/controllers/kafkaschemaregistryacl_controller.go
+++ b/controllers/kafkaschemaregistryacl_controller.go
@@ -5,10 +5,10 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkaschemaregistry"
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
@@ -39,40 +39,30 @@ func (r *KafkaSchemaRegistryACLController) Observe(ctx context.Context, acl *v1a
 		return Observation{}, err
 	}
 
-	if acl.Status.ACLId == "" {
-		// No stored ID — adopt an existing ACL if one matches the spec, e.g. after an
-		// Orphan-policy deletion and re-application of the CR, or an ACL created outside
-		// the operator.
-		list, err := r.avnGen.ServiceSchemaRegistryAclList(ctx, acl.Spec.Project, acl.Spec.ServiceName)
-		if err != nil {
-			return Observation{}, fmt.Errorf("cannot list KafkaSchemaRegistryACLs on Aiven side: %w", err)
-		}
-		for _, existing := range list {
-			if existing.Id != nil && schemaRegistrySpecMatches(acl.Spec, existing) {
-				acl.Status.ACLId = *existing.Id
-				markInstanceRunning(acl)
-				return Observation{ResourceExists: true, ResourceUpToDate: true}, nil
-			}
-		}
-		return Observation{ResourceExists: false}, nil
-	}
-
-	exists, err := r.exists(ctx, acl)
+	list, err := r.avnGen.ServiceSchemaRegistryAclList(ctx, acl.Spec.Project, acl.Spec.ServiceName)
 	if err != nil {
-		return Observation{}, err
+		return Observation{}, fmt.Errorf("cannot list KafkaSchemaRegistryACLs on Aiven side: %w", err)
 	}
 
-	// Spec fields are immutable
-	if !exists {
-		return Observation{ResourceExists: false}, nil
+	for _, existing := range list {
+		if existing.Id == nil || !schemaRegistrySpecMatches(acl.Spec, existing) {
+			continue
+		}
+
+		if acl.Status.ACLId != *existing.Id {
+			// Adopting an entry this CR did not create.
+			logr.FromContextOrDiscard(ctx).Info("adopting existing KafkaSchemaRegistryACL",
+				"aclID", *existing.Id)
+			acl.Status.ACLId = *existing.Id
+		}
+
+		markInstanceRunning(acl)
+
+		// Spec fields are immutable, so an existing ACL is always up to date.
+		return Observation{ResourceExists: true, ResourceUpToDate: true}, nil
 	}
 
-	markInstanceRunning(acl)
-
-	return Observation{
-		ResourceExists:   true,
-		ResourceUpToDate: true,
-	}, nil
+	return Observation{ResourceExists: false}, nil
 }
 
 func (r *KafkaSchemaRegistryACLController) Create(ctx context.Context, acl *v1alpha1.KafkaSchemaRegistryACL) (CreateResult, error) {
@@ -130,22 +120,6 @@ func (r *KafkaSchemaRegistryACLController) addACL(ctx context.Context, acl *v1al
 	}
 
 	return fmt.Errorf("created KafkaSchemaRegistryACL not found in Aiven response")
-}
-
-// exists reports whether the ACL identified by Status.ACLId is present on Aiven.
-func (r *KafkaSchemaRegistryACLController) exists(
-	ctx context.Context,
-	acl *v1alpha1.KafkaSchemaRegistryACL,
-) (bool, error) {
-	list, err := r.avnGen.ServiceSchemaRegistryAclList(ctx, acl.Spec.Project, acl.Spec.ServiceName)
-	if err != nil {
-		return false, err
-	}
-
-	return slices.ContainsFunc(
-		list,
-		func(v kafkaschemaregistry.AclOut) bool { return v.Id != nil && *v.Id == acl.Status.ACLId },
-	), nil
 }
 
 // schemaRegistrySpecMatches reports whether an existing Schema Registry ACL matches the CR spec.

--- a/controllers/kafkaschemaregistryacl_controller_test.go
+++ b/controllers/kafkaschemaregistryacl_controller_test.go
@@ -27,6 +27,17 @@ func newKafkaSchemaRegistryACL(t *testing.T) *v1alpha1.KafkaSchemaRegistryACL {
 	return acl
 }
 
+// schemaRegistryACLListWith returns a list response holding one remote entry that matches the
+// CR spec under the given ID.
+func schemaRegistryACLListWith(acl *v1alpha1.KafkaSchemaRegistryACL, id string) []kafkaschemaregistry.AclOut {
+	return []kafkaschemaregistry.AclOut{{
+		Id:         new(id),
+		Permission: kafkaschemaregistry.PermissionType(acl.Spec.Permission),
+		Resource:   acl.Spec.Resource,
+		Username:   acl.Spec.Username,
+	}}
+}
+
 func runKafkaSchemaRegistryACLScenario(
 	t *testing.T,
 	acl *v1alpha1.KafkaSchemaRegistryACL,
@@ -165,12 +176,7 @@ func TestKafkaSchemaRegistryACLReconciler(t *testing.T) {
 			Return(runningService(), nil).Once()
 		avn.EXPECT().
 			ServiceSchemaRegistryAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
-			Return([]kafkaschemaregistry.AclOut{{
-				Id:         new("acl-id"),
-				Permission: kafkaschemaregistry.PermissionType(acl.Spec.Permission),
-				Resource:   acl.Spec.Resource,
-				Username:   acl.Spec.Username,
-			}}, nil).Once()
+			Return(schemaRegistryACLListWith(acl, "acl-id"), nil).Once()
 
 		r, res, err := runKafkaSchemaRegistryACLScenario(t, acl, avn)
 		require.NoError(t, err)
@@ -182,7 +188,48 @@ func TestKafkaSchemaRegistryACLReconciler(t *testing.T) {
 		require.Equal(t, "acl-id", got.Status.ACLId)
 	})
 
-	t.Run("Recreates ACL when Status.ACLId is no longer present on Aiven", func(t *testing.T) {
+	t.Run("Re-adopts KafkaSchemaRegistryACL when the entry was recreated under a new ID", func(t *testing.T) {
+		acl := newKafkaSchemaRegistryACL(t)
+		acl.Generation = 1
+		acl.Annotations = map[string]string{processedGenerationAnnotation: "1"}
+		acl.Status.ACLId = "stale-id"
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistryAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
+			Return(schemaRegistryACLListWith(acl, "recreated-acl-id"), nil).Once()
+		// ServiceSchemaRegistryAclAdd must NOT be called.
+
+		r, res, err := runKafkaSchemaRegistryACLScenario(t, acl, avn)
+		require.NoError(t, err)
+		require.Equal(t, ctrlruntime.Result{RequeueAfter: testPollInterval}, res)
+
+		got := &v1alpha1.KafkaSchemaRegistryACL{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: acl.Name, Namespace: acl.Namespace}, got))
+		require.Equal(t, "recreated-acl-id", got.Status.ACLId)
+		require.Equal(t, "true", got.Annotations[instanceIsRunningAnnotation])
+	})
+
+	t.Run("Fails reconcile when the KafkaSchemaRegistryACL list call fails", func(t *testing.T) {
+		acl := newKafkaSchemaRegistryACL(t)
+		acl.Generation = 1
+
+		avn := avngen.NewMockClient(t)
+		avn.EXPECT().
+			ServiceGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
+			Return(runningService(), nil).Once()
+		avn.EXPECT().
+			ServiceSchemaRegistryAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
+			Return(nil, newAivenError(400, "bad request")).Once()
+
+		_, _, err := runKafkaSchemaRegistryACLScenario(t, acl, avn)
+		require.ErrorContains(t, err, "cannot list KafkaSchemaRegistryACLs on Aiven side")
+	})
+
+	t.Run("Recreates ACL when no remote entry matches the spec", func(t *testing.T) {
 		acl := newKafkaSchemaRegistryACL(t)
 		acl.Generation = 1
 		acl.Annotations = map[string]string{
@@ -195,10 +242,12 @@ func TestKafkaSchemaRegistryACLReconciler(t *testing.T) {
 		avn.EXPECT().
 			ServiceGet(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName, mock.Anything).
 			Return(runningService(), nil).Once()
-		// Observe: the stored ID is no longer present, so the resource is recreated.
+		// Observe: only an unrelated entry is present, which must not be adopted.
+		other := schemaRegistryACLListWith(acl, "other-acl-id")
+		other[0].Username = "someone-else"
 		avn.EXPECT().
 			ServiceSchemaRegistryAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
-			Return(nil, nil).Once()
+			Return(other, nil).Once()
 		// Create: adds the ACL and resolves the new ID.
 		avn.EXPECT().
 			ServiceSchemaRegistryAclAdd(
@@ -208,12 +257,7 @@ func TestKafkaSchemaRegistryACLReconciler(t *testing.T) {
 						in.Resource == acl.Spec.Resource &&
 						in.Username == acl.Spec.Username
 				}),
-			).Return([]kafkaschemaregistry.AclOut{{
-			Id:         new("new-id"),
-			Permission: kafkaschemaregistry.PermissionType(acl.Spec.Permission),
-			Resource:   acl.Spec.Resource,
-			Username:   acl.Spec.Username,
-		}}, nil).Once()
+			).Return(schemaRegistryACLListWith(acl, "new-id"), nil).Once()
 
 		r, res, err := runKafkaSchemaRegistryACLScenario(t, acl, avn)
 		require.NoError(t, err)
@@ -271,8 +315,7 @@ func TestKafkaSchemaRegistryACLReconciler(t *testing.T) {
 
 	t.Run("Adopts orphaned KafkaSchemaRegistryACL when status ACLId is empty but spec matches existing entry", func(t *testing.T) {
 		// Simulates: CR deleted with deletionPolicy:Orphan, then re-applied.
-		// Without the fix, the operator would call ServiceSchemaRegistryAclAdd and create a
-		// duplicate instead of adopting the existing entry.
+		// Without the fix, ServiceSchemaRegistryAclAdd is called and fails with 409 forever.
 		acl := newKafkaSchemaRegistryACL(t)
 		acl.Generation = 1
 		// No Status.ACLId — fresh CR after Orphan deletion.
@@ -283,13 +326,8 @@ func TestKafkaSchemaRegistryACLReconciler(t *testing.T) {
 			Return(runningService(), nil).Once()
 		avn.EXPECT().
 			ServiceSchemaRegistryAclList(mock.Anything, acl.Spec.Project, acl.Spec.ServiceName).
-			Return([]kafkaschemaregistry.AclOut{{
-				Id:         new("orphaned-schema-acl-id"),
-				Permission: kafkaschemaregistry.PermissionType(acl.Spec.Permission),
-				Resource:   acl.Spec.Resource,
-				Username:   acl.Spec.Username,
-			}}, nil).Once()
-		// ServiceSchemaRegistryAclAdd must NOT be called — adoption avoids the duplicate.
+			Return(schemaRegistryACLListWith(acl, "orphaned-schema-acl-id"), nil).Once()
+		// ServiceSchemaRegistryAclAdd must NOT be called — adoption avoids the conflict.
 
 		r, res, err := runKafkaSchemaRegistryACLScenario(t, acl, avn)
 		require.NoError(t, err)

--- a/docs/docs/resources/kafkanativeacl.md
+++ b/docs/docs/resources/kafkanativeacl.md
@@ -19,7 +19,7 @@ This resource uses the following API operations, and for each operation, _any_ o
 | [ServiceGet](https://api.aiven.io/doc/#operation/ServiceGet) | `project:services:read` |
 | [ServiceKafkaNativeAclAdd](https://api.aiven.io/doc/#operation/ServiceKafkaNativeAclAdd) | `service:data:write` |
 | [ServiceKafkaNativeAclDelete](https://api.aiven.io/doc/#operation/ServiceKafkaNativeAclDelete) | `service:data:write` |
-| [ServiceKafkaNativeAclGet](https://api.aiven.io/doc/#operation/ServiceKafkaNativeAclGet) | `service:data:write` |
+| [ServiceKafkaNativeAclList](https://api.aiven.io/doc/#operation/ServiceKafkaNativeAclList) | `service:data:write` |
 
 ## Usage example
 

--- a/docs/permissions.yaml
+++ b/docs/permissions.yaml
@@ -96,7 +96,7 @@ KafkaNativeACL:
     ServiceGet,
     ServiceKafkaNativeAclAdd,
     ServiceKafkaNativeAclDelete,
-    ServiceKafkaNativeAclGet,
+    ServiceKafkaNativeAclList,
   ]
 KafkaQuota:
   [

--- a/tests/kafkanativeacl_test.go
+++ b/tests/kafkanativeacl_test.go
@@ -3,11 +3,18 @@
 package tests
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	avngen "github.com/aiven/go-client-codegen"
+	"github.com/aiven/go-client-codegen/handler/kafka"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 )
@@ -74,4 +81,420 @@ func TestKafkaNativeACL(t *testing.T) {
 		_, err = avnGen.ServiceKafkaNativeAclGet(ctx, cfg.Project, kafkaName, acl.Status.ID)
 		return err
 	}))
+}
+
+// TestKafkaNativeACLAdoption covers what happens when a matching ACL is already present on Aiven.
+func TestKafkaNativeACLAdoption(t *testing.T) {
+	t.Parallel()
+	defer recoverPanic(t)
+
+	ctx, cancel := testCtx()
+	defer cancel()
+
+	kafkaService, releaseKafka, err := sharedResources.AcquireKafka(ctx)
+	require.NoError(t, err)
+	defer releaseKafka()
+
+	kafkaName := kafkaService.GetName()
+
+	t.Run("Aiven refuses a second identical entry", func(t *testing.T) {
+		in := newForeignNativeACL(randName("dup"))
+		spec := foreignNativeACLSpec(in)
+		t.Cleanup(func() { deleteKafkaNativeACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		created, err := avnGen.ServiceKafkaNativeAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.NoError(t, err, "Aiven refused an empty host, so normalizeACLHost guards a state that cannot occur")
+
+		stored, err := findKafkaNativeACLByID(ctx, cfg.Project, kafkaName, created.Id)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		t.Logf("an empty host was stored as %q", stored.Host)
+
+		_, err = avnGen.ServiceKafkaNativeAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.Error(t, err, "a duplicate add must not succeed")
+		assert.True(t, avngen.IsAlreadyExists(err), "expected 409 already exists, got: %s", err)
+
+		ids, err := findKafkaNativeACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "the refused add must not have created a second entry")
+	})
+
+	// An ACL that exists before any CR does, as created in the Console or by Terraform.
+	t.Run("adopts an entry created outside the operator", func(t *testing.T) {
+		aclName := randName("native-acl-foreign")
+		in := newForeignNativeACL(randName("foreign"))
+		spec := foreignNativeACLSpec(in)
+		t.Cleanup(func() { deleteKafkaNativeACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		created, err := avnGen.ServiceKafkaNativeAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.NoError(t, err)
+		foreignID := created.Id
+
+		s := NewSession(ctx, k8sClient)
+		defer s.Destroy(t)
+
+		// The CR carries host "*", the CRD default; the entry above was created with "".
+		require.NoError(t, s.Apply(getKafkaNativeACLYaml(
+			cfg.Project, kafkaName, aclName,
+			spec.Host, string(spec.PatternType), spec.ResourceName, spec.Principal,
+		)))
+
+		adopted := new(v1alpha1.KafkaNativeACL)
+		require.NoError(t, s.GetRunning(adopted, aclName))
+
+		assert.Equal(t, foreignID, adopted.Status.ID,
+			"the CR must adopt the pre-existing ACL, not create a second one")
+
+		ids, err := findKafkaNativeACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "adoption must not leave a duplicate ACL behind")
+
+		// An adopted ACL is deleted with the CR, the trade-off the CHANGELOG warns about.
+		assert.NoError(t, s.Delete(adopted, func() error {
+			_, err := avnGen.ServiceKafkaNativeAclGet(ctx, cfg.Project, kafkaName, foreignID)
+			return err
+		}))
+	})
+
+	t.Run("re-adopts an entry after an Orphan deletion", func(t *testing.T) {
+		principal := "User:" + randName("adopt")
+		prefixedName := randName("native-acl-prefixed")
+		wildcardName := randName("native-acl-wildcard")
+
+		// The risky shape: PREFIXED pattern with an explicit host.
+		prefixedYml := getKafkaNativeACLYaml(
+			cfg.Project, kafkaName, prefixedName,
+			"10.20.30.40", "PREFIXED", randName("adopt-prefix"), principal,
+		)
+		// The common shape: host "*", which is also the CRD default.
+		wildcardYml := getKafkaNativeACLYaml(
+			cfg.Project, kafkaName, wildcardName,
+			"*", "LITERAL", randName("adopt-topic"), principal,
+		)
+
+		s := NewSession(ctx, k8sClient)
+		defer s.Destroy(t)
+
+		require.NoError(t, s.Apply(prefixedYml+"\n---\n"+wildcardYml))
+
+		prefixed := new(v1alpha1.KafkaNativeACL)
+		require.NoError(t, s.GetRunning(prefixed, prefixedName))
+
+		wildcard := new(v1alpha1.KafkaNativeACL)
+		require.NoError(t, s.GetRunning(wildcard, wildcardName))
+
+		// Capture before deleting: s.Delete leaves the local object in an undefined state.
+		originalID := prefixed.Status.ID
+		prefixedSpec := prefixed.Spec
+		require.NotEmpty(t, originalID)
+
+		t.Cleanup(func() {
+			if err := avnGen.ServiceKafkaNativeAclDelete(context.Background(), cfg.Project, kafkaName, originalID); err != nil && !avngen.IsNotFound(err) {
+				t.Logf("leftover orphaned ACL %s: %s", originalID, err)
+			}
+		})
+
+		// The matcher's core assumption, checked for both shapes.
+		prefixedAvn, err := findKafkaNativeACLByID(ctx, cfg.Project, kafkaName, originalID)
+		require.NoError(t, err)
+		require.NotNil(t, prefixedAvn)
+		assertNativeACLEchoedVerbatim(t, prefixedAvn, prefixedSpec)
+
+		wildcardAvn, err := findKafkaNativeACLByID(ctx, cfg.Project, kafkaName, wildcard.Status.ID)
+		require.NoError(t, err)
+		require.NotNil(t, wildcardAvn)
+		assertNativeACLEchoedVerbatim(t, wildcardAvn, wildcard.Spec)
+
+		// Orphan the ACL, then drop the CR: this is the state a user lands in after
+		// `kubectl delete` with the Orphan policy.
+		require.NoError(t, setOrphanDeletionPolicy(ctx, prefixed))
+		require.NoError(t, s.Delete(prefixed, func() error {
+			_, err := avnGen.ServiceKafkaNativeAclGet(ctx, cfg.Project, kafkaName, originalID)
+			return err
+		}))
+
+		gone := new(v1alpha1.KafkaNativeACL)
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: prefixedName, Namespace: defaultNamespace}, gone)
+		require.True(t, isNotFound(err), "CR should be gone")
+
+		orphaned, err := findKafkaNativeACLByID(ctx, cfg.Project, kafkaName, originalID)
+		require.NoError(t, err)
+		require.NotNil(t, orphaned, "Orphan policy should have left the ACL on Aiven")
+
+		// Re-apply the identical spec, without the Orphan annotation this time.
+		require.NoError(t, s.Apply(prefixedYml))
+
+		readopted := new(v1alpha1.KafkaNativeACL)
+		require.NoError(t, s.GetRunning(readopted, prefixedName))
+
+		assert.Equal(t, originalID, readopted.Status.ID,
+			"re-applied CR must adopt the existing ACL, not create a new one")
+
+		ids, err := findKafkaNativeACLMatches(ctx, cfg.Project, kafkaName, prefixedSpec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "adoption must not leave a duplicate ACL behind")
+
+		// The adopted ACL is deletable through the CR again.
+		assert.NoError(t, s.Delete(readopted, func() error {
+			_, err := avnGen.ServiceKafkaNativeAclGet(ctx, cfg.Project, kafkaName, originalID)
+			return err
+		}))
+	})
+
+	t.Run("Aiven assigns a new ID when an entry is recreated", func(t *testing.T) {
+		in := newForeignNativeACL(randName("reid"))
+		spec := foreignNativeACLSpec(in)
+		t.Cleanup(func() { deleteKafkaNativeACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		first, err := avnGen.ServiceKafkaNativeAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.NoError(t, err)
+		require.NoError(t, avnGen.ServiceKafkaNativeAclDelete(ctx, cfg.Project, kafkaName, first.Id))
+
+		second, err := avnGen.ServiceKafkaNativeAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, first.Id, second.Id,
+			"Aiven reused the ACL ID, so a cached ID could never go stale and adoption by content is unnecessary")
+	})
+
+	t.Run("re-adopts the live entry when Status.ID no longer matches it", func(t *testing.T) {
+		aclName := randName("native-acl-stale")
+		spec := foreignNativeACLSpec(newForeignNativeACL(randName("stale")))
+		t.Cleanup(func() { deleteKafkaNativeACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		s := NewSession(ctx, k8sClient)
+		defer s.Destroy(t)
+
+		require.NoError(t, s.Apply(getKafkaNativeACLYaml(
+			cfg.Project, kafkaName, aclName,
+			spec.Host, string(spec.PatternType), spec.ResourceName, spec.Principal,
+		)))
+
+		acl := new(v1alpha1.KafkaNativeACL)
+		require.NoError(t, s.GetRunning(acl, aclName))
+
+		liveID := acl.Status.ID
+		require.NotEmpty(t, liveID)
+
+		// Point the cache at nothing, as `kubectl patch --subresource=status` does. The entry
+		// itself is untouched, so only the operator's own bookkeeping is wrong.
+		require.NoError(t, k8sClient.Status().Patch(ctx, acl, client.RawPatch(
+			types.MergePatchType, []byte(`{"status":{"id":"stale-id-that-does-not-exist"}}`))))
+
+		// What is under test: Observe matches the spec against the live list and repairs
+		// Status.ID from what it finds there. Trusting Status.ID instead, as the operator used
+		// to, reports the ACL missing and retries Create against an entry that already exists,
+		// so the ID would never come back and this wait would time out.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			got := new(v1alpha1.KafkaNativeACL)
+			if !assert.NoError(collect, k8sClient.Get(ctx, types.NamespacedName{Name: aclName, Namespace: defaultNamespace}, got)) {
+				return
+			}
+			assert.Equal(collect, liveID, got.Status.ID)
+		}, 3*time.Minute, 2*time.Second)
+
+		ids, err := findKafkaNativeACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "a stale cache must not produce a duplicate entry")
+	})
+
+	// The entry is destroyed and an identical one is created outside the operator.
+	t.Run("converges on the live entry after an out-of-band recreate", func(t *testing.T) {
+		aclName := randName("native-acl-recreated")
+		spec := foreignNativeACLSpec(newForeignNativeACL(randName("recreate")))
+		t.Cleanup(func() { deleteKafkaNativeACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		s := NewSession(ctx, k8sClient)
+		defer s.Destroy(t)
+
+		require.NoError(t, s.Apply(getKafkaNativeACLYaml(
+			cfg.Project, kafkaName, aclName,
+			spec.Host, string(spec.PatternType), spec.ResourceName, spec.Principal,
+		)))
+
+		acl := new(v1alpha1.KafkaNativeACL)
+		require.NoError(t, s.GetRunning(acl, aclName))
+
+		cachedID := acl.Status.ID
+		require.NotEmpty(t, cachedID)
+
+		require.NoError(t, avnGen.ServiceKafkaNativeAclDelete(ctx, cfg.Project, kafkaName, cachedID))
+
+		if _, err := avnGen.ServiceKafkaNativeAclAdd(ctx, cfg.Project, kafkaName, foreignNativeACLAddIn(spec)); err != nil {
+			// The operator got there first, so it recreated the entry through Create rather
+			// than adopting one. Convergence still has to hold.
+			require.True(t, avngen.IsAlreadyExists(err), "unexpected add error: %s", err)
+			t.Log("the operator recreated the entry before this add")
+		}
+
+		ids, err := findKafkaNativeACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		require.Len(t, ids, 1, "the recreate must leave exactly one entry")
+
+		recreatedID := ids[0]
+		require.NotEqual(t, cachedID, recreatedID, "Aiven reused the ID, so the cache never went stale")
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			got := new(v1alpha1.KafkaNativeACL)
+			if !assert.NoError(collect, k8sClient.Get(ctx, types.NamespacedName{Name: aclName, Namespace: defaultNamespace}, got)) {
+				return
+			}
+			assert.Equal(collect, recreatedID, got.Status.ID)
+		}, 3*time.Minute, 2*time.Second)
+
+		ids, err = findKafkaNativeACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "converging must not produce a duplicate entry")
+	})
+}
+
+// newForeignNativeACL builds an ACL to create straight through the API, as the Console or
+// Terraform would. The host is left empty rather than "*" to exercise normalizeACLHost.
+func newForeignNativeACL(suffix string) *kafka.ServiceKafkaNativeAclAddIn {
+	return &kafka.ServiceKafkaNativeAclAddIn{
+		Host:           anyPointer(""),
+		Operation:      "Read",
+		PatternType:    "LITERAL",
+		PermissionType: "ALLOW",
+		Principal:      "User:" + suffix,
+		ResourceName:   suffix + "-topic",
+		ResourceType:   "Topic",
+	}
+}
+
+// foreignNativeACLSpec is the CR spec with the same identity, carrying the "*" host default.
+func foreignNativeACLSpec(in *kafka.ServiceKafkaNativeAclAddIn) v1alpha1.KafkaNativeACLSpec {
+	return v1alpha1.KafkaNativeACLSpec{
+		Host:           "*",
+		Operation:      in.Operation,
+		PatternType:    in.PatternType,
+		PermissionType: in.PermissionType,
+		Principal:      in.Principal,
+		ResourceName:   in.ResourceName,
+		ResourceType:   in.ResourceType,
+	}
+}
+
+// foreignNativeACLAddIn is the API payload for an entry with the spec's identity, matching
+// what the controller sends on Create.
+func foreignNativeACLAddIn(spec v1alpha1.KafkaNativeACLSpec) *kafka.ServiceKafkaNativeAclAddIn {
+	return &kafka.ServiceKafkaNativeAclAddIn{
+		Host:           &spec.Host,
+		Operation:      spec.Operation,
+		PatternType:    spec.PatternType,
+		PermissionType: spec.PermissionType,
+		Principal:      spec.Principal,
+		ResourceName:   spec.ResourceName,
+		ResourceType:   spec.ResourceType,
+	}
+}
+
+// The adoption path: a CR deleted with deletion-policy Orphan leaves the ACL on Aiven, and
+// re-applying the same spec must adopt that entry instead of creating a second one.
+func getKafkaNativeACLYaml(project, service, name, host, patternType, resourceName, principal string) string {
+	return fmt.Sprintf(`
+apiVersion: aiven.io/v1alpha1
+kind: KafkaNativeACL
+metadata:
+  name: %[3]s
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: %[1]s
+  serviceName: %[2]s
+  host: %[4]q
+  operation: Read
+  patternType: %[5]s
+  permissionType: ALLOW
+  principal: %[7]q
+  resourceName: %[6]q
+  resourceType: Topic
+`, project, service, name, host, patternType, resourceName, principal)
+}
+
+// setOrphanDeletionPolicy annotates the resource so deleting it keeps the Aiven object.
+func setOrphanDeletionPolicy(ctx context.Context, obj client.Object) error {
+	patch := []byte(`{"metadata":{"annotations":{"controllers.aiven.io/deletion-policy":"Orphan"}}}`)
+	return k8sClient.Patch(ctx, obj, client.RawPatch(types.MergePatchType, patch))
+}
+
+func findKafkaNativeACLByID(ctx context.Context, project, service, id string) (*kafka.KafkaAclOut, error) {
+	list, err := avnGen.ServiceKafkaNativeAclList(ctx, project, service)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range list.KafkaAcl {
+		if list.KafkaAcl[i].Id == id {
+			return &list.KafkaAcl[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// findKafkaNativeACLMatches returns the IDs of the remote ACLs matching the spec identity.
+// Host is normalized as the controller does, because Aiven may report an empty host for what the spec calls "*".
+func findKafkaNativeACLMatches(ctx context.Context, project, service string, spec v1alpha1.KafkaNativeACLSpec) ([]string, error) {
+	list, err := avnGen.ServiceKafkaNativeAclList(ctx, project, service)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for _, v := range list.KafkaAcl {
+		if wildcardHost(v.Host) == wildcardHost(spec.Host) &&
+			v.Principal == spec.Principal &&
+			v.ResourceName == spec.ResourceName &&
+			v.Operation == spec.Operation &&
+			v.PatternType == spec.PatternType &&
+			string(v.PermissionType) == string(spec.PermissionType) &&
+			v.ResourceType == spec.ResourceType {
+			ids = append(ids, v.Id)
+		}
+	}
+
+	return ids, nil
+}
+
+// wildcardHost mirrors the controller's normalizeACLHost.
+func wildcardHost(host string) string {
+	if host == "" {
+		return "*"
+	}
+	return host
+}
+
+// deleteKafkaNativeACLMatches removes every remote ACL matching the spec identity. Entries
+// created directly against the API are owned by no CR, so nothing else cleans them up.
+func deleteKafkaNativeACLMatches(t *testing.T, project, service string, spec v1alpha1.KafkaNativeACLSpec) {
+	t.Helper()
+	ctx := context.Background()
+
+	ids, err := findKafkaNativeACLMatches(ctx, project, service, spec)
+	if err != nil {
+		t.Logf("cannot list Kafka-native ACLs for cleanup: %s", err)
+		return
+	}
+
+	for _, id := range ids {
+		if err := avnGen.ServiceKafkaNativeAclDelete(ctx, project, service, id); err != nil && !avngen.IsNotFound(err) {
+			t.Logf("leftover Kafka-native ACL %s: %s", id, err)
+		}
+	}
+}
+
+// assertNativeACLEchoedVerbatim checks that every field the adoption matcher compares
+// round-trips through the Aiven API unchanged.
+func assertNativeACLEchoedVerbatim(t *testing.T, avn *kafka.KafkaAclOut, spec v1alpha1.KafkaNativeACLSpec) {
+	t.Helper()
+	assert.Equal(t, spec.Host, avn.Host, "host was not echoed verbatim")
+	assert.Equal(t, spec.Principal, avn.Principal, "principal was not echoed verbatim")
+	assert.Equal(t, spec.ResourceName, avn.ResourceName, "resourceName was not echoed verbatim")
+	assert.Equal(t, spec.Operation, avn.Operation)
+	assert.Equal(t, spec.PatternType, avn.PatternType)
+	assert.EqualValues(t, spec.PermissionType, avn.PermissionType)
+	assert.Equal(t, spec.ResourceType, avn.ResourceType)
 }

--- a/tests/kafkschemaregistryacl_test.go
+++ b/tests/kafkschemaregistryacl_test.go
@@ -3,15 +3,19 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
+	avngen "github.com/aiven/go-client-codegen"
 	"github.com/aiven/go-client-codegen/handler/kafkaschemaregistry"
 	"github.com/aiven/go-client-codegen/handler/kafkatopic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 	"github.com/aiven/aiven-operator/controllers"
@@ -164,4 +168,335 @@ func TestKafkaSchemaRegistryACL(t *testing.T) {
 		// There is no Get method for the ACL, so we emulate 404 for this
 		return controllers.NewNotFound("KafkaSchemaRegistryAcl not found with id " + acl.Status.ACLId)
 	}))
+}
+
+// The adoption path: a CR deleted with deletion-policy Orphan leaves the ACL on Aiven, and
+// re-applying the same spec must adopt that entry instead of creating a second one.
+func getKafkaSchemaRegistryACLAdoptionYaml(project, service, name, resource, username string) string {
+	return fmt.Sprintf(`
+apiVersion: aiven.io/v1alpha1
+kind: KafkaSchemaRegistryACL
+metadata:
+  name: %[3]s
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  project: %[1]s
+  serviceName: %[2]s
+  resource: %[4]q
+  username: %[5]q
+  permission: schema_registry_read
+`, project, service, name, resource, username)
+}
+
+// findKafkaSchemaRegistryACLMatches returns the IDs of the remote entries matching the spec
+// identity, which is what Aiven uniquely indexes.
+func findKafkaSchemaRegistryACLMatches(ctx context.Context, project, service string, spec v1alpha1.KafkaSchemaRegistryACLSpec) ([]string, error) {
+	list, err := avnGen.ServiceSchemaRegistryAclList(ctx, project, service)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for _, v := range list {
+		if v.Id != nil && string(v.Permission) == spec.Permission && v.Resource == spec.Resource && v.Username == spec.Username {
+			ids = append(ids, *v.Id)
+		}
+	}
+
+	return ids, nil
+}
+
+// deleteKafkaSchemaRegistryACLMatches removes every remote entry matching the spec identity.
+// Entries created directly against the API are owned by no CR, so nothing else cleans them up.
+func deleteKafkaSchemaRegistryACLMatches(t *testing.T, project, service string, spec v1alpha1.KafkaSchemaRegistryACLSpec) {
+	t.Helper()
+	ctx := context.Background()
+
+	ids, err := findKafkaSchemaRegistryACLMatches(ctx, project, service, spec)
+	if err != nil {
+		t.Logf("cannot list Schema Registry ACLs for cleanup: %s", err)
+		return
+	}
+
+	for _, id := range ids {
+		if _, err := avnGen.ServiceSchemaRegistryAclDelete(ctx, project, service, id); err != nil && !avngen.IsNotFound(err) {
+			t.Logf("leftover Schema Registry ACL %s: %s", id, err)
+		}
+	}
+}
+
+// TestKafkaSchemaRegistryACLAdoption covers what happens when a matching entry is already present on Aiven.
+func TestKafkaSchemaRegistryACLAdoption(t *testing.T) {
+	t.Parallel()
+	defer recoverPanic(t)
+
+	ctx, cancel := testCtx()
+	defer cancel()
+
+	kafkaService, releaseKafka, err := sharedResources.AcquireKafka(ctx)
+	require.NoError(t, err)
+	defer releaseKafka()
+
+	kafkaName := kafkaService.GetName()
+
+	t.Run("Aiven refuses a second identical entry", func(t *testing.T) {
+		spec := foreignSchemaRegistryACLSpec(randName("dup"))
+		in := foreignSchemaRegistryACLAddIn(spec)
+		t.Cleanup(func() { deleteKafkaSchemaRegistryACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		_, err := avnGen.ServiceSchemaRegistryAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.NoError(t, err)
+
+		_, err = avnGen.ServiceSchemaRegistryAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.Error(t, err, "a duplicate add must not succeed")
+		assert.True(t, avngen.IsAlreadyExists(err), "expected 409 already exists, got: %s", err)
+
+		ids, err := findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "the refused add must not have created a second entry")
+	})
+
+	// An entry that exists before any CR does, as created in the Console or by Terraform.
+	t.Run("adopts an entry created outside the operator", func(t *testing.T) {
+		aclName := randName("sr-acl-foreign")
+		spec := foreignSchemaRegistryACLSpec(randName("foreign"))
+		in := foreignSchemaRegistryACLAddIn(spec)
+		t.Cleanup(func() { deleteKafkaSchemaRegistryACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		_, err := avnGen.ServiceSchemaRegistryAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.NoError(t, err)
+
+		ids, err := findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		require.Len(t, ids, 1)
+		foreignID := ids[0]
+
+		s := NewSession(ctx, k8sClient)
+		defer s.Destroy(t)
+
+		require.NoError(t, s.Apply(getKafkaSchemaRegistryACLAdoptionYaml(
+			cfg.Project, kafkaName, aclName, spec.Resource, spec.Username,
+		)))
+
+		adopted := new(v1alpha1.KafkaSchemaRegistryACL)
+		require.NoError(t, s.GetRunning(adopted, aclName))
+
+		assert.Equal(t, foreignID, adopted.Status.ACLId,
+			"the CR must adopt the pre-existing entry, not create a second one")
+
+		ids, err = findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "adoption must not leave a duplicate entry behind")
+
+		// An adopted entry is deleted together with the CR.
+		assert.NoError(t, s.Delete(adopted, func() error {
+			return schemaRegistryACLExists(ctx, kafkaName, spec, foreignID)
+		}))
+	})
+
+	t.Run("re-adopts an entry after an Orphan deletion", func(t *testing.T) {
+		aclName := randName("sr-acl-adopt")
+		resource := "Subject:" + randName("adopt-subject")
+		username := randName("adopt-user")
+
+		yml := getKafkaSchemaRegistryACLAdoptionYaml(cfg.Project, kafkaName, aclName, resource, username)
+
+		s := NewSession(ctx, k8sClient)
+		defer s.Destroy(t)
+
+		require.NoError(t, s.Apply(yml))
+
+		acl := new(v1alpha1.KafkaSchemaRegistryACL)
+		require.NoError(t, s.GetRunning(acl, aclName))
+
+		originalID := acl.Status.ACLId
+		aclSpec := acl.Spec
+		require.NotEmpty(t, originalID)
+
+		t.Cleanup(func() {
+			if _, err := avnGen.ServiceSchemaRegistryAclDelete(context.Background(), cfg.Project, kafkaName, originalID); err != nil && !avngen.IsNotFound(err) {
+				t.Logf("leftover orphaned schema registry ACL %s: %s", originalID, err)
+			}
+		})
+
+		// Sanity: exactly one entry, and it round-trips verbatim.
+		ids, err := findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, aclSpec)
+		require.NoError(t, err)
+		require.Len(t, ids, 1)
+
+		require.NoError(t, setOrphanDeletionPolicy(ctx, acl))
+		require.NoError(t, s.Delete(acl, func() error { return nil }))
+
+		gone := new(v1alpha1.KafkaSchemaRegistryACL)
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: aclName, Namespace: defaultNamespace}, gone)
+		require.True(t, isNotFound(err), "CR should be gone")
+
+		ids, err = findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, aclSpec)
+		require.NoError(t, err)
+		require.Len(t, ids, 1, "Orphan policy should have left the ACL on Aiven")
+
+		require.NoError(t, s.Apply(yml))
+
+		readopted := new(v1alpha1.KafkaSchemaRegistryACL)
+		require.NoError(t, s.GetRunning(readopted, aclName))
+
+		assert.Equal(t, originalID, readopted.Status.ACLId,
+			"re-applied CR must adopt the existing ACL, not create a second one")
+
+		ids, err = findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, aclSpec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "adoption must not leave a duplicate entry behind")
+
+		assert.NoError(t, s.Delete(readopted, func() error {
+			return schemaRegistryACLExists(ctx, kafkaName, aclSpec, originalID)
+		}))
+	})
+
+	t.Run("Aiven assigns a new ID when an entry is recreated", func(t *testing.T) {
+		spec := foreignSchemaRegistryACLSpec(randName("reid"))
+		in := foreignSchemaRegistryACLAddIn(spec)
+		t.Cleanup(func() { deleteKafkaSchemaRegistryACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		_, err := avnGen.ServiceSchemaRegistryAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.NoError(t, err)
+
+		ids, err := findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		require.Len(t, ids, 1)
+		firstID := ids[0]
+
+		_, err = avnGen.ServiceSchemaRegistryAclDelete(ctx, cfg.Project, kafkaName, firstID)
+		require.NoError(t, err)
+
+		_, err = avnGen.ServiceSchemaRegistryAclAdd(ctx, cfg.Project, kafkaName, in)
+		require.NoError(t, err)
+
+		ids, err = findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		require.Len(t, ids, 1)
+
+		assert.NotEqual(t, firstID, ids[0],
+			"Aiven reused the ACL ID, so a cached ID could never go stale and adoption by content is unnecessary")
+	})
+
+	t.Run("re-adopts the live entry when Status.ACLId no longer matches it", func(t *testing.T) {
+		aclName := randName("sr-acl-stale")
+		spec := foreignSchemaRegistryACLSpec(randName("stale"))
+		t.Cleanup(func() { deleteKafkaSchemaRegistryACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		s := NewSession(ctx, k8sClient)
+		defer s.Destroy(t)
+
+		require.NoError(t, s.Apply(getKafkaSchemaRegistryACLAdoptionYaml(
+			cfg.Project, kafkaName, aclName, spec.Resource, spec.Username,
+		)))
+
+		acl := new(v1alpha1.KafkaSchemaRegistryACL)
+		require.NoError(t, s.GetRunning(acl, aclName))
+
+		liveID := acl.Status.ACLId
+		require.NotEmpty(t, liveID)
+
+		// Point the cache at nothing, as `kubectl patch --subresource=status` does. The entry
+		// itself is untouched, so only the operator's own bookkeeping is wrong.
+		require.NoError(t, k8sClient.Status().Patch(ctx, acl, client.RawPatch(
+			types.MergePatchType, []byte(`{"status":{"acl_id":"stale-id-that-does-not-exist"}}`))))
+
+		// Observe matches the spec against the live list and repairs Status.ACLId from what it finds there.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			got := new(v1alpha1.KafkaSchemaRegistryACL)
+			if !assert.NoError(collect, k8sClient.Get(ctx, types.NamespacedName{Name: aclName, Namespace: defaultNamespace}, got)) {
+				return
+			}
+			assert.Equal(collect, liveID, got.Status.ACLId)
+		}, 3*time.Minute, 2*time.Second)
+
+		ids, err := findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "a stale cache must not produce a duplicate entry")
+	})
+
+	// The entry is destroyed and an identical one is created outside the operator.
+	t.Run("converges on the live entry after an out-of-band recreate", func(t *testing.T) {
+		aclName := randName("sr-acl-recreated")
+		spec := foreignSchemaRegistryACLSpec(randName("recreate"))
+		t.Cleanup(func() { deleteKafkaSchemaRegistryACLMatches(t, cfg.Project, kafkaName, spec) })
+
+		s := NewSession(ctx, k8sClient)
+		defer s.Destroy(t)
+
+		require.NoError(t, s.Apply(getKafkaSchemaRegistryACLAdoptionYaml(
+			cfg.Project, kafkaName, aclName, spec.Resource, spec.Username,
+		)))
+
+		acl := new(v1alpha1.KafkaSchemaRegistryACL)
+		require.NoError(t, s.GetRunning(acl, aclName))
+
+		cachedID := acl.Status.ACLId
+		require.NotEmpty(t, cachedID)
+
+		_, err := avnGen.ServiceSchemaRegistryAclDelete(ctx, cfg.Project, kafkaName, cachedID)
+		require.NoError(t, err)
+
+		if _, err := avnGen.ServiceSchemaRegistryAclAdd(ctx, cfg.Project, kafkaName, foreignSchemaRegistryACLAddIn(spec)); err != nil {
+			// The operator got there first, so it recreated the entry through Create rather
+			// than adopting one. Convergence still has to hold.
+			require.True(t, avngen.IsAlreadyExists(err), "unexpected add error: %s", err)
+			t.Log("the operator recreated the entry before this add")
+		}
+
+		ids, err := findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		require.Len(t, ids, 1, "the recreate must leave exactly one entry")
+
+		recreatedID := ids[0]
+		require.NotEqual(t, cachedID, recreatedID, "Aiven reused the ID, so the cache never went stale")
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			got := new(v1alpha1.KafkaSchemaRegistryACL)
+			if !assert.NoError(collect, k8sClient.Get(ctx, types.NamespacedName{Name: aclName, Namespace: defaultNamespace}, got)) {
+				return
+			}
+			assert.Equal(collect, recreatedID, got.Status.ACLId)
+		}, 3*time.Minute, 2*time.Second)
+
+		ids, err = findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, kafkaName, spec)
+		require.NoError(t, err)
+		assert.Len(t, ids, 1, "converging must not produce a duplicate entry")
+	})
+}
+
+// foreignSchemaRegistryACLSpec is a CR spec for an entry created straight through the API, as
+// the Console or Terraform would.
+func foreignSchemaRegistryACLSpec(suffix string) v1alpha1.KafkaSchemaRegistryACLSpec {
+	return v1alpha1.KafkaSchemaRegistryACLSpec{
+		Permission: "schema_registry_read",
+		Resource:   "Subject:" + suffix,
+		Username:   suffix,
+	}
+}
+
+func foreignSchemaRegistryACLAddIn(spec v1alpha1.KafkaSchemaRegistryACLSpec) *kafkaschemaregistry.ServiceSchemaRegistryAclAddIn {
+	return &kafkaschemaregistry.ServiceSchemaRegistryAclAddIn{
+		Permission: kafkaschemaregistry.PermissionType(spec.Permission),
+		Resource:   spec.Resource,
+		Username:   spec.Username,
+	}
+}
+
+// schemaRegistryACLExists reports nil while the entry is still on Aiven.
+func schemaRegistryACLExists(ctx context.Context, service string, spec v1alpha1.KafkaSchemaRegistryACLSpec, id string) error {
+	ids, err := findKafkaSchemaRegistryACLMatches(ctx, cfg.Project, service, spec)
+	if err != nil {
+		return err
+	}
+
+	if len(ids) > 0 {
+		return nil
+	}
+
+	return controllers.NewNotFound("KafkaSchemaRegistryAcl not found with id " + id)
 }


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
Follow-up to #1254, which adopted a matching `ACLs` only when the status ID was empty.

- Observe now decides existence by matching the spec against the live ACL list, on every reconcile.                                                                                                                                          
- **Behaviour change**: an ACL recreated outside the operator is taken over instead of left in an error state, and deleting the resource deletes the taken-over entry unless `deletionPolicy: Orphan` is set.
- An empty host from Aiven is treated as the "*" the spec defaults to.

Resolves: NEX-2794

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
