### PR TITLE
docs(kafkaschema): document the compatibilityLevel removal limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 - `ServiceUser`: increased the amount of concurrent reconcilers up to 10
 - Fix `KafkaSchema` never converging when `schema` and `compatibilityLevel` change in the same apply:
-  the compatibility level is now set on the subject before the new schema version is registered, so a
-  schema that only becomes valid after a loosening change (for example `BACKWARD` to `NONE`) is accepted.
-  Behavior change: a schema the registry rejects now leaves the new compatibility level applied, and
-  tightening the level together with a schema that violates it now fails instead of silently succeeding
+  the compatibility level is now set before the new schema version is registered. Behavior change: a
+  rejected schema leaves the new level applied, and tightening the level alongside a schema that violates it now fails.
+- Docs: clarified that removing `KafkaSchema.spec.compatibilityLevel` leaves the existing
+  subject-level override in place instead of reverting it to the registry's global default.
 
 ## v0.44.0 - 2026-08-11
 

--- a/api/v1alpha1/kafkaschema_types.go
+++ b/api/v1alpha1/kafkaschema_types.go
@@ -26,7 +26,10 @@ type KafkaSchemaSpec struct {
 	SchemaType kafkaschemaregistry.SchemaType `json:"schemaType,omitempty"`
 
 	// +kubebuilder:validation:Enum=BACKWARD;BACKWARD_TRANSITIVE;FORWARD;FORWARD_TRANSITIVE;FULL;FULL_TRANSITIVE;NONE
-	// Kafka Schemas compatibility level
+	// Kafka Schemas compatibility level.
+	// When set, it is applied as the subject-level compatibility override.
+	// Removing this field does not change the subject: an existing override stays in place
+	// and is not reverted to the registry's global default.
 	CompatibilityLevel kafkaschemaregistry.CompatibilityType `json:"compatibilityLevel,omitempty"`
 
 	// +kubebuilder:validation:MaxItems=100

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
@@ -81,7 +81,11 @@ spec:
                     - name
                   type: object
                 compatibilityLevel:
-                  description: Kafka Schemas compatibility level
+                  description: |-
+                    Kafka Schemas compatibility level.
+                    When set, it is applied as the subject-level compatibility override.
+                    Removing this field does not change the subject: an existing override stays in place
+                    and is not reverted to the registry's global default.
                   enum:
                     - BACKWARD
                     - BACKWARD_TRANSITIVE

--- a/config/crd/bases/aiven.io_kafkaschemas.yaml
+++ b/config/crd/bases/aiven.io_kafkaschemas.yaml
@@ -81,7 +81,11 @@ spec:
                     - name
                   type: object
                 compatibilityLevel:
-                  description: Kafka Schemas compatibility level
+                  description: |-
+                    Kafka Schemas compatibility level.
+                    When set, it is applied as the subject-level compatibility override.
+                    Removing this field does not change the subject: an existing override stays in place
+                    and is not reverted to the registry's global default.
                   enum:
                     - BACKWARD
                     - BACKWARD_TRANSITIVE

--- a/docs/docs/resources/kafkaschema.md
+++ b/docs/docs/resources/kafkaschema.md
@@ -206,6 +206,9 @@ KafkaSchemaSpec defines the desired state of KafkaSchema.
 
 - [`authSecretRef`](#spec.authSecretRef-property){: name='spec.authSecretRef-property'} (object). Authentication reference to Aiven token in a secret. See below for [nested schema](#spec.authSecretRef).
 - [`compatibilityLevel`](#spec.compatibilityLevel-property){: name='spec.compatibilityLevel-property'} (string, Enum: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`). Kafka Schemas compatibility level.
+    When set, it is applied as the subject-level compatibility override.
+    Removing this field does not change the subject: an existing override stays in place
+    and is not reverted to the registry's global default.
 - [`references`](#spec.references-property){: name='spec.references-property'} (array of objects, MaxItems: 100). Schema references for Protobuf or JSON schemas that import other schemas.
     References must form a directed acyclic graph (DAG); cycles are not allowed. See below for [nested schema](#spec.references).
 - [`schemaType`](#spec.schemaType-property){: name='spec.schemaType-property'} (string, Enum: `AVRO`, `JSON`, `PROTOBUF`, Immutable). Schema type.


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Documented the current behavior of removing `spec.compatibilityLevel` from a `KafkaSchema`: an existing subject-level compatibility override stays in place and is not reverted to the registry's global default.

Resolves: NEX-2809. Contributes to: #1264 

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
