### PR TITLE
feat(service): added status.version to service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   Resources whose `compatibilityLevel` was removed under an older operator version are not detected
   retroactively: their override is picked up again the next time `compatibilityLevel` is set and
   applied, after which removing the field reverts it as described above.
+- Add `status.version` to service resources (`Kafka`, `PostgreSQL`, `MySQL`, `ClickHouse`, `OpenSearch`,
+  `Grafana`, `Flink`, `Valkey`): the version the service is currently running.
 
 ## v0.45.0 - 2026-08-24
 

--- a/api/v1alpha1/clickhouse_types.go
+++ b/api/v1alpha1/clickhouse_types.go
@@ -25,6 +25,7 @@ type ClickhouseSpec struct {
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.cloudName"
 // +kubebuilder:printcolumn:name="Plan",type="string",JSONPath=".spec.plan"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 type Clickhouse struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -62,6 +62,10 @@ type ServiceStatus struct {
 
 	// Service state
 	State service.ServiceStateType `json:"state,omitempty"`
+
+	// Version of the service currently running.
+	// May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
+	Version string `json:"version,omitempty"`
 }
 
 type ServiceTechEmail struct {

--- a/api/v1alpha1/flink_types.go
+++ b/api/v1alpha1/flink_types.go
@@ -24,6 +24,7 @@ type FlinkSpec struct {
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.cloudName"
 // +kubebuilder:printcolumn:name="Plan",type="string",JSONPath=".spec.plan"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 type Flink struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/grafana_types.go
+++ b/api/v1alpha1/grafana_types.go
@@ -26,6 +26,7 @@ type GrafanaSpec struct {
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.cloudName"
 // +kubebuilder:printcolumn:name="Plan",type="string",JSONPath=".spec.plan"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 type Grafana struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/kafka_types.go
+++ b/api/v1alpha1/kafka_types.go
@@ -28,6 +28,7 @@ type KafkaSpec struct {
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.cloudName"
 // +kubebuilder:printcolumn:name="Plan",type="string",JSONPath=".spec.plan"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 type Kafka struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/mysql_types.go
+++ b/api/v1alpha1/mysql_types.go
@@ -31,6 +31,7 @@ type MySQLSpec struct {
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.cloudName"
 // +kubebuilder:printcolumn:name="Plan",type="string",JSONPath=".spec.plan"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 type MySQL struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/opensearch_types.go
+++ b/api/v1alpha1/opensearch_types.go
@@ -25,6 +25,7 @@ type OpenSearchSpec struct {
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.cloudName"
 // +kubebuilder:printcolumn:name="Plan",type="string",JSONPath=".spec.plan"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 type OpenSearch struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/postgresql_types.go
+++ b/api/v1alpha1/postgresql_types.go
@@ -34,6 +34,7 @@ type PostgreSQLSpec struct {
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.cloudName"
 // +kubebuilder:printcolumn:name="Plan",type="string",JSONPath=".spec.plan"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 type PostgreSQL struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/valkey_types.go
+++ b/api/v1alpha1/valkey_types.go
@@ -28,6 +28,7 @@ type ValkeySpec struct {
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.cloudName"
 // +kubebuilder:printcolumn:name="Plan",type="string",JSONPath=".spec.plan"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 type Valkey struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_clickhouses.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -535,6 +538,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_flinks.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_flinks.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -410,6 +413,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_grafanas.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -942,6 +945,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkaconnects.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkaconnects.yaml
@@ -686,6 +686,11 @@ spec:
                 state:
                   description: Service state
                   type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
+                  type: string
               type: object
           type: object
       served: true

--- a/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_kafkas.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -1645,6 +1648,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_mysqls.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_mysqls.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -1070,6 +1073,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_opensearches.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -2108,6 +2111,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_postgresqls.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_postgresqls.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -1456,6 +1459,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/charts/aiven-operator-crds/templates/aiven.io_valkeys.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_valkeys.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -620,6 +623,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/config/crd/bases/aiven.io_clickhouses.yaml
+++ b/config/crd/bases/aiven.io_clickhouses.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -535,6 +538,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/config/crd/bases/aiven.io_flinks.yaml
+++ b/config/crd/bases/aiven.io_flinks.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -410,6 +413,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/config/crd/bases/aiven.io_grafanas.yaml
+++ b/config/crd/bases/aiven.io_grafanas.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -942,6 +945,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/config/crd/bases/aiven.io_kafkaconnects.yaml
+++ b/config/crd/bases/aiven.io_kafkaconnects.yaml
@@ -686,6 +686,11 @@ spec:
                 state:
                   description: Service state
                   type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
+                  type: string
               type: object
           type: object
       served: true

--- a/config/crd/bases/aiven.io_kafkas.yaml
+++ b/config/crd/bases/aiven.io_kafkas.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -1645,6 +1648,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/config/crd/bases/aiven.io_mysqls.yaml
+++ b/config/crd/bases/aiven.io_mysqls.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -1070,6 +1073,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/config/crd/bases/aiven.io_opensearches.yaml
+++ b/config/crd/bases/aiven.io_opensearches.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -2108,6 +2111,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/config/crd/bases/aiven.io_postgresqls.yaml
+++ b/config/crd/bases/aiven.io_postgresqls.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -1456,6 +1459,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/config/crd/bases/aiven.io_valkeys.yaml
+++ b/config/crd/bases/aiven.io_valkeys.yaml
@@ -27,6 +27,9 @@ spec:
         - jsonPath: .status.state
           name: State
           type: string
+        - jsonPath: .status.version
+          name: Version
+          type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -620,6 +623,11 @@ spec:
                   type: array
                 state:
                   description: Service state
+                  type: string
+                version:
+                  description: |-
+                    Version of the service currently running.
+                    May be more specific than the version configured in userConfig, e.g. `8.1.2` vs `8.1`
                   type: string
               type: object
           type: object

--- a/controllers/generic_service_handler.go
+++ b/controllers/generic_service_handler.go
@@ -231,6 +231,7 @@ func (h *genericServiceHandler) observe(ctx context.Context, avnGen avngen.Clien
 
 	status := o.getServiceStatus()
 	status.State = avnService.State
+	status.Version = serviceVersion(o.getServiceType(), avnService.Metadata)
 
 	// Powered=true is in priority, we check if it was explicitly set to false
 	// This could have been a one-liner, but we want to be explicit about the logic
@@ -458,6 +459,26 @@ const (
 	serviceTypeFlink        serviceType = "flink"
 	serviceTypeValkey       serviceType = "valkey"
 )
+
+// serviceVersionKeys maps a service type to the key holding its running version in the
+// service metadata. kafka_connect is absent: its metadata has no comparable version string.
+var serviceVersionKeys = map[serviceType]string{
+	serviceTypeKafka:      "kafka_version",
+	serviceTypeMySQL:      "mysql_version",
+	serviceTypePostgreSQL: "pg_version",
+	serviceTypeClickhouse: "clickhouse_version",
+	serviceTypeOpenSearch: "opensearch_version",
+	serviceTypeGrafana:    "grafana_version",
+	serviceTypeFlink:      "flink_version",
+	serviceTypeValkey:     "valkey_version",
+}
+
+// serviceVersion extracts the running service version from the service metadata.
+// Returns an empty string when the API doesn't report one.
+func serviceVersion(t serviceType, metadata map[string]any) string {
+	v, _ := metadata[serviceVersionKeys[t]].(string)
+	return v
+}
 
 // serviceAdapter turns client.Object into a generic thing
 type serviceAdapter interface {

--- a/controllers/generic_service_handler_test.go
+++ b/controllers/generic_service_handler_test.go
@@ -543,3 +543,18 @@ func TestHasPendingMigration(t *testing.T) {
 		assert.False(t, hasPendingMigration(pg))
 	})
 }
+
+func TestServiceVersion(t *testing.T) {
+	t.Parallel()
+
+	metadata := map[string]any{
+		"valkey_version": "9.1.1",
+		"plan_type":      "plan",
+		"engine_version": 2, // non-string values must not panic
+	}
+
+	assert.Equal(t, "9.1.1", serviceVersion(serviceTypeValkey, metadata))
+	assert.Empty(t, serviceVersion(serviceTypePostgreSQL, metadata))
+	assert.Empty(t, serviceVersion(serviceTypeKafkaConnect, metadata))
+	assert.Empty(t, serviceVersion(serviceTypeValkey, nil))
+}

--- a/docs/docs/resources/clickhouse.md
+++ b/docs/docs/resources/clickhouse.md
@@ -76,8 +76,8 @@ kubectl get clickhouses my-clickhouse
 
 The output is similar to the following:
 ```shell
-Name             Project             Region                 Plan          State      
-my-clickhouse    my-aiven-project    google-europe-west1    startup-16    RUNNING    
+Name             Project             Region                 Plan          State      Version      
+my-clickhouse    my-aiven-project    google-europe-west1    startup-16    RUNNING    <version>    
 ```
 
 To view the details of the `Secret`, use the following command:

--- a/docs/docs/resources/flink.md
+++ b/docs/docs/resources/flink.md
@@ -72,8 +72,8 @@ kubectl get flinks my-flink
 
 The output is similar to the following:
 ```shell
-Name        Project             Region                 Plan          State      
-my-flink    my-aiven-project    google-europe-west1    business-4    RUNNING    
+Name        Project             Region                 Plan          State      Version      
+my-flink    my-aiven-project    google-europe-west1    business-4    RUNNING    <version>    
 ```
 
 To view the details of the `Secret`, use the following command:

--- a/docs/docs/resources/grafana.md
+++ b/docs/docs/resources/grafana.md
@@ -74,8 +74,8 @@ kubectl get grafanas my-grafana
 
 The output is similar to the following:
 ```shell
-Name          Project             Region                 Plan         State      
-my-grafana    my-aiven-project    google-europe-west1    startup-1    RUNNING    
+Name          Project             Region                 Plan         State      Version      
+my-grafana    my-aiven-project    google-europe-west1    startup-1    RUNNING    <version>    
 ```
 
 To view the details of the `Secret`, use the following command:

--- a/docs/docs/resources/kafka.md
+++ b/docs/docs/resources/kafka.md
@@ -66,8 +66,8 @@ kubectl get kafkas my-kafka
 
 The output is similar to the following:
 ```shell
-Name        Project             Region                 Plan         State      
-my-kafka    my-aiven-project    google-europe-west1    startup-4    RUNNING    
+Name        Project             Region                 Plan         State      Version      
+my-kafka    my-aiven-project    google-europe-west1    startup-4    RUNNING    <version>    
 ```
 
 To view the details of the `Secret`, use the following command:

--- a/docs/docs/resources/mysql.md
+++ b/docs/docs/resources/mysql.md
@@ -74,8 +74,8 @@ kubectl get mysqls my-mysql
 
 The output is similar to the following:
 ```shell
-Name        Project             Region                 Plan          State      
-my-mysql    my-aiven-project    google-europe-west1    business-4    RUNNING    
+Name        Project             Region                 Plan          State      Version      
+my-mysql    my-aiven-project    google-europe-west1    business-4    RUNNING    <version>    
 ```
 
 To view the details of the `Secret`, use the following command:

--- a/docs/docs/resources/opensearch.md
+++ b/docs/docs/resources/opensearch.md
@@ -67,8 +67,8 @@ kubectl get opensearches my-os
 
 The output is similar to the following:
 ```shell
-Name     Project             Region                 Plan         State      
-my-os    my-aiven-project    google-europe-west1    startup-4    RUNNING    
+Name     Project             Region                 Plan         State      Version      
+my-os    my-aiven-project    google-europe-west1    startup-4    RUNNING    <version>    
 ```
 
 To view the details of the `Secret`, use the following command:

--- a/docs/docs/resources/postgresql.md
+++ b/docs/docs/resources/postgresql.md
@@ -68,8 +68,8 @@ kubectl get postgresqls my-postgresql
 
 The output is similar to the following:
 ```shell
-Name             Project               Region                 Plan         State      
-my-postgresql    aiven-project-name    google-europe-west1    startup-4    RUNNING    
+Name             Project               Region                 Plan         State      Version      
+my-postgresql    aiven-project-name    google-europe-west1    startup-4    RUNNING    <version>    
 ```
 
 To view the details of the `Secret`, use the following command:

--- a/docs/docs/resources/valkey.md
+++ b/docs/docs/resources/valkey.md
@@ -75,8 +75,8 @@ kubectl get valkeys my-valkey
 
 The output is similar to the following:
 ```shell
-Name         Project             Region                 Plan         State      
-my-valkey    my-aiven-project    google-europe-west1    startup-4    RUNNING    
+Name         Project             Region                 Plan         State      Version      
+my-valkey    my-aiven-project    google-europe-west1    startup-4    RUNNING    <version>    
 ```
 
 To view the details of the `Secret`, use the following command:

--- a/tests/clickhouse_test.go
+++ b/tests/clickhouse_test.go
@@ -86,6 +86,8 @@ func TestClickhouse(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, chAvn.ServiceName, ch.GetName())
 	assert.Equal(t, serviceRunningState, ch.Status.State)
+	assert.NotEmpty(t, ch.Status.Version)
+	assert.Equal(t, chAvn.Metadata["clickhouse_version"], ch.Status.Version)
 	assert.Contains(t, serviceRunningStatesAiven, chAvn.State)
 	assert.Equal(t, chAvn.Plan, ch.Spec.Plan)
 	assert.Equal(t, chAvn.CloudName, ch.Spec.CloudName)

--- a/tests/flink_test.go
+++ b/tests/flink_test.go
@@ -47,6 +47,8 @@ func TestFlink(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, flinkAvn.ServiceName, flink.GetName())
 	assert.Equal(t, serviceRunningState, flink.Status.State)
+	assert.NotEmpty(t, flink.Status.Version)
+	assert.Equal(t, flinkAvn.Metadata["flink_version"], flink.Status.Version)
 	assert.Contains(t, serviceRunningStatesAiven, flinkAvn.State)
 	assert.Equal(t, flinkAvn.Plan, flink.Spec.Plan)
 	assert.Equal(t, flinkAvn.CloudName, flink.Spec.CloudName)

--- a/tests/grafana_test.go
+++ b/tests/grafana_test.go
@@ -73,6 +73,8 @@ func TestGrafana(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, grafanaAvn.ServiceName, grafana.GetName())
 	assert.Equal(t, serviceRunningState, grafana.Status.State)
+	assert.NotEmpty(t, grafana.Status.Version)
+	assert.Equal(t, grafanaAvn.Metadata["grafana_version"], grafana.Status.Version)
 	assert.Contains(t, serviceRunningStatesAiven, grafanaAvn.State)
 	assert.Equal(t, grafanaAvn.Plan, grafana.Spec.Plan)
 	assert.Equal(t, grafanaAvn.CloudName, grafana.Spec.CloudName)

--- a/tests/kafka_test.go
+++ b/tests/kafka_test.go
@@ -75,6 +75,8 @@ func TestKafka(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ksAvn.ServiceName, ks.GetName())
 	assert.Equal(t, serviceRunningState, ks.Status.State)
+	assert.NotEmpty(t, ks.Status.Version)
+	assert.Equal(t, ksAvn.Metadata["kafka_version"], ks.Status.Version)
 	assert.Contains(t, serviceRunningStatesAiven, ksAvn.State)
 	assert.Equal(t, ksAvn.Plan, ks.Spec.Plan)
 	assert.Equal(t, ksAvn.CloudName, ks.Spec.CloudName)

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -73,6 +73,8 @@ func TestMySQL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, msAvn.ServiceName, ms.GetName())
 	assert.Equal(t, serviceRunningState, ms.Status.State)
+	assert.NotEmpty(t, ms.Status.Version)
+	assert.Equal(t, msAvn.Metadata["mysql_version"], ms.Status.Version)
 	assert.Contains(t, serviceRunningStatesAiven, msAvn.State)
 	assert.Equal(t, msAvn.Plan, ms.Spec.Plan)
 	assert.Equal(t, msAvn.CloudName, ms.Spec.CloudName)

--- a/tests/opensearch_test.go
+++ b/tests/opensearch_test.go
@@ -78,6 +78,8 @@ func TestOpenSearch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, osAvn.ServiceName, os.GetName())
 	assert.Equal(t, serviceRunningState, os.Status.State)
+	assert.NotEmpty(t, os.Status.Version)
+	assert.Equal(t, osAvn.Metadata["opensearch_version"], os.Status.Version)
 	assert.Contains(t, serviceRunningStatesAiven, osAvn.State)
 	assert.Equal(t, osAvn.Plan, os.Spec.Plan)
 	assert.Equal(t, osAvn.CloudName, os.Spec.CloudName)

--- a/tests/postgresql_test.go
+++ b/tests/postgresql_test.go
@@ -97,6 +97,8 @@ func TestPgReadReplica(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, masterAvn.ServiceName, master.GetName())
 	assert.Equal(t, serviceRunningState, master.Status.State)
+	assert.NotEmpty(t, master.Status.Version)
+	assert.Equal(t, masterAvn.Metadata["pg_version"], master.Status.Version)
 	assert.Contains(t, serviceRunningStatesAiven, masterAvn.State)
 	assert.Equal(t, masterAvn.Plan, master.Spec.Plan)
 	assert.Equal(t, masterAvn.CloudName, master.Spec.CloudName)

--- a/tests/valkey_test.go
+++ b/tests/valkey_test.go
@@ -48,6 +48,8 @@ func TestValkey(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rsAvn.ServiceName, rs.GetName())
 	assert.Equal(t, serviceRunningState, rs.Status.State)
+	assert.NotEmpty(t, rs.Status.Version)
+	assert.Equal(t, rsAvn.Metadata["valkey_version"], rs.Status.Version)
 	assert.Contains(t, serviceRunningStatesAiven, rsAvn.State)
 	assert.Equal(t, rsAvn.Plan, rs.Spec.Plan)
 	assert.Equal(t, rsAvn.CloudName, rs.Spec.CloudName)


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Added `status.version` to service resources (Kafka, PostgreSQL, MySQL, ClickHouse, OpenSearch, Grafana, Flink, Valkey), exposing the version the service is currently running. The value may be more specific than the one configured in userConfig (e.g. 8.1.2 vs 8.1).

Resolves: NEX-2825. 
Replaces #1277 

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
