### PR TITLE
fix(kafkaschema): set compatibility level before registering schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
 - `ServiceUser`: increased the amount of concurrent reconcilers up to 10
+- Fix `KafkaSchema` never converging when `schema` and `compatibilityLevel` change in the same apply:
+  the compatibility level is now set on the subject before the new schema version is registered, so a
+  schema that only becomes valid after a loosening change (for example `BACKWARD` to `NONE`) is accepted.
+  Behavior change: a schema the registry rejects now leaves the new compatibility level applied, and
+  tightening the level together with a schema that violates it now fails instead of silently succeeding
 
 ## v0.44.0 - 2026-08-11
 

--- a/api/v1alpha1/kafkaschema_types.go
+++ b/api/v1alpha1/kafkaschema_types.go
@@ -97,6 +97,10 @@ type KafkaSchemaStatus struct {
 // Deletion: the operator performs a soft delete followed by a hard delete on
 // the subject. The subject disappears from the registry's listing, re-applying a KafkaSchema with the same subjectName
 // after deletion starts a brand-new subject at version 1.
+//
+// Update ordering: when schema and compatibilityLevel change in the same apply, the
+// compatibility level is set first, because the registry validates a new version against the
+// level currently configured for the subject. A rejected schema leaves the new level applied.
 // +kubebuilder:printcolumn:name="Service Name",type="string",JSONPath=".spec.serviceName"
 // +kubebuilder:printcolumn:name="Project",type="string",JSONPath=".spec.project"
 // +kubebuilder:printcolumn:name="Subject",type="string",JSONPath=".spec.subjectName"

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
@@ -42,6 +42,10 @@ spec:
             Deletion: the operator performs a soft delete followed by a hard delete on
             the subject. The subject disappears from the registry's listing, re-applying a KafkaSchema with the same subjectName
             after deletion starts a brand-new subject at version 1.
+
+            Update ordering: when schema and compatibilityLevel change in the same apply, the
+            compatibility level is set first, because the registry validates a new version against the
+            level currently configured for the subject. A rejected schema leaves the new level applied.
           properties:
             apiVersion:
               description: |-

--- a/config/crd/bases/aiven.io_kafkaschemas.yaml
+++ b/config/crd/bases/aiven.io_kafkaschemas.yaml
@@ -42,6 +42,10 @@ spec:
             Deletion: the operator performs a soft delete followed by a hard delete on
             the subject. The subject disappears from the registry's listing, re-applying a KafkaSchema with the same subjectName
             after deletion starts a brand-new subject at version 1.
+
+            Update ordering: when schema and compatibilityLevel change in the same apply, the
+            compatibility level is set first, because the registry validates a new version against the
+            level currently configured for the subject. A rejected schema leaves the new level applied.
           properties:
             apiVersion:
               description: |-

--- a/controllers/kafkaschema_controller.go
+++ b/controllers/kafkaschema_controller.go
@@ -213,7 +213,24 @@ func (r *KafkaSchemaController) Update(ctx context.Context, schema *v1alpha1.Kaf
 // Schema A -> ID:1, Version:1
 // Schema B -> ID:2, Version:2
 // Revert to A -> ID:1, Version:1
+//
+// The compatibility level must be set first, see the KafkaSchema docs for why. The two calls
+// are not atomic, so a rejected schema leaves the new level applied and is retried on the next
+// reconciliation. Configuring a subject that does not exist yet is accepted by the registry and
+// does not make it visible to Observe.
 func (r *KafkaSchemaController) applySchema(ctx context.Context, schema *v1alpha1.KafkaSchema) error {
+	if schema.Spec.CompatibilityLevel != "" {
+		if _, err := r.avnGen.ServiceSchemaRegistrySubjectConfigPut(
+			ctx,
+			schema.Spec.Project,
+			schema.Spec.ServiceName,
+			schema.Spec.SubjectName,
+			&kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn{Compatibility: schema.Spec.CompatibilityLevel},
+		); err != nil {
+			return fmt.Errorf("cannot update Kafka Schema Configuration: %w", err)
+		}
+	}
+
 	postIn := &kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionPostIn{
 		Schema:     schema.Spec.Schema,
 		SchemaType: schema.Spec.SchemaType,
@@ -246,18 +263,6 @@ func (r *KafkaSchemaController) applySchema(ctx context.Context, schema *v1alpha
 	}
 	schema.Status.ID = schemaID
 	schema.Status.Version = version
-
-	if schema.Spec.CompatibilityLevel != "" {
-		if _, err := r.avnGen.ServiceSchemaRegistrySubjectConfigPut(
-			ctx,
-			schema.Spec.Project,
-			schema.Spec.ServiceName,
-			schema.Spec.SubjectName,
-			&kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn{Compatibility: schema.Spec.CompatibilityLevel},
-		); err != nil {
-			return fmt.Errorf("cannot update Kafka Schema Configuration: %w", err)
-		}
-	}
 
 	metav1.SetMetaDataAnnotation(
 		&schema.ObjectMeta,

--- a/controllers/kafkaschema_controller_test.go
+++ b/controllers/kafkaschema_controller_test.go
@@ -1075,6 +1075,36 @@ func TestFingerprintSchema(t *testing.T) {
 	})
 }
 
+func TestKafkaSchemaApplySchemaConfigBeforePost(t *testing.T) {
+	t.Parallel()
+
+	schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+	schema.Spec.CompatibilityLevel = kafkaschemaregistry.CompatibilityTypeNone
+
+	avn := avngen.NewMockClient(t)
+	configPut := avn.EXPECT().
+		ServiceSchemaRegistrySubjectConfigPut(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName,
+			&kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn{
+				Compatibility: kafkaschemaregistry.CompatibilityTypeNone,
+			},
+		).Return(kafkaschemaregistry.CompatibilityTypeNone, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionPost(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, mock.Anything,
+		).Return(1, nil).Once().
+		NotBefore(configPut)
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+		Return([]int{1}, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, 1).
+		Return(&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionGetOut{Id: 1, Version: 1}, nil).Once()
+
+	r := &KafkaSchemaController{avnGen: avn}
+	require.NoError(t, r.applySchema(t.Context(), schema))
+}
+
 // A missing referent must surface as errPreconditionNotMet.
 func TestResolveReferences(t *testing.T) {
 	scheme := runtime.NewScheme()

--- a/docs/docs/resources/kafkaschema.md
+++ b/docs/docs/resources/kafkaschema.md
@@ -178,6 +178,10 @@ Deletion: the operator performs a soft delete followed by a hard delete on
 the subject. The subject disappears from the registry's listing, re-applying a KafkaSchema with the same subjectName
 after deletion starts a brand-new subject at version 1.
 
+Update ordering: when schema and compatibilityLevel change in the same apply, the
+compatibility level is set first, because the registry validates a new version against the
+level currently configured for the subject. A rejected schema leaves the new level applied.
+
 **Required**
 
 - [`apiVersion`](#apiVersion-property){: name='apiVersion-property'} (string). Value `aiven.io/v1alpha1`.

--- a/tests/kafkaschema_test.go
+++ b/tests/kafkaschema_test.go
@@ -162,6 +162,55 @@ func TestKafkaSchema(t *testing.T) {
 	assert.NoError(t, s.Delete(schemaA, subjectExists))
 }
 
+// Loosening compatibilityLevel and breaking the schema in one apply must converge.
+func TestKafkaSchemaCompatibilityLoosening(t *testing.T) {
+	t.Parallel()
+	defer recoverPanic(t)
+
+	ctx, cancel := testCtx()
+	defer cancel()
+
+	kafka, releaseKafka, err := sharedResources.AcquireKafka(ctx)
+	require.NoError(t, err)
+	defer releaseKafka()
+
+	kafkaName := kafka.GetName()
+	schemaName := randName("kafka-schema-compat")
+	subjectName := randName("kafka-schema-compat")
+	s := NewSession(ctx, k8sClient)
+	defer s.Destroy(t)
+
+	// getKafkaSchemaYaml pins the subject to BACKWARD.
+	require.NoError(t, s.Apply(getKafkaSchemaYaml(cfg.Project, kafkaName, schemaName, subjectName)))
+
+	strict := new(v1alpha1.KafkaSchema)
+	require.NoError(t, s.GetRunning(strict, schemaName))
+	require.Equal(t, 1, strict.Status.Version)
+
+	// Guards against the test going vacuous if the registry ever accepts the breaking schema.
+	check, err := avnGen.ServiceSchemaRegistryCompatibility(
+		ctx, cfg.Project, kafkaName, subjectName, strict.Status.Version,
+		&kafkaschemaregistry.ServiceSchemaRegistryCompatibilityIn{
+			Schema:     avroSchemaBreaking,
+			SchemaType: kafkaschemaregistry.SchemaTypeAvro,
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, check.IsCompatible, "must be incompatible under BACKWARD: %v", check.Messages)
+
+	loose := strict.DeepCopy()
+	loose.Spec.CompatibilityLevel = kafkaschemaregistry.CompatibilityTypeNone
+	loose.Spec.Schema = avroSchemaBreaking
+	require.NoError(t, k8sClient.Update(ctx, loose))
+	require.NoError(t, s.GetRunning(loose, schemaName))
+
+	assert.Greater(t, loose.Status.Version, strict.Status.Version)
+
+	level, err := avnGen.ServiceSchemaRegistrySubjectConfigGet(ctx, cfg.Project, kafkaName, subjectName)
+	require.NoError(t, err)
+	assert.Equal(t, kafkaschemaregistry.CompatibilityTypeNone, level)
+}
+
 func TestKafkaSchemaReferences(t *testing.T) {
 	t.Parallel()
 	defer recoverPanic(t)
@@ -906,6 +955,11 @@ spec:
     }
 `, project, kafkaName, schemaName, subjectName)
 }
+
+// avroSchemaBreaking adds a field without a default value to the schema built by
+// getKafkaSchemaYaml: a reader using it cannot read data written with the previous version,
+// so BACKWARD rejects it and NONE accepts it.
+const avroSchemaBreaking = `{"type":"record","doc":"example_doc","name":"example_name","namespace":"example_namespace","fields":[{"name":"field_name","namespace":"field_namespace","type":"int","default":5},{"name":"addition","type":"string"}]}`
 
 func getKafkaSchemaYaml(project, kafkaName, schemaName, subjectName string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

Reorders `applySchema` to set the subject's compatibility level before registering the new schema version, so the registry validates the version against the level the apply is about to install.

Resolves: #1263

Behavior change:
- Loosening the level alongside a schema that is only valid under it now succeeds instead of looping forever.
- Tightening the level alongside a schema that violates it now fails instead of silently succeeding.
- A schema the registry rejects leaves the new compatibility level applied and is retried on the next reconcile.

## Why this way

Setting the level first mirrors Confluent Schema Registry semantics: `PUT /config/{subject}` creates the override without the subject having any schema versions, and registration validates against the level in effect at POST time. Karapace's `config_subject_set` emits a config message without any subject lookup, so a subject holding only a config entry still 404s on version list and `Observe` treats it as absent -- the create path is unaffected.

`compatibilityLevel` stays in the same drift fingerprint as the schema body, so both land in a single `applySchema` pass; the write is unconditional because no sub-resource controller reads back its own config first.