### PR TITLE
test(project): pin billing group

### DIFF
--- a/docs/docs/resources/examples/project.yaml
+++ b/docs/docs/resources/examples/project.yaml
@@ -11,5 +11,6 @@ spec:
     env: prod
 
   accountId: my-account-id
+  billingGroupId: 00000000-0000-0000-0000-000000000000
   billingAddress: NYC
   cloud: aws-eu-west-1

--- a/docs/docs/resources/project.md
+++ b/docs/docs/resources/project.md
@@ -37,6 +37,7 @@ spec:
     env: prod
 
   accountId: my-account-id
+  billingGroupId: 00000000-0000-0000-0000-000000000000
   billingAddress: NYC
   cloud: aws-eu-west-1
 ```

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -19,10 +19,23 @@ func TestProject(t *testing.T) {
 	ctx, cancel := testCtx()
 	defer cancel()
 
+	// Pins an existing billing group so a failed run can't strand an auto-created one.
+	billingGroups, err := avnGen.BillingGroupList(ctx)
+	require.NoError(t, err)
+	var billingGroupID string
+	for _, bg := range billingGroups {
+		if bg.AccountId == cfg.AccountID {
+			billingGroupID = bg.BillingGroupId
+			break
+		}
+	}
+	require.NotEmpty(t, billingGroupID, "no billing group found for account %q", cfg.AccountID)
+
 	name := randName("project")
 	yml, err := loadExampleYaml("project.yaml", map[string]string{
-		"metadata.name":  name,
-		"spec.accountId": cfg.AccountID,
+		"metadata.name":       name,
+		"spec.accountId":      cfg.AccountID,
+		"spec.billingGroupId": billingGroupID,
 	})
 	require.NoError(t, err)
 	s := NewSession(ctx, k8sClient)


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->

**WHY:**
- **TestProject** created its project without `billingGroupId`, so Aiven auto-created a new billing group per run. A failed run may leave stale billing group

**WHAT:**
- The test now picks an existing billing group from the account and sets `spec.billingGroupId`

Resolves: NEX-2831

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
