### PR TITLE
feat(kafka_schema): return to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
 
+- Fix `KafkaSchema` silently ignoring the removal of `compatibilityLevel`: a subject-level override
+  previously applied by the operator is now reverted to a snapshot of the registry's current global
+  default. Overrides created outside the operator, or changed outside it since they were
+  applied, are never modified.
+  Resources whose `compatibilityLevel` was removed under an older operator version are not detected
+  retroactively: their override is picked up again the next time `compatibilityLevel` is set and
+  applied, after which removing the field reverts it as described above.
+
 ## v0.45.0 - 2026-08-24
 
 - `ServiceUser`: increased the amount of concurrent reconcilers up to 10

--- a/api/v1alpha1/kafkaschema_types.go
+++ b/api/v1alpha1/kafkaschema_types.go
@@ -28,8 +28,11 @@ type KafkaSchemaSpec struct {
 	// +kubebuilder:validation:Enum=BACKWARD;BACKWARD_TRANSITIVE;FORWARD;FORWARD_TRANSITIVE;FULL;FULL_TRANSITIVE;NONE
 	// Kafka Schemas compatibility level.
 	// When set, it is applied as the subject-level compatibility override.
-	// Removing this field does not change the subject: an existing override stays in place
-	// and is not reverted to the registry's global default.
+	// When removed, an override previously applied by the operator is reverted to a
+	// snapshot of the registry's current global default; later changes to the global
+	// default are not tracked.
+	// Overrides created outside the operator, or changed
+	// outside it since they were applied, are never modified.
 	CompatibilityLevel kafkaschemaregistry.CompatibilityType `json:"compatibilityLevel,omitempty"`
 
 	// +kubebuilder:validation:MaxItems=100
@@ -102,8 +105,12 @@ type KafkaSchemaStatus struct {
 // after deletion starts a brand-new subject at version 1.
 //
 // Update ordering: when schema and compatibilityLevel change in the same apply, the
-// compatibility level is set first, because the registry validates a new version against the
-// level currently configured for the subject. A rejected schema leaves the new level applied.
+// compatibility level is applied first, because the registry validates a new version against
+// the level currently configured for the subject. A rejected schema leaves the new level applied.
+// Removing compatibilityLevel reverts a subject-level override previously applied by the
+// operator to a snapshot of the registry's current global default before the schema is
+// registered; overrides created outside the operator, or changed outside it since they
+// were applied, are left untouched.
 // +kubebuilder:printcolumn:name="Service Name",type="string",JSONPath=".spec.serviceName"
 // +kubebuilder:printcolumn:name="Project",type="string",JSONPath=".spec.project"
 // +kubebuilder:printcolumn:name="Subject",type="string",JSONPath=".spec.subjectName"

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkaschemas.yaml
@@ -44,8 +44,12 @@ spec:
             after deletion starts a brand-new subject at version 1.
 
             Update ordering: when schema and compatibilityLevel change in the same apply, the
-            compatibility level is set first, because the registry validates a new version against the
-            level currently configured for the subject. A rejected schema leaves the new level applied.
+            compatibility level is applied first, because the registry validates a new version against
+            the level currently configured for the subject. A rejected schema leaves the new level applied.
+            Removing compatibilityLevel reverts a subject-level override previously applied by the
+            operator to a snapshot of the registry's current global default before the schema is
+            registered; overrides created outside the operator, or changed outside it since they
+            were applied, are left untouched.
           properties:
             apiVersion:
               description: |-
@@ -84,8 +88,11 @@ spec:
                   description: |-
                     Kafka Schemas compatibility level.
                     When set, it is applied as the subject-level compatibility override.
-                    Removing this field does not change the subject: an existing override stays in place
-                    and is not reverted to the registry's global default.
+                    When removed, an override previously applied by the operator is reverted to a
+                    snapshot of the registry's current global default; later changes to the global
+                    default are not tracked.
+                    Overrides created outside the operator, or changed
+                    outside it since they were applied, are never modified.
                   enum:
                     - BACKWARD
                     - BACKWARD_TRANSITIVE

--- a/config/crd/bases/aiven.io_kafkaschemas.yaml
+++ b/config/crd/bases/aiven.io_kafkaschemas.yaml
@@ -44,8 +44,12 @@ spec:
             after deletion starts a brand-new subject at version 1.
 
             Update ordering: when schema and compatibilityLevel change in the same apply, the
-            compatibility level is set first, because the registry validates a new version against the
-            level currently configured for the subject. A rejected schema leaves the new level applied.
+            compatibility level is applied first, because the registry validates a new version against
+            the level currently configured for the subject. A rejected schema leaves the new level applied.
+            Removing compatibilityLevel reverts a subject-level override previously applied by the
+            operator to a snapshot of the registry's current global default before the schema is
+            registered; overrides created outside the operator, or changed outside it since they
+            were applied, are left untouched.
           properties:
             apiVersion:
               description: |-
@@ -84,8 +88,11 @@ spec:
                   description: |-
                     Kafka Schemas compatibility level.
                     When set, it is applied as the subject-level compatibility override.
-                    Removing this field does not change the subject: an existing override stays in place
-                    and is not reverted to the registry's global default.
+                    When removed, an override previously applied by the operator is reverted to a
+                    snapshot of the registry's current global default; later changes to the global
+                    default are not tracked.
+                    Overrides created outside the operator, or changed
+                    outside it since they were applied, are never modified.
                   enum:
                     - BACKWARD
                     - BACKWARD_TRANSITIVE

--- a/controllers/kafkaschema_controller.go
+++ b/controllers/kafkaschema_controller.go
@@ -32,6 +32,10 @@ import (
 // schema body + resolved references + compatibility level.
 const kafkaSchemaAppliedFingerprintAnnotation = "controllers.aiven.io/kafka-schema-applied"
 
+// kafkaSchemaAppliedCompatibilityAnnotation records the subject-level compatibility
+// override last applied by the operator.
+const kafkaSchemaAppliedCompatibilityAnnotation = "controllers.aiven.io/kafka-schema-applied-compatibility"
+
 // kafkaSchemaRefIndex is the cache index key for finding KafkaSchemas that
 // reference another KafkaSchema by name.
 const kafkaSchemaRefIndex = "spec.references.kafkaSchemaRef.name"
@@ -162,8 +166,15 @@ func (r *KafkaSchemaController) Observe(ctx context.Context, schema *v1alpha1.Ka
 		resolvedRefs = refs
 	}
 	desiredFP := fingerprintSchema(schema, resolvedRefs)
-
 	appliedFP, ok := schema.GetAnnotations()[kafkaSchemaAppliedFingerprintAnnotation]
+
+	// Backfill ownership for CRs whose level was applied before the annotation existed,
+	// so clearing the field on them still reverts the override.
+	if ok && appliedFP == desiredFP && schema.Spec.CompatibilityLevel != "" &&
+		!metav1.HasAnnotation(schema.ObjectMeta, kafkaSchemaAppliedCompatibilityAnnotation) {
+		metav1.SetMetaDataAnnotation(&schema.ObjectMeta, kafkaSchemaAppliedCompatibilityAnnotation, string(schema.Spec.CompatibilityLevel))
+	}
+
 	if !ok || appliedFP != desiredFP {
 		return Observation{ResourceExists: true, ResourceUpToDate: false}, nil
 	}
@@ -214,23 +225,11 @@ func (r *KafkaSchemaController) Update(ctx context.Context, schema *v1alpha1.Kaf
 // Schema B -> ID:2, Version:2
 // Revert to A -> ID:1, Version:1
 //
-// The compatibility level must be set first, see the KafkaSchema docs for why. The two calls
+// The compatibility level must be applied first, see the KafkaSchema docs for why. The calls
 // are not atomic, so a rejected schema leaves the new level applied and is retried on the next
 // reconciliation. Configuring a subject that does not exist yet is accepted by the registry and
 // does not make it visible to Observe.
 func (r *KafkaSchemaController) applySchema(ctx context.Context, schema *v1alpha1.KafkaSchema) error {
-	if schema.Spec.CompatibilityLevel != "" {
-		if _, err := r.avnGen.ServiceSchemaRegistrySubjectConfigPut(
-			ctx,
-			schema.Spec.Project,
-			schema.Spec.ServiceName,
-			schema.Spec.SubjectName,
-			&kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn{Compatibility: schema.Spec.CompatibilityLevel},
-		); err != nil {
-			return fmt.Errorf("cannot update Kafka Schema Configuration: %w", err)
-		}
-	}
-
 	postIn := &kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionPostIn{
 		Schema:     schema.Spec.Schema,
 		SchemaType: schema.Spec.SchemaType,
@@ -244,6 +243,10 @@ func (r *KafkaSchemaController) applySchema(ctx context.Context, schema *v1alpha
 		}
 		resolvedRefs = refs
 		postIn.References = &refs
+	}
+
+	if err := r.applyCompatibilityLevel(ctx, schema); err != nil {
+		return err
 	}
 
 	schemaID, err := r.avnGen.ServiceSchemaRegistrySubjectVersionPost(
@@ -269,6 +272,67 @@ func (r *KafkaSchemaController) applySchema(ctx context.Context, schema *v1alpha
 		kafkaSchemaAppliedFingerprintAnnotation,
 		fingerprintSchema(schema, resolvedRefs),
 	)
+
+	return nil
+}
+
+// applyCompatibilityLevel reconciles the subject-level compatibility override.
+func (r *KafkaSchemaController) applyCompatibilityLevel(ctx context.Context, schema *v1alpha1.KafkaSchema) error {
+	if level := schema.Spec.CompatibilityLevel; level != "" {
+		if err := r.putCompatibilityLevel(ctx, schema, level); err != nil {
+			return err
+		}
+		metav1.SetMetaDataAnnotation(&schema.ObjectMeta, kafkaSchemaAppliedCompatibilityAnnotation, string(level))
+		return nil
+	}
+
+	applied, ok := schema.GetAnnotations()[kafkaSchemaAppliedCompatibilityAnnotation]
+	if !ok {
+		return nil
+	}
+
+	override, err := r.avnGen.ServiceSchemaRegistrySubjectConfigGet(
+		ctx,
+		schema.Spec.Project,
+		schema.Spec.ServiceName,
+		schema.Spec.SubjectName,
+		kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigGetGlobalDefaultFallback(false),
+	)
+	switch {
+	case isNotFound(err):
+		// Override already gone, nothing to revert.
+	case err != nil:
+		return fmt.Errorf("getting Kafka Schema Configuration: %w", err)
+	case string(override) != applied:
+		// The override no longer matches what we applied — changed externally. We do not override.
+	default:
+		global, err := r.avnGen.ServiceSchemaRegistryGlobalConfigGet(ctx, schema.Spec.Project, schema.Spec.ServiceName)
+		if err != nil {
+			return fmt.Errorf("getting global Kafka Schema Configuration: %w", err)
+		}
+		if override != global {
+			if err := r.putCompatibilityLevel(ctx, schema, global); err != nil {
+				return err
+			}
+		}
+	}
+
+	delete(schema.GetAnnotations(), kafkaSchemaAppliedCompatibilityAnnotation)
+	return nil
+}
+
+func (r *KafkaSchemaController) putCompatibilityLevel(
+	ctx context.Context, schema *v1alpha1.KafkaSchema, level kafkaschemaregistry.CompatibilityType,
+) error {
+	if _, err := r.avnGen.ServiceSchemaRegistrySubjectConfigPut(
+		ctx,
+		schema.Spec.Project,
+		schema.Spec.ServiceName,
+		schema.Spec.SubjectName,
+		&kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn{Compatibility: level},
+	); err != nil {
+		return fmt.Errorf("cannot update Kafka Schema Configuration: %w", err)
+	}
 
 	return nil
 }

--- a/controllers/kafkaschema_controller_test.go
+++ b/controllers/kafkaschema_controller_test.go
@@ -1103,6 +1103,225 @@ func TestKafkaSchemaApplySchemaConfigBeforePost(t *testing.T) {
 
 	r := &KafkaSchemaController{avnGen: avn}
 	require.NoError(t, r.applySchema(t.Context(), schema))
+	require.Equal(t, string(kafkaschemaregistry.CompatibilityTypeNone),
+		schema.GetAnnotations()[kafkaSchemaAppliedCompatibilityAnnotation],
+		"applying a level must mark the override operator-owned")
+}
+
+// Clearing compatibilityLevel reverts an operator-owned subject override to the current
+// global default, and the revert lands before the schema is registered.
+func TestKafkaSchemaApplySchemaRevertsClearedCompatibility(t *testing.T) {
+	t.Parallel()
+
+	schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+	metav1.SetMetaDataAnnotation(&schema.ObjectMeta, kafkaSchemaAppliedCompatibilityAnnotation,
+		string(kafkaschemaregistry.CompatibilityTypeFull))
+
+	avn := avngen.NewMockClient(t)
+	configGet := avn.EXPECT().
+		ServiceSchemaRegistrySubjectConfigGet(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName,
+			[][2]string{kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigGetGlobalDefaultFallback(false)},
+		).Return(kafkaschemaregistry.CompatibilityTypeFull, nil).Once()
+	globalGet := avn.EXPECT().
+		ServiceSchemaRegistryGlobalConfigGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName).
+		Return(kafkaschemaregistry.CompatibilityTypeBackward, nil).Once()
+	configPut := avn.EXPECT().
+		ServiceSchemaRegistrySubjectConfigPut(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName,
+			&kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigPutIn{
+				Compatibility: kafkaschemaregistry.CompatibilityTypeBackward,
+			},
+		).Return(kafkaschemaregistry.CompatibilityTypeBackward, nil).Once().
+		NotBefore(configGet, globalGet)
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionPost(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, mock.Anything,
+		).Return(1, nil).Once().
+		NotBefore(configPut)
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+		Return([]int{1}, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, 1).
+		Return(&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionGetOut{Id: 1, Version: 1}, nil).Once()
+
+	r := &KafkaSchemaController{avnGen: avn}
+	require.NoError(t, r.applySchema(t.Context(), schema))
+	require.NotContains(t, schema.GetAnnotations(), kafkaSchemaAppliedCompatibilityAnnotation,
+		"a reverted override is no longer operator-owned")
+}
+
+// An override already equal to the global default needs no write.
+func TestKafkaSchemaApplySchemaSkipsRevertWhenOverrideEqualsGlobal(t *testing.T) {
+	t.Parallel()
+
+	schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+	metav1.SetMetaDataAnnotation(&schema.ObjectMeta, kafkaSchemaAppliedCompatibilityAnnotation,
+		string(kafkaschemaregistry.CompatibilityTypeBackward))
+
+	avn := avngen.NewMockClient(t)
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectConfigGet(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName,
+			[][2]string{kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigGetGlobalDefaultFallback(false)},
+		).Return(kafkaschemaregistry.CompatibilityTypeBackward, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistryGlobalConfigGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName).
+		Return(kafkaschemaregistry.CompatibilityTypeBackward, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionPost(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, mock.Anything,
+		).Return(1, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+		Return([]int{1}, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, 1).
+		Return(&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionGetOut{Id: 1, Version: 1}, nil).Once()
+
+	r := &KafkaSchemaController{avnGen: avn}
+	require.NoError(t, r.applySchema(t.Context(), schema))
+	require.NotContains(t, schema.GetAnnotations(), kafkaSchemaAppliedCompatibilityAnnotation)
+}
+
+// An empty compatibilityLevel on a CR that never applied one must not touch subject
+// config at all: an out-of-band override stays in place. The strict mock proves no
+// config call is made.
+func TestKafkaSchemaApplySchemaLeavesUnownedOverrideUntouched(t *testing.T) {
+	t.Parallel()
+
+	schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+
+	avn := avngen.NewMockClient(t)
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionPost(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, mock.Anything,
+		).Return(1, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+		Return([]int{1}, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, 1).
+		Return(&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionGetOut{Id: 1, Version: 1}, nil).Once()
+
+	r := &KafkaSchemaController{avnGen: avn}
+	require.NoError(t, r.applySchema(t.Context(), schema))
+	require.NotContains(t, schema.GetAnnotations(), kafkaSchemaAppliedCompatibilityAnnotation)
+}
+
+// An owned override changed outside the operator since it was applied is not reverted:
+// the current level no longer matches the annotated one, so it is no longer ours.
+// Ownership is still released. The strict mock proves no global lookup or write happens.
+func TestKafkaSchemaApplySchemaLeavesExternallyChangedOverrideUntouched(t *testing.T) {
+	t.Parallel()
+
+	schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+	metav1.SetMetaDataAnnotation(&schema.ObjectMeta, kafkaSchemaAppliedCompatibilityAnnotation,
+		string(kafkaschemaregistry.CompatibilityTypeFull))
+
+	avn := avngen.NewMockClient(t)
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectConfigGet(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName,
+			[][2]string{kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigGetGlobalDefaultFallback(false)},
+		).Return(kafkaschemaregistry.CompatibilityTypeForward, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionPost(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, mock.Anything,
+		).Return(1, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+		Return([]int{1}, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, 1).
+		Return(&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionGetOut{Id: 1, Version: 1}, nil).Once()
+
+	r := &KafkaSchemaController{avnGen: avn}
+	require.NoError(t, r.applySchema(t.Context(), schema))
+	require.NotContains(t, schema.GetAnnotations(), kafkaSchemaAppliedCompatibilityAnnotation)
+}
+
+// An owned override that disappeared from the registry needs no revert; ownership is released.
+func TestKafkaSchemaApplySchemaReleasesOwnershipWhenOverrideGone(t *testing.T) {
+	t.Parallel()
+
+	schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+	metav1.SetMetaDataAnnotation(&schema.ObjectMeta, kafkaSchemaAppliedCompatibilityAnnotation,
+		string(kafkaschemaregistry.CompatibilityTypeFull))
+
+	avn := avngen.NewMockClient(t)
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectConfigGet(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName,
+			[][2]string{kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigGetGlobalDefaultFallback(false)},
+		).Return("", newAivenError(404, "no explicit config for this subject")).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionPost(
+			mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, mock.Anything,
+		).Return(1, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+		Return([]int{1}, nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName, 1).
+		Return(&kafkaschemaregistry.ServiceSchemaRegistrySubjectVersionGetOut{Id: 1, Version: 1}, nil).Once()
+
+	r := &KafkaSchemaController{avnGen: avn}
+	require.NoError(t, r.applySchema(t.Context(), schema))
+	require.NotContains(t, schema.GetAnnotations(), kafkaSchemaAppliedCompatibilityAnnotation)
+}
+
+// A CR whose level was applied by an operator version predating ownership tracking
+// gets the annotation backfilled by Observe, so a later removal still reverts.
+func TestKafkaSchemaObserveBackfillsCompatibilityOwnership(t *testing.T) {
+	t.Parallel()
+
+	schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+	schema.Spec.CompatibilityLevel = kafkaschemaregistry.CompatibilityTypeFull
+	// A matching fingerprint proves the pre-annotation operator applied this exact level.
+	metav1.SetMetaDataAnnotation(&schema.ObjectMeta, kafkaSchemaAppliedFingerprintAnnotation,
+		fingerprintSchema(schema, nil))
+
+	avn := avngen.NewMockClient(t)
+	avn.EXPECT().
+		ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+		Return(runningService(), nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+		Return([]int{1}, nil).Once()
+
+	r := &KafkaSchemaController{avnGen: avn}
+	obs, err := r.Observe(t.Context(), schema)
+	require.NoError(t, err)
+	require.True(t, obs.ResourceExists)
+	require.Equal(t, string(kafkaschemaregistry.CompatibilityTypeFull),
+		schema.GetAnnotations()[kafkaSchemaAppliedCompatibilityAnnotation])
+}
+
+// A set level whose fingerprint never landed is not backfilled: the spec field alone
+// doesn't prove the operator wrote the override, and claiming ownership of a
+// never-applied level could revert an override created outside the operator.
+func TestKafkaSchemaObserveSkipsBackfillWhenLevelNotApplied(t *testing.T) {
+	t.Parallel()
+
+	schema := newObjectFromYAML[v1alpha1.KafkaSchema](t, yamlKafkaSchema)
+	schema.Spec.CompatibilityLevel = kafkaschemaregistry.CompatibilityTypeFull
+
+	avn := avngen.NewMockClient(t)
+	avn.EXPECT().
+		ServiceGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, mock.Anything).
+		Return(runningService(), nil).Once()
+	avn.EXPECT().
+		ServiceSchemaRegistrySubjectVersionsGet(mock.Anything, schema.Spec.Project, schema.Spec.ServiceName, schema.Spec.SubjectName).
+		Return([]int{1}, nil).Once()
+
+	r := &KafkaSchemaController{avnGen: avn}
+	obs, err := r.Observe(t.Context(), schema)
+	require.NoError(t, err)
+	require.True(t, obs.ResourceExists)
+	require.False(t, obs.ResourceUpToDate)
+	require.NotContains(t, schema.GetAnnotations(), kafkaSchemaAppliedCompatibilityAnnotation)
 }
 
 // A missing referent must surface as errPreconditionNotMet.

--- a/docs/docs/resources/kafkaschema.md
+++ b/docs/docs/resources/kafkaschema.md
@@ -179,8 +179,12 @@ the subject. The subject disappears from the registry's listing, re-applying a K
 after deletion starts a brand-new subject at version 1.
 
 Update ordering: when schema and compatibilityLevel change in the same apply, the
-compatibility level is set first, because the registry validates a new version against the
-level currently configured for the subject. A rejected schema leaves the new level applied.
+compatibility level is applied first, because the registry validates a new version against
+the level currently configured for the subject. A rejected schema leaves the new level applied.
+Removing compatibilityLevel reverts a subject-level override previously applied by the
+operator to a snapshot of the registry's current global default before the schema is
+registered; overrides created outside the operator, or changed outside it since they
+were applied, are left untouched.
 
 **Required**
 
@@ -207,8 +211,11 @@ KafkaSchemaSpec defines the desired state of KafkaSchema.
 - [`authSecretRef`](#spec.authSecretRef-property){: name='spec.authSecretRef-property'} (object). Authentication reference to Aiven token in a secret. See below for [nested schema](#spec.authSecretRef).
 - [`compatibilityLevel`](#spec.compatibilityLevel-property){: name='spec.compatibilityLevel-property'} (string, Enum: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, `NONE`). Kafka Schemas compatibility level.
     When set, it is applied as the subject-level compatibility override.
-    Removing this field does not change the subject: an existing override stays in place
-    and is not reverted to the registry's global default.
+    When removed, an override previously applied by the operator is reverted to a
+    snapshot of the registry's current global default; later changes to the global
+    default are not tracked.
+    Overrides created outside the operator, or changed
+    outside it since they were applied, are never modified.
 - [`references`](#spec.references-property){: name='spec.references-property'} (array of objects, MaxItems: 100). Schema references for Protobuf or JSON schemas that import other schemas.
     References must form a directed acyclic graph (DAG); cycles are not allowed. See below for [nested schema](#spec.references).
 - [`schemaType`](#spec.schemaType-property){: name='spec.schemaType-property'} (string, Enum: `AVRO`, `JSON`, `PROTOBUF`, Immutable). Schema type.

--- a/generators/changelog/notes.go
+++ b/generators/changelog/notes.go
@@ -25,7 +25,7 @@ func extractNotes(body []byte, version string) (string, error) {
 	var section []string
 	found := false
 
-	for _, line := range strings.Split(string(body), "\n") {
+	for line := range strings.SplitSeq(string(body), "\n") {
 		if !found {
 			found = reHeader.MatchString(line)
 			continue

--- a/tests/kafkaschema_test.go
+++ b/tests/kafkaschema_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/aiven/aiven-operator/controllers"
 )
 
+// appliedCompatibilityAnnotation mirrors the controller's unexported ownership annotation.
+const appliedCompatibilityAnnotation = "controllers.aiven.io/kafka-schema-applied-compatibility"
+
 func TestKafkaSchema(t *testing.T) {
 	t.Parallel()
 	defer recoverPanic(t)
@@ -209,6 +212,71 @@ func TestKafkaSchemaCompatibilityLoosening(t *testing.T) {
 	level, err := avnGen.ServiceSchemaRegistrySubjectConfigGet(ctx, cfg.Project, kafkaName, subjectName)
 	require.NoError(t, err)
 	assert.Equal(t, kafkaschemaregistry.CompatibilityTypeNone, level)
+}
+
+// Clearing compatibilityLevel must revert the subject override to the registry's
+// current global default instead of being silently ignored.
+func TestKafkaSchemaCompatibilityRevertToGlobalDefault(t *testing.T) {
+	t.Parallel()
+	defer recoverPanic(t)
+
+	ctx, cancel := testCtx()
+	defer cancel()
+
+	kafka, releaseKafka, err := sharedResources.AcquireKafka(ctx)
+	require.NoError(t, err)
+	defer releaseKafka()
+
+	kafkaName := kafka.GetName()
+	schemaName := randName("kafka-schema-revert")
+	subjectName := randName("kafka-schema-revert")
+	s := NewSession(ctx, k8sClient)
+	defer s.Destroy(t)
+
+	// getKafkaSchemaYaml pins the subject to BACKWARD.
+	require.NoError(t, s.Apply(getKafkaSchemaYaml(cfg.Project, kafkaName, schemaName, subjectName)))
+
+	created := new(v1alpha1.KafkaSchema)
+	require.NoError(t, s.GetRunning(created, schemaName))
+
+	global, err := avnGen.ServiceSchemaRegistryGlobalConfigGet(ctx, cfg.Project, kafkaName)
+	require.NoError(t, err)
+	// Guards against the revert going vacuous: pin an override that differs from the global default.
+	// Assumes no other test mutates the shared service's global config; one that sets it to NONE
+	// would fail this guard.
+	require.NotEqual(t, kafkaschemaregistry.CompatibilityTypeNone, global,
+		"the service's global default must differ from the override this test pins")
+
+	pinned := created.DeepCopy()
+	pinned.Spec.CompatibilityLevel = kafkaschemaregistry.CompatibilityTypeNone
+	require.NoError(t, k8sClient.Update(ctx, pinned))
+	require.NoError(t, s.GetRunning(pinned, schemaName))
+	// The applied override is marked operator-owned; only owned overrides are reverted.
+	require.Equal(t, string(kafkaschemaregistry.CompatibilityTypeNone),
+		pinned.GetAnnotations()[appliedCompatibilityAnnotation])
+
+	override, err := avnGen.ServiceSchemaRegistrySubjectConfigGet(
+		ctx, cfg.Project, kafkaName, subjectName,
+		kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigGetGlobalDefaultFallback(false),
+	)
+	require.NoError(t, err)
+	require.Equal(t, kafkaschemaregistry.CompatibilityTypeNone, override)
+
+	cleared := pinned.DeepCopy()
+	cleared.Spec.CompatibilityLevel = ""
+	require.NoError(t, k8sClient.Update(ctx, cleared))
+	require.NoError(t, s.GetRunning(cleared, schemaName))
+
+	// The override cannot be deleted through the Aiven API, so the operator
+	// overwrites it with a snapshot of the global default.
+	reverted, err := avnGen.ServiceSchemaRegistrySubjectConfigGet(
+		ctx, cfg.Project, kafkaName, subjectName,
+		kafkaschemaregistry.ServiceSchemaRegistrySubjectConfigGetGlobalDefaultFallback(false),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, global, reverted)
+	assert.NotContains(t, cleared.GetAnnotations(), appliedCompatibilityAnnotation,
+		"ownership is released after the revert")
 }
 
 func TestKafkaSchemaReferences(t *testing.T) {


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
**Issue**

Removing `compatibilityLevel` from a `KafkaSchema` spec was silently ignored: the resource reported `Running`, but the subject-level override stayed in the Schema Registry.

**Changes**

- Clearing `compatibilityLevel` now reverts the subject override to the registry's current global default
- Ownership is tracked with a new annotation (`controllers.aiven.io/kafka-schema-applied-compatibilit`y), recorded whenever the operator applies a level. On removal, the override is reverted only if:
  - the annotation is present (the operator applied it), and
  - the current override still matches the annotated value (nobody changed it out-of-band since).
- Overrides created or changed outside the operator are never touched. Absent field = `unmanaged`.
- Since the Aiven API has no `DELETE` for subject config, the revert writes a snapshot of the current **global default**; later changes to the **global default** are not tracked. 


Resolves: NEX-2817 && #1264 

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
