### PR TITLE
feat(service_user): increased amount of concurrent reconcilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- `ServiceUser`: increased the amount of concurrent reconcilers up to 10
+
 ## v0.44.0 - 2026-08-11
 
 - Add kind: `OrganizationProject` to manage Aiven projects that belong to an organization or organizational unit.

--- a/controllers/serviceuser_controller.go
+++ b/controllers/serviceuser_controller.go
@@ -20,10 +20,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/aiven/aiven-operator/api/v1alpha1"
 	kafkauserconfig "github.com/aiven/aiven-operator/api/v1alpha1/userconfig/service/kafka"
 )
+
+// serviceUserMaxConcurrentReconciles keeps the queue draining faster than the poll interval refills it.
+// With a single worker the standing population alone saturates it at a few hundred users.
+const serviceUserMaxConcurrentReconciles = 10
 
 func newServiceUserReconciler(c Controller) reconcilerType {
 	return newManagedReconciler(
@@ -35,7 +40,7 @@ func newServiceUserReconciler(c Controller) reconcilerType {
 				rec:    c.Recorder,
 			}
 		},
-		nil,
+		&controller.Options{MaxConcurrentReconciles: serviceUserMaxConcurrentReconciles},
 	)
 }
 

--- a/controllers/serviceuser_controller_test.go
+++ b/controllers/serviceuser_controller_test.go
@@ -37,6 +37,14 @@ spec:
   serviceName: test-service
 `
 
+func Test_newServiceUserReconciler(t *testing.T) {
+	t.Parallel()
+
+	r := newServiceUserReconciler(Controller{}).(*Reconciler[*v1alpha1.ServiceUser])
+	require.NotNil(t, r.options)
+	require.Equal(t, serviceUserMaxConcurrentReconciles, r.options.MaxConcurrentReconciles)
+}
+
 func TestAccessControlMatches(t *testing.T) {
 	t.Parallel()
 

--- a/tests/serviceuser_test.go
+++ b/tests/serviceuser_test.go
@@ -650,8 +650,8 @@ func getServiceUserWithRetry(
 			return retryErr
 		},
 		retry.RetryIf(isNotFound),
-		retry.Attempts(3),
-		retry.Delay(200*time.Millisecond),
+		retry.Attempts(5),
+		retry.Delay(400*time.Millisecond),
 	)
 
 	return user, err


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- increased the amount of concurrent reconcilers for `ServiceUser` resource up to 10
- as agreed, this is the first step for #1261 

Resolves: NEX-2804

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
