### PR TITLE
feat(reconciler): exposed pollInterval param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@
 - Add `PostgreSQL` field `userConfig.pgbouncer.server_login_retry`, type `number`: If login to the server
   failed, because of failure to connect or from authentication, the pooler waits this much before
   retrying to connect
+- Add `--poll-interval` flag and matching `pollInterval` Helm value, to configure how often
+  resources in a steady state are re-reconciled against the Aiven API. Accepted range is 10m-60m,
+  so the interval can only be raised; the default is unchanged at 10 minutes. Does not apply to
+  the service kinds (`Clickhouse`, `Flink`, `Grafana`, `Kafka`, `KafkaConnect`, `MySQL`,
+  `OpenSearch`, `PostgreSQL`, `Valkey`), which do not re-reconcile on a fixed interval.
 
 ## v0.44.0 - 2026-08-11
 

--- a/charts/aiven-operator/ci/test-values.yaml
+++ b/charts/aiven-operator/ci/test-values.yaml
@@ -10,3 +10,5 @@ extraEnvs:
 logging:
   level: info
   encoder: json
+
+pollInterval: 15m

--- a/charts/aiven-operator/templates/deployment.yaml
+++ b/charts/aiven-operator/templates/deployment.yaml
@@ -75,6 +75,14 @@ spec:
             {{- end }}
             - --zap-encoder={{ .Values.logging.encoder }}
             {{- end }}
+            {{- if .Values.pollInterval }}
+            {{- $pollInterval := .Values.pollInterval | toString }}
+            {{- /* Bare numbers are not durations; the operator validates the accepted range at startup. */}}
+            {{- if regexMatch "^[0-9.]+$" $pollInterval }}
+            {{- fail (printf "pollInterval '%s' has no unit. Use a Go duration such as 15m or 1h, or leave it empty for the default" $pollInterval) }}
+            {{- end }}
+            - --poll-interval={{ $pollInterval }}
+            {{- end }}
 
           ports:
             - name: metrics

--- a/charts/aiven-operator/values.yaml
+++ b/charts/aiven-operator/values.yaml
@@ -112,3 +112,11 @@ logging:
   # Log encoder for the operator (json, console)
   # If not set, the operator will use its default encoder
   encoder: ""
+
+# How often resources in a steady state are re-reconciled against the Aiven API.
+# Go duration between 10m and 60m, e.g. 15m or 1h.
+# If not set, the operator uses its built-in default of 10m.
+# Values outside the range are rejected at startup.
+# Does not apply to the service kinds (Clickhouse, Flink, Grafana, Kafka, KafkaConnect, MySQL,
+# OpenSearch, PostgreSQL, Valkey), which do not re-reconcile on a fixed interval.
+pollInterval: ""

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -16,27 +16,50 @@ type reconcilerType interface {
 	SetupWithManager(mgr ctrl.Manager) error
 }
 
-const defaultPollInterval = 10 * time.Minute
+// DefaultPollInterval is how often a Ready resource is re-reconciled when no interval is configured.
+const DefaultPollInterval = 10 * time.Minute
+
+const (
+	minPollInterval = DefaultPollInterval
+	maxPollInterval = 60 * time.Minute
+)
+
+// ValidatePollInterval reports whether d is an acceptable value for the --poll-interval flag.
+func ValidatePollInterval(d time.Duration) error {
+	if d == 0 {
+		return nil
+	}
+
+	if d < minPollInterval || d > maxPollInterval {
+		return fmt.Errorf(
+			"poll interval %s is outside the accepted range %s-%s",
+			d,
+			minPollInterval,
+			maxPollInterval,
+		)
+	}
+
+	return nil
+}
 
 type SetupConfig struct {
 	DefaultToken    string
 	KubeVersion     string
 	OperatorVersion string
-	PollInterval    time.Duration
+
+	// PollInterval is how often a Ready resource is re-reconciled against the Aiven API.
+	PollInterval time.Duration
 }
 
