### PR TITLE
chore(project): add migration guide for orgProject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   applied, after which removing the field reverts it as described above.
 - Add `status.version` to service resources (`Kafka`, `PostgreSQL`, `MySQL`, `ClickHouse`, `OpenSearch`,
   `Grafana`, `Flink`, `Valkey`): the version the service is currently running.
+- Deprecate `Project` in favor of `OrganizationProject`. `Project` keeps working; see the new
+  [migration guide](https://aiven.github.io/aiven-operator/guides/migrate-project-to-organizationproject.html)
+  for moving an existing project over without deleting it
 
 ## v0.45.0 - 2026-08-24
 

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -172,7 +172,7 @@ tasks:
     desc: 🗑️ Delete local Kind cluster
     cmds:
       - |
-        if kubectl cluster-info --context {{.KIND_KUBECTL_CONTEXT}} >/dev/null 2>&1; then
+        if kind get clusters 2>/dev/null | grep -qx {{.KIND_CLUSTER_NAME}}; then
           echo "🗑️ Deleting Kind cluster '{{.KIND_CLUSTER_NAME}}'..."
           kind delete cluster --name {{.KIND_CLUSTER_NAME}}
           echo "✅ Kind cluster deleted"

--- a/Taskfile.internal.yml
+++ b/Taskfile.internal.yml
@@ -272,6 +272,10 @@ tasks:
       - |
         if kubectl cluster-info --context {{.KIND_KUBECTL_CONTEXT}} >/dev/null 2>&1; then
           echo "✅ Kind cluster '{{.KIND_CLUSTER_NAME}}' already exists"
+        elif kind get clusters 2>/dev/null | grep -qx {{.KIND_CLUSTER_NAME}}; then
+          echo "❌ Kind cluster '{{.KIND_CLUSTER_NAME}}' exists but is not running."
+          echo "   Run 'task kind:delete' and retry."
+          exit 1
         else
           echo "🚀 Creating Kind cluster '{{.KIND_CLUSTER_NAME}}'..."
           kind create cluster \

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -91,6 +91,7 @@ type ProjectStatus struct {
 // Project is the Schema for the projects API.
 // Info "Exposes secret keys": `PROJECT_CA_CERT`
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="aiven.io/v1alpha1 Project is deprecated: use OrganizationProject instead."
 type Project struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/aiven-operator-crds/templates/aiven.io_projects.yaml
+++ b/charts/aiven-operator-crds/templates/aiven.io_projects.yaml
@@ -14,7 +14,11 @@ spec:
     singular: project
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - deprecated: true
+      deprecationWarning:
+        "aiven.io/v1alpha1 Project is deprecated: use OrganizationProject
+        instead."
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: |-

--- a/config/crd/bases/aiven.io_projects.yaml
+++ b/config/crd/bases/aiven.io_projects.yaml
@@ -14,7 +14,11 @@ spec:
     singular: project
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - deprecated: true
+      deprecationWarning:
+        "aiven.io/v1alpha1 Project is deprecated: use OrganizationProject
+        instead."
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: |-

--- a/controllers/basic_controller.go
+++ b/controllers/basic_controller.go
@@ -495,8 +495,7 @@ func (i *instanceReconcilerHelper) createOrUpdateInstance(ctx context.Context, o
 
 	err := i.h.createOrUpdate(ctx, i.avnGen, o, refs)
 
-	var requeueNeeded ErrRequeueNeeded
-	if errors.As(err, &requeueNeeded) {
+	if requeueNeeded, ok := errors.AsType[ErrRequeueNeeded](err); ok {
 		i.log.Info("requeue needed", "reason", requeueNeeded.Error())
 		return true, nil
 	}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -408,8 +408,7 @@ func NewNotFound(msg string) error {
 
 // isAivenError returns true if the error comes from the old or new client and has given http code
 func isAivenError(err error, code int) bool {
-	var e avngen.Error
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[avngen.Error](err); ok {
 		return e.Status == code
 	}
 
@@ -417,8 +416,7 @@ func isAivenError(err error, code int) bool {
 }
 
 func isServerError(err error) bool {
-	var e avngen.Error
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[avngen.Error](err); ok {
 		return e.Status >= http.StatusInternalServerError && e.Status < 600
 	}
 	return false

--- a/docs/docs/examples/project.md
+++ b/docs/docs/examples/project.md
@@ -6,6 +6,11 @@ weight: 5
 
 The `Project` CRD allows you to create Aiven Projects, where your resources can be located.
 
+!!! warning "Deprecated"
+    `Project` is deprecated in favor of [`OrganizationProject`](../resources/organizationproject.md).
+    See the [migration guide](../guides/migrate-project-to-organizationproject.md) for moving an
+    existing project to the new resource.
+
 ## Prerequisites
 
 * A Kubernetes cluster with Aiven Kubernetes Operator installed using [helm](../installation/helm.md) or [kubectl](../installation/kubectl.md).

--- a/docs/docs/guides/migrate-project-to-organizationproject.md
+++ b/docs/docs/guides/migrate-project-to-organizationproject.md
@@ -1,0 +1,212 @@
+# Migrating from Project to OrganizationProject
+
+[`OrganizationProject`](../resources/organizationproject.md) is the replacement for [`Project`](../resources/project.md).
+
+This guide moves a project managed by `Project` over to `OrganizationProject` **without deleting the
+Aiven project** and without touching the services running in it.
+
+!!! warning "Read this first"
+    `Project` deletes the Aiven project — and every service in it — when the Kubernetes resource is
+    deleted. This procedure relies on the [`Orphan` deletion policy](deletion-policy.md) to prevent
+    that. Do not skip step 2.
+
+## Before you start
+
+Check whether your `Project` uses `spec.cloud` or `spec.copyFromProject`. Neither exists in the
+organization API, and `OrganizationProject` cannot express them — see
+[What you lose](#what-you-lose) below. Everything else has an equivalent or is already deprecated
+on the Aiven platform.
+
+## What changes
+
+`OrganizationProject` addresses a project by `spec.organizationId` + `spec.projectId` rather than
+using `metadata.name` as the project name, which frees `metadata.name` to be any Kubernetes name.
+
+| `Project`              | `OrganizationProject`                                               |
+| ---------------------- | ------------------------------------------------------------------- |
+| `metadata.name`        | `spec.projectId`                                                    |
+| `spec.accountId`       | `spec.parentId` (organization or organizational unit)               |
+| `spec.billingGroupId`  | `spec.billingGroupId` — now **required**, and no longer immutable   |
+| `spec.technicalEmails` | `spec.technicalEmails`                                              |
+| `spec.tags`            | `spec.tags`                                                         |
+| —                      | `spec.organizationId` — **required**                                |
+| —                      | `spec.basePort`                                                     |
+
+### Billing fields
+
+These `Project` fields have no counterpart:
+
+`cardId`, `billingAddress`, `billingEmails`, `billingCurrency`, `billingExtraText`, `countryCode`.
+
+Every one of them is deprecated in the Aiven API itself. Manage them on the billing group in the
+[Aiven Console](https://console.aiven.io/) instead. Removing them from your manifests does not
+change anything in Aiven.
+
+### What you lose
+
+Two fields are genuinely unavailable in `OrganizationProject`, because the organization API has no
+equivalent:
+
+* **`spec.cloud`** sets the project's default cloud for newly launched services. Migrating does not
+  reset it — whatever it is today stays — but you can no longer manage it declaratively. Set
+  `spec.cloudName` explicitly on each service resource instead, which is the recommended practice
+  regardless.
+* **`spec.copyFromProject`** only ever applied when the project was first created, so it has no
+  effect on an existing project.
+
+The `Project` status fields `vatId`, `country`, `estimatedBalance`, `paymentMethod` and
+`availableCredits` are also gone. If you read them, get the equivalent from the billing group.
+
+### Behavior to be aware of
+
+!!! note "`tags` and `technicalEmails` are authoritative"
+    `OrganizationProject` treats both as the complete desired state: omitting them **removes** tags
+    and technical emails that were added outside Kubernetes. Copy the current values into your spec
+    unless you intend to clear them. `spec.basePort` behaves the other way — when omitted it is left
+    unmanaged.
+
+Other resources are unaffected. `PostgreSQL`, `Kafka`, `ServiceUser`, `ProjectVPC` and the rest
+reference the project by name in `spec.project`, and that name does not change.
+
+## Migration
+
+The example migrates a project named `my-project`.
+
+### Step 1: Collect the new field values
+
+`OrganizationProject` requires `organizationId`, `parentId` and `billingGroupId`. All three come
+from the project itself:
+
+```shell
+curl -sH "Authorization: aivenv1 $AIVEN_TOKEN" \
+  https://api.aiven.io/v1/project/my-project \
+  | jq '.project | {organization_id, account_id, billing_group_id, tags, tech_emails}'
+```
+
+The output is similar to the following:
+
+```json
+{
+  "organization_id": "org123456789a",
+  "account_id": "a123456789a",
+  "billing_group_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  "tags": { "env": "prod" },
+  "tech_emails": [{ "email": "tech@example.com" }]
+}
+```
+
+Map the values as follows:
+
+* `organization_id` → `spec.organizationId`
+* `account_id` → `spec.parentId`
+* `billing_group_id` → `spec.billingGroupId`
+
+Carry `tags` and `tech_emails` into the spec as well, otherwise the operator clears them.
+
+### Step 2: Protect the Aiven project
+
+Annotate the existing `Project` so that deleting it leaves the Aiven project intact:
+
+```shell
+kubectl annotate project my-project controllers.aiven.io/deletion-policy=Orphan
+```
+
+Verify the annotation before continuing:
+
+```shell
+kubectl get project my-project -o jsonpath='{.metadata.annotations}'
+```
+
+If you manage the resource with GitOps, add the annotation to the manifest and let it sync **first**.
+An annotation applied in the same commit that removes the resource is never reconciled.
+
+### Step 3: Delete the Project resource
+
+```shell
+kubectl delete project my-project
+```
+
+The Aiven project and its services are preserved.
+
+The connection secret is owned by the `Project` and is garbage collected along with it. If you want
+to reuse the same secret name in the next step, wait for it to actually disappear:
+
+```shell
+kubectl wait --for=delete secret/my-project --timeout=60s
+```
+
+!!! warning "Do not run both resources at once"
+    Never point a `Project` and an `OrganizationProject` at the same Aiven project. Both controllers
+    reconcile tags and technical emails and will overwrite each other. Finish step 3 before step 4.
+
+### Step 4: Apply the OrganizationProject
+
+`OrganizationProject` adopts an existing project when `spec.projectId` matches it, so the same
+project is now managed by the new resource:
+
+```yaml
+apiVersion: aiven.io/v1alpha1
+kind: OrganizationProject
+metadata:
+  name: my-project
+spec:
+  authSecretRef:
+    name: aiven-token
+    key: token
+
+  connInfoSecretTarget:
+    name: my-project
+    prefix: PROJECT_
+
+  organizationId: org123456789a
+  projectId: my-project
+  parentId: a123456789a
+  billingGroupId: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+
+  technicalEmails:
+    - tech@example.com
+
+  tags:
+    env: prod
+```
+
+```shell
+kubectl apply -f organizationproject.yaml
+```
+
+### Step 5: Verify
+
+```shell
+kubectl get organizationproject my-project
+```
+
+The output is similar to the following:
+
+```shell
+NAME         ORGANIZATION     PROJECT      PARENT
+my-project   org123456789a    my-project   a123456789a
+```
+
+Confirm the resource reconciled:
+
+```shell
+kubectl wait --for=condition=Running organizationproject/my-project --timeout=2m
+```
+
+## Connection secret
+
+`Project` writes `PROJECT_CA_CERT` into its secret, plus a legacy unprefixed `CA_CERT`.
+`OrganizationProject` writes `ORGANIZATIONPROJECT_CA_CERT` by default, because the key is prefixed
+with the resource kind.
+
+Setting `connInfoSecretTarget.prefix: PROJECT_`, as in step 4, keeps the key named `PROJECT_CA_CERT`
+so that workloads reading it need no change. The certificate itself is unchanged — it is the same
+project, so the same CA is fetched.
+
+The legacy unprefixed `CA_CERT` key cannot be reproduced. Update any workload that reads it.
+
+!!! note "Reusing the secret name"
+    Reuse the old secret's name only after the old secret is gone (see step 3). The operator makes
+    the new resource the owner of the secret, and while the deleted `Project` is still listed as its
+    owner, that fails with an `already owned` error. The reconciler recovers on its own once
+    Kubernetes finishes the cleanup, but waiting avoids the error entirely.

--- a/docs/docs/resources/project.md
+++ b/docs/docs/resources/project.md
@@ -1,6 +1,9 @@
 ---
-title: "Project"
+title: "Project [DEPRECATED]"
 ---
+
+!!! warning "Deprecation warning"
+	aiven.io/v1alpha1 Project is deprecated: use OrganizationProject instead.
 
 ## Prerequisites
 	

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
           - installation/uninstalling.md
           - guides/token-management.md
           - guides/deletion-policy.md
+          - guides/migrate-project-to-organizationproject.md
           - guides/serviceuser-password-management.md
           - controllers/reconciler.md
           - controllers/clickhouseuser.md


### PR DESCRIPTION
<!-- All contributors, please complete these sections, including maintainers. -->

## About this change—what it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below, if it exists. -->
- Deprecates `Project` in favor of `OrganizationProject` and documents how to migrate without deleting the Aiven project.

Resolves: NEX-1472

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