-func SetupControllers(mgr ctrl.Manager, defaultToken, kubeVersion, operatorVersion string) error {
-	return SetupControllersWithConfig(mgr, SetupConfig{
-		DefaultToken:    defaultToken,
-		KubeVersion:     kubeVersion,
-		OperatorVersion: operatorVersion,
-	})
-}
-
-func SetupControllersWithConfig(mgr ctrl.Manager, cfg SetupConfig) error {
-	if cfg.PollInterval <= 0 {
-		cfg.PollInterval = defaultPollInterval
+// normalize applies built-in defaults to unset fields.
+func (c *SetupConfig) normalize() {
+	if c.PollInterval <= 0 {
+		c.PollInterval = DefaultPollInterval
 	}
+}
+
+func SetupControllers(mgr ctrl.Manager, cfg SetupConfig) error {
+	cfg.normalize()
 
 	if err := (&SecretFinalizerGCController{
 		Client: mgr.GetClient(),

--- a/controllers/setup_test.go
+++ b/controllers/setup_test.go
@@ -1,0 +1,63 @@
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePollInterval(t *testing.T) {
+	cases := []struct {
+		name    string
+		give    time.Duration
+		wantErr bool
+	}{
+		{name: "zero means use the default", give: 0},
+		{name: "at the floor", give: 10 * time.Minute},
+		{name: "at the ceiling", give: 60 * time.Minute},
+		{name: "within the range", give: 30 * time.Minute},
+		{name: "below the floor", give: time.Minute, wantErr: true},
+		{name: "just below the floor", give: 10*time.Minute - time.Second, wantErr: true},
+		// The floor equals the default, so anything faster than the default is rejected.
+		{name: "faster than the default", give: 5 * time.Minute, wantErr: true},
+		{name: "just above the ceiling", give: 60*time.Minute + time.Second, wantErr: true},
+		{name: "above the ceiling", give: 2 * time.Hour, wantErr: true},
+		{name: "negative", give: -time.Minute, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePollInterval(tc.give)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.give.String())
+			require.Contains(t, err.Error(), "10m0s-1h0m0s")
+		})
+	}
+}
+
+func TestSetupConfigNormalizePollInterval(t *testing.T) {
+	cases := []struct {
+		name string
+		give time.Duration
+		want time.Duration
+	}{
+		{name: "unset falls back to the default", give: 0, want: DefaultPollInterval},
+		{name: "negative falls back to the default", give: -time.Minute, want: DefaultPollInterval},
+		{name: "a set value is left alone", give: 30 * time.Minute, want: 30 * time.Minute},
+		{name: "an out-of-range value is not clamped", give: time.Minute, want: time.Minute},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := SetupConfig{PollInterval: tc.give}
+			cfg.normalize()
+			require.Equal(t, tc.want, cfg.PollInterval)
+		})
+	}
+}

--- a/docs/docs/installation/helm.md
+++ b/docs/docs/installation/helm.md
@@ -86,3 +86,24 @@ Refer to the [values.yaml file](https://github.com/aiven/aiven-charts/blob/main/
 You can configure the operator to monitor resources within specific namespaces.
 If the `ClusterRole` is enabled, it's bound to the operator's `ServiceAccount` within each watched namespace using a `RoleBinding`.
 This setup grants the operator the permissions specified in the `ClusterRole`, but only within the context of the specific namespaces where the `RoleBinding` is created.
+
+### Tune the reconcile interval
+
+Once a resource is ready, the operator re-reconciles most kinds against the Aiven API on a fixed
+interval to pick up changes made outside Kubernetes. The default is 10 minutes. See
+[which resources this affects](#which-resources-this-affects) below — the service kinds are not
+among them.
+
+Set the `pollInterval` value to change it:
+
+```yaml
+pollInterval: 30m
+```
+
+The accepted range is `10m` to `60m`. A value outside it is rejected at startup.
+
+#### Which resources this affects
+
+It does **not** apply to the service kinds — `Clickhouse`, `Flink`, `Grafana`, `Kafka`,
+`KafkaConnect`, `MySQL`, `OpenSearch`, `PostgreSQL` and `Valkey`. Those do not re-reconcile on a
+fixed interval at all at the moment.

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,7 +55,11 @@ func main() {
 	var probeAddr string
 	var development bool
 	var webhookPort int
+	var pollInterval time.Duration
 	flag.IntVar(&webhookPort, "webhook-port", webhookDefaultPort, "Webhook server port (default: 9443)")
+	flag.DurationVar(&pollInterval, "poll-interval", controllers.DefaultPollInterval,
+		"How often resources in a steady state are re-reconciled against the Aiven API. "+
+			"Accepted range is 10m-60m.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -78,6 +83,12 @@ func main() {
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Validated before the manager is built, so a bad value costs nothing.
+	if err := controllers.ValidatePollInterval(pollInterval); err != nil {
+		setupLog.Error(err, "invalid --poll-interval")
+		os.Exit(1)
+	}
 
 	ctrlOptions := ctrl.Options{
 		Scheme: scheme,
@@ -140,10 +151,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	defaultToken := os.Getenv("DEFAULT_AIVEN_TOKEN")
-	err = controllers.SetupControllers(mgr, defaultToken, kubeVersion.String(), operatorVersion)
+	err = controllers.SetupControllers(mgr, controllers.SetupConfig{
+		DefaultToken:    os.Getenv("DEFAULT_AIVEN_TOKEN"),
+		KubeVersion:     kubeVersion.String(),
+		OperatorVersion: operatorVersion,
+		PollInterval:    pollInterval,
+	})
 	if err != nil {
 		setupLog.Error(err, "controllers setup error")
+		os.Exit(1)
 	}
 
 	// Webhooks are enabled by default

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -145,7 +145,7 @@ func setupSuite(ctx context.Context) (*envtest.Environment, error) {
 		return nil, err
 	}
 
-	err = controllers.SetupControllersWithConfig(mgr, controllers.SetupConfig{
+	err = controllers.SetupControllers(mgr, controllers.SetupConfig{
 		DefaultToken:    cfg.Token,
 		KubeVersion:     kubeVersion.String(),
 		OperatorVersion: operatorVersion,


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Added a -`-poll-interval` CLI flag and a matching `pollInterval` Helm value to configure how often resources in a steady state are re-reconciled against the Aiven API. The interval was previously hardcoded to **10** minutes. 

Resolves: NEX-2813, Contributes to: #1261 

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
